### PR TITLE
Fix broken buttons on taxi licensing pages

### DIFF
--- a/Pete-website-sample-v2/pages/taxi/driver.html
+++ b/Pete-website-sample-v2/pages/taxi/driver.html
@@ -256,7 +256,7 @@
           <section class="gcc-content-section" aria-labelledby="apply-heading">
             <h2 id="apply-heading">Apply for a driver licence</h2>
             <p>Contact the licensing team to get an application form or to ask about your application.</p>
-            <a href="mailto:licensing@gloucester.gov.uk" class="gcc-btn gcc-btn--primary">Start now</a>
+            <a href="#contact" class="gcc-btn gcc-btn--primary">Start now</a>
           </section>
 
         </div>
@@ -264,7 +264,7 @@
         <!-- Sidebar -->
         <aside class="gcc-sidebar" aria-label="Related information">
 
-          <div class="gcc-contact-panel">
+          <div class="gcc-contact-panel" id="contact">
             <h2>Contact licensing</h2>
             <dl>
               <dt>Email</dt>
@@ -327,7 +327,6 @@
     </div>
   </footer>
 
-  <script src="../../assets/js/main.js"></script>
   <script>
     // Tab functionality
     (function () {

--- a/Pete-website-sample-v2/pages/taxi/index.html
+++ b/Pete-website-sample-v2/pages/taxi/index.html
@@ -221,6 +221,5 @@
     </div>
   </footer>
 
-  <script src="../../assets/js/main.js"></script>
 </body>
 </html>

--- a/Pete-website-sample-v2/pages/taxi/operators.html
+++ b/Pete-website-sample-v2/pages/taxi/operators.html
@@ -180,7 +180,7 @@
           <section class="gcc-content-section" aria-labelledby="op-apply-heading">
             <h2 id="op-apply-heading">Apply for an operator licence</h2>
             <p>Contact the licensing team to get an application form or to discuss your application.</p>
-            <a href="mailto:licensing@gloucester.gov.uk" class="gcc-btn gcc-btn--primary">Start now</a>
+            <a href="#contact" class="gcc-btn gcc-btn--primary">Start now</a>
           </section>
 
         </div>
@@ -188,7 +188,7 @@
         <!-- Sidebar -->
         <aside class="gcc-sidebar" aria-label="Related information">
 
-          <div class="gcc-contact-panel">
+          <div class="gcc-contact-panel" id="contact">
             <h2>Contact licensing</h2>
             <dl>
               <dt>Email</dt>
@@ -251,6 +251,5 @@
     </div>
   </footer>
 
-  <script src="../../assets/js/main.js"></script>
 </body>
 </html>

--- a/Pete-website-sample-v2/pages/taxi/passengers.html
+++ b/Pete-website-sample-v2/pages/taxi/passengers.html
@@ -214,6 +214,5 @@
     </div>
   </footer>
 
-  <script src="../../assets/js/main.js"></script>
 </body>
 </html>

--- a/Pete-website-sample-v2/pages/taxi/policy.html
+++ b/Pete-website-sample-v2/pages/taxi/policy.html
@@ -262,6 +262,5 @@
     </div>
   </footer>
 
-  <script src="../../assets/js/main.js"></script>
 </body>
 </html>

--- a/Pete-website-sample-v2/pages/taxi/vehicles.html
+++ b/Pete-website-sample-v2/pages/taxi/vehicles.html
@@ -286,7 +286,7 @@
           <section class="gcc-content-section" aria-labelledby="vehicle-apply-heading">
             <h2 id="vehicle-apply-heading">Apply for a vehicle licence</h2>
             <p>Contact the licensing team to get an application form or to ask a question about your vehicle licence.</p>
-            <a href="mailto:licensing@gloucester.gov.uk" class="gcc-btn gcc-btn--primary">Start now</a>
+            <a href="#contact" class="gcc-btn gcc-btn--primary">Start now</a>
           </section>
 
         </div>
@@ -294,7 +294,7 @@
         <!-- Sidebar -->
         <aside class="gcc-sidebar" aria-label="Related information">
 
-          <div class="gcc-contact-panel">
+          <div class="gcc-contact-panel" id="contact">
             <h2>Contact licensing</h2>
             <dl>
               <dt>Email</dt>
@@ -357,7 +357,6 @@
     </div>
   </footer>
 
-  <script src="../../assets/js/main.js"></script>
   <script>
     (function () {
       var tabs = document.querySelectorAll('[role="tab"]');


### PR DESCRIPTION
Two causes were identified:

1. main.js crashed on every taxi page because ThemeManager and SearchManager both call addEventListener on elements that don't exist on these pages (#theme-toggle, #main-search). The resulting TypeError halted the DOMContentLoaded callback and could interfere with page scripts. Removed the main.js script tag from all 6 taxi pages; the shared JS is not needed here.

2. The 'Start now' CTA buttons on driver, vehicles and operators pages used href="mailto:..." which silently does nothing in environments without a configured mail client. Changed each button to href="#contact" so clicking scrolls to the visible contact panel, and added id="contact" to each panel as the anchor target.

https://claude.ai/code/session_01J4a8S9nmaUV8hYyQpSDrK9