### PR TITLE
Add staticwebapp.config.json for Azure Static Web Apps

### DIFF
--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json.schemastore.org/staticwebapp.config.json",
+  "routes": [
+    {
+      "route": "/assets/*",
+      "headers": {
+        "Cache-Control": "public, max-age=31536000, immutable"
+      }
+    },
+    {
+      "route": "/*.css",
+      "headers": {
+        "Cache-Control": "public, max-age=604800"
+      }
+    },
+    {
+      "route": "/*.js",
+      "headers": {
+        "Cache-Control": "public, max-age=604800"
+      }
+    },
+    {
+      "route": "/manifest.json",
+      "headers": {
+        "Cache-Control": "public, max-age=86400"
+      }
+    },
+    {
+      "route": "/service-worker.js",
+      "headers": {
+        "Cache-Control": "no-cache"
+      }
+    }
+  ],
+  "navigationFallback": {
+    "rewrite": "/index.html",
+    "exclude": [
+      "/assets/*",
+      "*.css",
+      "*.js",
+      "*.json",
+      "*.ico",
+      "*.png",
+      "*.jpg",
+      "*.jpeg",
+      "*.gif",
+      "*.svg",
+      "*.webp",
+      "*.woff",
+      "*.woff2",
+      "*.ttf",
+      "*.eot"
+    ]
+  },
+  "responseOverrides": {
+    "404": {
+      "rewrite": "/index.html",
+      "statusCode": 404
+    }
+  },
+  "globalHeaders": {
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "SAMEORIGIN",
+    "X-XSS-Protection": "1; mode=block",
+    "Referrer-Policy": "strict-origin-when-cross-origin",
+    "Permissions-Policy": "camera=(), microphone=(), geolocation=(self)"
+  },
+  "mimeTypes": {
+    ".json": "application/json",
+    ".webmanifest": "application/manifest+json"
+  },
+  "trailingSlash": "auto"
+}


### PR DESCRIPTION
## Summary
This PR adds a `staticwebapp.config.json` configuration file to enable proper routing, caching, and security headers for Azure Static Web Apps deployment.

## Key Changes
- **Routing Configuration**: Added route-specific cache control headers for optimal performance
  - Assets (1 year): Long-term caching for versioned/hashed assets
  - CSS/JS files (7 days): Standard caching for stylesheets and scripts
  - Manifest (1 day): Moderate caching for PWA manifest
  - Service Worker (no-cache): Always fetch latest service worker
  
- **Navigation Fallback**: Configured SPA routing to serve `index.html` for client-side navigation while excluding static assets and file types

- **Security Headers**: Added global security headers to protect against common vulnerabilities
  - `X-Content-Type-Options`: Prevent MIME type sniffing
  - `X-Frame-Options`: Prevent clickjacking attacks
  - `X-XSS-Protection`: Enable browser XSS protection
  - `Referrer-Policy`: Control referrer information
  - `Permissions-Policy`: Restrict access to sensitive APIs

- **MIME Types**: Configured proper MIME types for JSON and web manifest files

- **Trailing Slash**: Set to "auto" for flexible URL handling

## Implementation Details
This configuration ensures the application works correctly as a Single Page Application (SPA) on Azure Static Web Apps while maintaining optimal performance through intelligent caching strategies and enforcing security best practices.

https://claude.ai/code/session_0124tk8sLJaB1upKMUgNh54B