### PR TITLE
Fix benefits icon, text size controls, and contact details

### DIFF
--- a/Beta-website-sample-v1/css/main.css
+++ b/Beta-website-sample-v1/css/main.css
@@ -123,8 +123,46 @@ body.text-size-large {
     font-size: 1.125rem;
 }
 
+body.text-size-large h1,
+body.text-size-large h2,
+body.text-size-large h3,
+body.text-size-large h4,
+body.text-size-large h5,
+body.text-size-large h6,
+body.text-size-large a,
+body.text-size-large span,
+body.text-size-large li,
+body.text-size-large label,
+body.text-size-large input,
+body.text-size-large button,
+body.text-size-large .service-title,
+body.text-size-large .menu-item a,
+body.text-size-large .search-label,
+body.text-size-large .section-heading {
+    font-size: 1.125em;
+}
+
 body.text-size-xlarge {
     font-size: 1.25rem;
+}
+
+body.text-size-xlarge h1,
+body.text-size-xlarge h2,
+body.text-size-xlarge h3,
+body.text-size-xlarge h4,
+body.text-size-xlarge h5,
+body.text-size-xlarge h6,
+body.text-size-xlarge a,
+body.text-size-xlarge span,
+body.text-size-xlarge li,
+body.text-size-xlarge label,
+body.text-size-xlarge input,
+body.text-size-xlarge button,
+body.text-size-xlarge .service-title,
+body.text-size-xlarge .menu-item a,
+body.text-size-xlarge .search-label,
+body.text-size-xlarge .section-heading {
+    font-size: 1.25em;
 }
 
 /* Skip link for keyboard users */

--- a/Beta-website-sample-v1/index.html
+++ b/Beta-website-sample-v1/index.html
@@ -140,7 +140,7 @@
                     <li class="service-item">
                         <a href="pages/benefits.html" class="service-link" title="Apply for housing benefit or council tax support">
                             <span class="service-icon" aria-hidden="true">
-                                <svg viewBox="0 0 24 24" width="40" height="40"><path d="M11.8 10.9c-2.27-.59-3-1.2-3-2.15 0-1.09 1.01-1.85 2.7-1.85 1.78 0 2.44.85 2.5 2.1h2.21c-.07-1.72-1.12-3.3-3.21-3.81V3h-3v2.16c-1.94.42-3.5 1.68-3.5 3.61 0 2.31 1.91 3.46 4.7 4.13 2.5.6 3 1.48 3 2.41 0 .69-.49 1.79-2.7 1.79-2.06 0-2.87-.92-2.98-2.1h-2.2c.12 2.19 1.76 3.42 3.68 3.83V21h3v-2.15c1.95-.37 3.5-1.5 3.5-3.55 0-2.84-2.43-3.81-4.7-4.4z"/></svg>
+                                <svg viewBox="0 0 24 24" width="40" height="40"><path d="M14 21c1.93 0 3.62-1.17 4-3l-1.75-.88C16 18.21 15.33 19 14 19H9.1c.83-1 1.5-2.34 1.5-4h4v-2h-4v-2h4V9h-4.5L14 4h-2l-4 5H6v2h2v2H6v2h2c0 2.57 1.46 4.94 4 6v0h2z"/></svg>
                             </span>
                             <span class="service-title">Benefits</span>
                         </a>
@@ -291,8 +291,8 @@
             <div class="footer-section">
                 <h2 class="footer-heading">Contact us</h2>
                 <ul class="footer-list">
-                    <li>Phone: <a href="tel:01onal11232526700" title="Call the main council switchboard">01onal11 232 6700</a></li>
-                    <li>Email: <a href="mailto:info@gloucester.gov.uk" title="Send an email to the council">info@gloucester.gov.uk</a></li>
+                    <li>Phone: <a href="tel:01452396396" title="Call the main council switchboard">01452 396 396</a></li>
+                    <li>Email: <a href="mailto:heretohelp@gloucester.gov.uk" title="Send an email to the council">heretohelp@gloucester.gov.uk</a></li>
                     <li><a href="pages/contact-us.html" title="Find more contact options">All contact options</a></li>
                 </ul>
             </div>

--- a/Beta-website-sample-v1/pages/accessibility-statement.html
+++ b/Beta-website-sample-v1/pages/accessibility-statement.html
@@ -99,7 +99,7 @@
 
             <ul>
                 <li>email: <a href="mailto:accessibility@gloucester.gov.uk" title="Email our accessibility team">accessibility@gloucester.gov.uk</a></li>
-                <li>phone: <a href="tel:01onal11232526700" title="Call our main switchboard">01onal11 232 6700</a></li>
+                <li>phone: <a href="tel:01452396396" title="Call our main switchboard">01452 396 396</a></li>
             </ul>
 
             <p>We will consider your request and get back to you within 10 working days.</p>
@@ -229,8 +229,8 @@
             <div class="footer-section">
                 <h2 class="footer-heading">Contact us</h2>
                 <ul class="footer-list">
-                    <li>Phone: <a href="tel:01onal11232526700" title="Call the main council switchboard">01onal11 232 6700</a></li>
-                    <li>Email: <a href="mailto:info@gloucester.gov.uk" title="Send an email to the council">info@gloucester.gov.uk</a></li>
+                    <li>Phone: <a href="tel:01452396396" title="Call the main council switchboard">01452 396 396</a></li>
+                    <li>Email: <a href="mailto:heretohelp@gloucester.gov.uk" title="Send an email to the council">heretohelp@gloucester.gov.uk</a></li>
                     <li><a href="contact-us.html" title="Find more contact options">All contact options</a></li>
                 </ul>
             </div>

--- a/Beta-website-sample-v1/pages/bins-recycling.html
+++ b/Beta-website-sample-v1/pages/bins-recycling.html
@@ -171,7 +171,7 @@
 
                 <div class="sidebar-section">
                     <h2>Contact</h2>
-                    <p>Phone: <a href="tel:01onal11232526700" title="Call the waste team">01onal11 232 6700</a></p>
+                    <p>Phone: <a href="tel:01452396396" title="Call the waste team">01452 396 396</a></p>
                     <p>Email: <a href="mailto:waste@gloucester.gov.uk" title="Email the waste team">waste@gloucester.gov.uk</a></p>
                 </div>
             </aside>
@@ -184,8 +184,8 @@
             <div class="footer-section">
                 <h2 class="footer-heading">Contact us</h2>
                 <ul class="footer-list">
-                    <li>Phone: <a href="tel:01onal11232526700" title="Call the main council switchboard">01onal11 232 6700</a></li>
-                    <li>Email: <a href="mailto:info@gloucester.gov.uk" title="Send an email to the council">info@gloucester.gov.uk</a></li>
+                    <li>Phone: <a href="tel:01452396396" title="Call the main council switchboard">01452 396 396</a></li>
+                    <li>Email: <a href="mailto:heretohelp@gloucester.gov.uk" title="Send an email to the council">heretohelp@gloucester.gov.uk</a></li>
                     <li><a href="contact-us.html" title="Find more contact options">All contact options</a></li>
                 </ul>
             </div>

--- a/Beta-website-sample-v1/pages/council-tax-pay.html
+++ b/Beta-website-sample-v1/pages/council-tax-pay.html
@@ -106,7 +106,7 @@
             <h2>Other ways to pay</h2>
 
             <h3>By phone</h3>
-            <p>Call our payment line on <a href="tel:01onal11232526700" title="Call to pay by phone">01onal11 232 6700</a>. You will need your account number and a debit or credit card.</p>
+            <p>Call our payment line on <a href="tel:01452396396" title="Call to pay by phone">01452 396 396</a>. You will need your account number and a debit or credit card.</p>
 
             <h3>At a bank or Post Office</h3>
             <p>You can pay at any bank or Post Office using the barcode on your bill. You will need to take your bill with you.</p>
@@ -136,7 +136,7 @@
 
             <p>The sooner you contact us, the more options we have to help you.</p>
 
-            <p>Phone: <a href="tel:01onal11232526700" title="Call the council tax team">01onal11 232 6700</a></p>
+            <p>Phone: <a href="tel:01452396396" title="Call the council tax team">01452 396 396</a></p>
             <p>Email: <a href="mailto:counciltax@gloucester.gov.uk" title="Email the council tax team">counciltax@gloucester.gov.uk</a></p>
 
             <section class="related-links">
@@ -158,8 +158,8 @@
             <div class="footer-section">
                 <h2 class="footer-heading">Contact us</h2>
                 <ul class="footer-list">
-                    <li>Phone: <a href="tel:01onal11232526700" title="Call the main council switchboard">01onal11 232 6700</a></li>
-                    <li>Email: <a href="mailto:info@gloucester.gov.uk" title="Send an email to the council">info@gloucester.gov.uk</a></li>
+                    <li>Phone: <a href="tel:01452396396" title="Call the main council switchboard">01452 396 396</a></li>
+                    <li>Email: <a href="mailto:heretohelp@gloucester.gov.uk" title="Send an email to the council">heretohelp@gloucester.gov.uk</a></li>
                     <li><a href="contact-us.html" title="Find more contact options">All contact options</a></li>
                 </ul>
             </div>

--- a/Beta-website-sample-v1/pages/council-tax.html
+++ b/Beta-website-sample-v1/pages/council-tax.html
@@ -147,7 +147,7 @@
 
                 <div class="info-box">
                     <h3>Contact the council tax team</h3>
-                    <p>Phone: <a href="tel:01onal11232526700" title="Call the council tax team">01onal11 232 6700</a></p>
+                    <p>Phone: <a href="tel:01452396396" title="Call the council tax team">01452 396 396</a></p>
                     <p>Email: <a href="mailto:counciltax@gloucester.gov.uk" title="Email the council tax team">counciltax@gloucester.gov.uk</a></p>
                     <p>Monday to Friday, 9am to 5pm</p>
                 </div>
@@ -182,8 +182,8 @@
             <div class="footer-section">
                 <h2 class="footer-heading">Contact us</h2>
                 <ul class="footer-list">
-                    <li>Phone: <a href="tel:01onal11232526700" title="Call the main council switchboard">01onal11 232 6700</a></li>
-                    <li>Email: <a href="mailto:info@gloucester.gov.uk" title="Send an email to the council">info@gloucester.gov.uk</a></li>
+                    <li>Phone: <a href="tel:01452396396" title="Call the main council switchboard">01452 396 396</a></li>
+                    <li>Email: <a href="mailto:heretohelp@gloucester.gov.uk" title="Send an email to the council">heretohelp@gloucester.gov.uk</a></li>
                     <li><a href="contact-us.html" title="Find more contact options">All contact options</a></li>
                 </ul>
             </div>


### PR DESCRIPTION
- Changed benefits icon from dollar sign to pound sign (£)
- Fixed text size accessibility controls to affect all text elements (headings, links, buttons, labels) not just paragraphs
- Updated contact details with correct Gloucester City Council info: Phone: 01452 396 396 Email: heretohelp@gloucester.gov.uk

https://claude.ai/code/session_017P3f666BYDsMHjFBw5Tz97