### PR TITLE
Add HMO service pages for Gloucester City Council

### DIFF
--- a/HMO/web/apply.html
+++ b/HMO/web/apply.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<!--
+  Gloucester City Council — Apply for an HMO Licence
+  Template: transaction.html
+  Output: /HMO/web/apply.html
+-->
+<html lang="en-GB">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Apply for an HMO licence — Gloucester City Council</title>
+  <meta name="description" content="Apply for a new or renewal HMO licence for a property in Gloucester.">
+  <meta name="theme-color" content="#0054a4">
+  <link rel="stylesheet" href="../../templates/assets/styles.css">
+  <link rel="stylesheet" href="../../templates/assets/a11y.css">
+</head>
+<body>
+
+<a class="skip-link" href="#main">Skip to main content</a>
+
+<header class="site-header" role="banner">
+  <div class="container header-inner">
+    <a href="index.html" class="brand" aria-label="Gloucester City Council home">
+      <img src="../../templates/assets/GCC_logo.svg" alt="Gloucester City Council" class="brand-logo">
+    </a>
+    <form class="header-search" role="search" action="#" onsubmit="event.preventDefault();">
+      <label for="site-search" class="visually-hidden">Search the site</label>
+      <input type="search" id="site-search" placeholder="Search Gloucester.gov.uk" autocomplete="off">
+      <button type="submit" aria-label="Search">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/>
+        </svg>
+      </button>
+    </form>
+  </div>
+</header>
+
+<div class="container">
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <ol>
+      <li><a href="#">Home</a></li>
+      <li><a href="index.html">Houses in Multiple Occupation (HMO)</a></li>
+      <li><span aria-current="page">Apply for an HMO licence</span></li>
+    </ol>
+  </nav>
+</div>
+
+<main id="main" role="main" tabindex="-1" data-screen-label="02 Transaction">
+  <div class="container">
+
+    <a href="index.html" class="back-link">Back to HMO home</a>
+
+    <h1>Apply for an HMO licence</h1>
+    <p class="lede">Apply for a new or renewal HMO licence for a property in Gloucester.</p>
+
+    <div class="page-layout">
+      <div class="main-content">
+
+        <!-- schema-source: localPolicy.licensingPolicy.fees.feesFrom1April2026 | SRC-01 -->
+        <section aria-labelledby="start-now-h" data-schema-source="localPolicy.licensingPolicy.fees.feesFrom1April2026">
+          <h2 id="start-now-h">Before you start</h2>
+
+          <!-- schema-source: localPolicy.licensingPolicy.licensingRequirement | SRC-02 -->
+          <div data-schema-source="localPolicy.licensingPolicy.licensingRequirement">
+            <p>You can apply for an HMO licence if:</p>
+            <ul>
+              <li>Your property is occupied by 5 or more people forming more than 1 household who share facilities such as kitchens or bathrooms.</li>
+            </ul>
+          </div>
+
+          <!-- schema-source: localPolicy.licensingPolicy.licenceApplicationGuidanceNotes.namedPersonRequirement | SRC-05 -->
+          <div data-schema-source="localPolicy.licensingPolicy.licenceApplicationGuidanceNotes.namedPersonRequirement">
+            <p>You will also need to confirm that:</p>
+            <ul>
+              <li>You are a fit and proper person — the licence holder must be a named individual. If a company wishes to licence a property, the licence holder must be a named person within the company.</li>
+            </ul>
+          </div>
+
+          <h3>What you will need</h3>
+          <ul>
+            <li>The full address of the property</li>
+            <li>Full details of all amenities and rooms in the property</li>
+            <li>A current Gas Safety Certificate (CP12)</li>
+            <li>A current Electrical Installation Condition Report (EICR)</li>
+            <li>A fire risk assessment for the common parts of the property</li>
+          </ul>
+
+          <h3>Fees</h3>
+          <!-- schema-source: localPolicy.licensingPolicy.fees | SRC-01 -->
+          <table class="gov-table" data-schema-source="localPolicy.licensingPolicy.fees">
+            <caption>HMO licence fees from 1 April 2026</caption>
+            <thead>
+              <tr>
+                <th scope="col">Licence type</th>
+                <th scope="col">Duration</th>
+                <th scope="col" class="num">Fee</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row">New licence</th>
+                <td>Up to 5 years</td>
+                <td class="num">£1,260.00</td>
+              </tr>
+              <tr>
+                <th scope="row">Renewal</th>
+                <td>Up to 5 years</td>
+                <td class="num">£900.00</td>
+              </tr>
+            </tbody>
+          </table>
+
+          <!-- schema-source: centralGovernmentLegislationAndGuidance.complianceFramework.licensing.mandatoryLicence | SRC-01 -->
+          <div data-schema-source="centralGovernmentLegislationAndGuidance.complianceFramework.licensing.mandatoryLicence">
+            <div class="inset-panel warning">
+              <p><strong>Warning:</strong> Operating an HMO without a licence is a criminal offence. You could face an unlimited fine or a civil penalty of up to £30,000. (Housing Act 2004, s.72; Housing and Planning Act 2016, ss.28–31)</p>
+            </div>
+          </div>
+
+          <div class="cta-block">
+            <h2 style="margin-top:0;">Ready to apply?</h2>
+            <p>You will be taken to our secure online application service.</p>
+            <a class="btn btn-primary" href="#" rel="external">
+              Start now
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M5 12h14M13 5l7 7-7 7"/>
+              </svg>
+            </a>
+          </div>
+        </section>
+
+      </div>
+
+      <aside class="sidebar" aria-label="Related information">
+        <div class="sidebar-card contact">
+          <h2>Need help?</h2>
+          <p>If you cannot complete this online, call us:</p>
+          <p style="font-weight:700;font-size:1.125rem;margin:0 0 8px;">
+            <a href="tel:01452396396">01452 396 396</a>
+          </p>
+          <p style="font-size:.9375rem;margin:0 0 var(--s-2);">Monday to Friday, 9am to 5pm (Wednesday: 10am to 5pm)</p>
+          <p style="margin:0;"><strong>Email:</strong> <a href="mailto:heretohelp@gloucester.gov.uk">heretohelp@gloucester.gov.uk</a></p>
+        </div>
+
+        <div class="sidebar-card">
+          <h2>Service standard</h2>
+          <p style="margin:0;font-size:.9375rem;">We aim to process applications within a reasonable timescale.</p>
+        </div>
+
+        <div class="sidebar-card">
+          <h2>Related</h2>
+          <ul>
+            <li><a href="licensing.html">HMO licensing information</a></li>
+            <li><a href="standards.html">HMO standards and safety</a></li>
+            <li><a href="faq.html">Frequently asked questions</a></li>
+          </ul>
+        </div>
+      </aside>
+    </div>
+  </div>
+</main>
+
+<footer class="site-footer" role="contentinfo">
+  <div class="container">
+    <div class="footer-grid">
+      <div>
+        <h2>Services</h2>
+        <ul>
+          <li><a href="licensing.html">HMO licensing</a></li>
+          <li><a href="standards.html">HMO standards</a></li>
+          <li><a href="planning.html">Planning guidance</a></li>
+          <li><a href="faq.html">FAQ</a></li>
+        </ul>
+      </div>
+      <div>
+        <h2>About</h2>
+        <ul>
+          <li><a href="#">About the council</a></li>
+          <li><a href="#">News</a></li>
+          <li><a href="#">Jobs</a></li>
+          <li><a href="#">Contact us</a></li>
+        </ul>
+      </div>
+      <div>
+        <h2>Help</h2>
+        <ul>
+          <li><a href="#">Accessibility statement</a></li>
+          <li><a href="#">Cookies</a></li>
+          <li><a href="#">Privacy</a></li>
+          <li><a href="#">Terms</a></li>
+        </ul>
+      </div>
+      <div>
+        <h2>Get in touch</h2>
+        <p style="margin: 0 0 8px;"><strong>Our opening hours are:</strong></p>
+        <ul>
+          <li>Mon, Tue, Thu, Fri: 9am to 5pm</li>
+          <li>Wednesday: 10am to 5pm</li>
+        </ul>
+        <p style="margin: 8px 0 4px;"><a href="tel:01452396396">01452 396 396</a></p>
+        <p style="margin: 0;"><a href="mailto:heretohelp@gloucester.gov.uk">heretohelp@gloucester.gov.uk</a></p>
+      </div>
+    </div>
+    <div class="legal">
+      <span>© Gloucester City Council 2026</span>
+      <span>All content available under the Open Government Licence v3.0, except where otherwise stated.</span>
+    </div>
+  </div>
+</footer>
+
+<script src="../../templates/assets/site.js"></script>
+</body>
+</html>

--- a/HMO/web/faq.html
+++ b/HMO/web/faq.html
@@ -1,0 +1,340 @@
+<!DOCTYPE html>
+<!--
+  Gloucester City Council — HMO Frequently Asked Questions
+  Template: faq.html
+  Output: /HMO/web/faq.html
+-->
+<html lang="en-GB">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>HMO frequently asked questions — Gloucester City Council</title>
+  <meta name="description" content="Answers to the most common questions about Houses in Multiple Occupation (HMO) for residents and landlords in Gloucester.">
+  <meta name="theme-color" content="#0054a4">
+  <link rel="stylesheet" href="../../templates/assets/styles.css">
+  <link rel="stylesheet" href="../../templates/assets/a11y.css">
+</head>
+<body>
+
+<a class="skip-link" href="#main">Skip to main content</a>
+
+<header class="site-header" role="banner">
+  <div class="container header-inner">
+    <a href="index.html" class="brand" aria-label="Gloucester City Council home">
+      <img src="../../templates/assets/GCC_logo.svg" alt="Gloucester City Council" class="brand-logo">
+    </a>
+    <form class="header-search" role="search" action="#" onsubmit="event.preventDefault();">
+      <label for="site-search" class="visually-hidden">Search the site</label>
+      <input type="search" id="site-search" placeholder="Search Gloucester.gov.uk" autocomplete="off">
+      <button type="submit" aria-label="Search">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/>
+        </svg>
+      </button>
+    </form>
+  </div>
+</header>
+
+<div class="container">
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <ol>
+      <li><a href="#">Home</a></li>
+      <li><a href="index.html">Houses in Multiple Occupation (HMO)</a></li>
+      <li><span aria-current="page">HMO frequently asked questions</span></li>
+    </ol>
+  </nav>
+</div>
+
+<main id="main" role="main" tabindex="-1" data-screen-label="04 FAQ">
+  <div class="container">
+    <h1>HMO frequently asked questions</h1>
+    <p class="lede">Answers to the most common questions about Houses in Multiple Occupation in Gloucester. Cannot find what you are looking for? <a href="#contact">Contact us</a>.</p>
+
+    <div class="page-layout">
+      <div class="main-content">
+
+        <!-- schema-source: localPolicy.hmoDefinitions.generalDefinition | SRC-01 -->
+        <section class="faq-cat" aria-labelledby="cat-1" data-schema-source="localPolicy.hmoDefinitions.generalDefinition">
+          <h2 id="cat-1">For residents and tenants</h2>
+          <p>Information for people who live or are thinking of living in an HMO in Gloucester.</p>
+        </section>
+
+        <div class="faq">
+
+          <!-- schema-source: localPolicy.licensingPolicy.tenantLicensingStatement | SRC-01 -->
+          <details data-schema-source="localPolicy.licensingPolicy.tenantLicensingStatement">
+            <summary>Does my landlord need an HMO licence?</summary>
+            <div class="faq-body">
+              <p>Your landlord must have a licence for all HMO properties which are occupied by five or more people forming two or more households. If you think your landlord is operating unlicensed, contact the council on <a href="tel:01452396396">01452 396 396</a>.</p>
+              <p>See also: <a href="licensing.html">HMO licensing information</a>.</p>
+            </div>
+          </details>
+
+          <!-- schema-source: localPolicy.hmoDefinitions.generalDefinition | SRC-01 -->
+          <details data-schema-source="localPolicy.hmoDefinitions.generalDefinition">
+            <summary>What is an HMO?</summary>
+            <div class="faq-body">
+              <p>A HMO is a house in multiple occupation and applies to buildings that are either a single dwelling or a flat where one or more separate households share facilities such as; kitchens, toilet and bathroom.</p>
+              <p>See also: <a href="residents.html">Living in an HMO — your rights and what to expect</a>.</p>
+            </div>
+          </details>
+
+          <!-- schema-source: localPolicy.hmoDefinitions.whatIsNotAnHMO | SRC-02 -->
+          <details data-schema-source="localPolicy.hmoDefinitions.whatIsNotAnHMO">
+            <summary>What is not an HMO?</summary>
+            <div class="faq-body">
+              <p>The following are not classified as HMOs:</p>
+              <ul>
+                <li>An entire flat or house let to one person, a couple, a family or two people sharing.</li>
+                <li>Two lodgers with an owner occupier living in the house.</li>
+              </ul>
+            </div>
+          </details>
+
+          <!-- schema-source: localPolicy.tenantEnforcementContact.councilResponsibility | SRC-01 -->
+          <details data-schema-source="localPolicy.tenantEnforcementContact.councilResponsibility">
+            <summary>What can I do if my landlord won't fix hazards?</summary>
+            <div class="faq-body">
+              <p>The council is responsible for enforcing HMO standards, so if you are a tenant living in a HMO and feel there are any unreasonable hazards which your private landlord is not dealing with, please report it.</p>
+              <p>Contact us:</p>
+              <ul>
+                <li><strong>Phone:</strong> <a href="tel:01452396396">01452 396 396</a></li>
+                <li><strong>Email:</strong> <a href="mailto:heretohelp@gloucester.gov.uk">heretohelp@gloucester.gov.uk</a></li>
+              </ul>
+            </div>
+          </details>
+
+          <!-- schema-source: centralGovernmentLegislationAndGuidance.complianceFramework.tenantRights | SRC-01 -->
+          <details data-schema-source="centralGovernmentLegislationAndGuidance.complianceFramework.tenantRights">
+            <summary>Can I claim back rent if my HMO is unlicensed?</summary>
+            <div class="faq-body">
+              <p>You may be able to apply to the First-tier Tribunal for a Rent Repayment Order of up to 12 months' rent where an HMO is unlicensed. (Housing and Planning Act 2016, ss.40–41)</p>
+              <p>Contact the council on <a href="tel:01452396396">01452 396 396</a> for advice on how to proceed.</p>
+            </div>
+          </details>
+
+        </div>
+
+        <!-- schema-source: localPolicy.licensingPolicy.licensingRequirement | SRC-02 -->
+        <section class="faq-cat" aria-labelledby="cat-2" data-schema-source="localPolicy.licensingPolicy.licensingRequirement">
+          <h2 id="cat-2">For landlords and managers</h2>
+          <p>Information for people who own or manage Houses in Multiple Occupation in Gloucester.</p>
+        </section>
+
+        <div class="faq">
+
+          <!-- schema-source: localPolicy.licensingPolicy.licensingRequirement | SRC-02 -->
+          <details data-schema-source="localPolicy.licensingPolicy.licensingRequirement">
+            <summary>Do I need a licence?</summary>
+            <div class="faq-body">
+              <p>A licence is required for all HMOs that are occupied by five or more people belonging to 2 or more households and who share a facility or amenity.</p>
+              <p>See also: <a href="licensing.html">HMO licensing in Gloucester</a>.</p>
+            </div>
+          </details>
+
+          <!-- schema-source: localPolicy.licensingPolicy.fees | SRC-01 -->
+          <details data-schema-source="localPolicy.licensingPolicy.fees">
+            <summary>How much does a licence cost?</summary>
+            <div class="faq-body">
+              <p>Fees from 1 April 2026:</p>
+              <ul>
+                <li><strong>New licence (up to 5 years):</strong> £1,260.00</li>
+                <li><strong>Renewal (up to 5 years):</strong> £900.00</li>
+              </ul>
+              <p>See also: <a href="apply.html">Apply for an HMO licence</a>.</p>
+            </div>
+          </details>
+
+          <!-- schema-source: localPolicy.licensingPolicy.licenceApplicationGuidanceNotes.licenceDurationStatement | SRC-05 -->
+          <details data-schema-source="localPolicy.licensingPolicy.licenceApplicationGuidanceNotes.licenceDurationStatement">
+            <summary>How long does an HMO licence last?</summary>
+            <div class="faq-body">
+              <p>The licence is valid for a period of up to five years. New applications are dated from when the application is deemed valid.</p>
+            </div>
+          </details>
+
+          <!-- schema-source: localPolicy.licensingPolicy.planningAndLicensingDistinction | SRC-03 -->
+          <details data-schema-source="localPolicy.licensingPolicy.planningAndLicensingDistinction">
+            <summary>Do I need planning permission?</summary>
+            <div class="faq-body">
+              <p>Planning and licensing are two different matters. You may not need planning permission but could still need a licence from the Council to operate. HMOs with five or more people require a licence.</p>
+              <ul>
+                <li><strong>Small HMOs (3–6 people, use class C4):</strong> Typically do not need planning permission, as a permitted development right applies for change of use from C3 to C4.</li>
+                <li><strong>Large HMOs (7 or more people, Sui Generis):</strong> Always require planning permission in addition to a licence.</li>
+              </ul>
+              <p>See also: <a href="planning.html">Planning permission for HMOs</a>.</p>
+            </div>
+          </details>
+
+          <!-- schema-source: centralGovernmentLegislationAndGuidance.complianceFramework.licensing.mandatoryLicence | SRC-01 -->
+          <details data-schema-source="centralGovernmentLegislationAndGuidance.complianceFramework.licensing.mandatoryLicence">
+            <summary>What happens if I operate without a licence?</summary>
+            <div class="faq-body">
+              <p>Operating an unlicensed HMO is a criminal offence carrying an unlimited fine on conviction, or a civil penalty of up to £30,000. (Housing Act 2004, s.72; Housing and Planning Act 2016, ss.28–31)</p>
+              <div class="inset-panel warning">
+                <p><strong>Important:</strong> Tenants in an unlicensed HMO may also apply to the First-tier Tribunal for a Rent Repayment Order of up to 12 months' rent. (Housing and Planning Act 2016, ss.40–41)</p>
+              </div>
+            </div>
+          </details>
+
+          <!-- schema-source: localPolicy.fireSafetyPolicy | SRC-02 -->
+          <details data-schema-source="localPolicy.fireSafetyPolicy">
+            <summary>What fire safety is required?</summary>
+            <div class="faq-body">
+              <p>As a minimum, interlinked smoke detectors must be fitted in hallways and on landings, and a heat detector must be fitted in the kitchen. These must comply with BS 5839:2019 part 6 — Grade D:LD2.</p>
+              <p>Specific requirements depend on the number of storeys and layout of the property. Three-storey or taller properties have additional requirements including 30-minute fire doors and emergency lighting.</p>
+              <p>See also: <a href="standards.html">HMO standards and safety requirements</a>.</p>
+            </div>
+          </details>
+
+          <!-- schema-source: localPolicy.spaceStandards | SRC-02 -->
+          <details data-schema-source="localPolicy.spaceStandards">
+            <summary>What are the minimum bedroom sizes?</summary>
+            <div class="faq-body">
+              <p>Rooms with shared facilities:</p>
+              <ul>
+                <li>1 person: 6.5 sqm</li>
+                <li>2 persons: 10.2 sqm</li>
+              </ul>
+              <p>Rooms with cooking facilities:</p>
+              <ul>
+                <li>1 person: 12.5 sqm</li>
+                <li>2 persons: 15.5 sqm</li>
+              </ul>
+              <p>See also: <a href="standards.html">HMO standards and safety requirements</a>.</p>
+            </div>
+          </details>
+
+        </div>
+
+        <!-- schema-source: localPolicy.hhsrsPolicy | SRC-02 -->
+        <section class="faq-cat" aria-labelledby="cat-3" data-schema-source="localPolicy.hhsrsPolicy">
+          <h2 id="cat-3">Enforcement and complaints</h2>
+          <p>Information about enforcement action and how the council handles HMO complaints.</p>
+        </section>
+
+        <div class="faq">
+
+          <!-- schema-source: localPolicy.hhsrsPolicy | SRC-02 -->
+          <details data-schema-source="localPolicy.hhsrsPolicy">
+            <summary>What enforcement powers does the council have?</summary>
+            <div class="faq-body">
+              <p>The council can take a range of enforcement action where an HMO does not meet required standards or where a property is operated without a licence:</p>
+              <ul>
+                <li><strong>Improvement Notices</strong> — requiring specified works to be carried out within a set timescale. (Housing Act 2004)</li>
+                <li><strong>Prohibition Orders</strong> — prohibiting the use of part or all of a property, or restricting the number of occupants. (Housing Act 2004)</li>
+                <li><strong>Civil penalties</strong> — of up to £30,000 per offence. (Housing and Planning Act 2016)</li>
+                <li><strong>Banning orders</strong> — in serious cases, preventing a landlord from letting or managing properties. (Housing and Planning Act 2016)</li>
+                <li><strong>Management orders</strong> — in serious cases, taking over the management of a property. (Housing Act 2004, ss.101–131)</li>
+              </ul>
+            </div>
+          </details>
+
+          <!-- schema-source: localPolicy.hhsrsPolicy | SRC-02 -->
+          <details data-schema-source="localPolicy.hhsrsPolicy">
+            <summary>Can the council take over management of my HMO?</summary>
+            <div class="faq-body">
+              <p>In cases where an HMO is unlicensed and a suitable licence holder cannot be found, or where licensable conditions persistently cannot be met, the council may apply for an Interim or Final Management Order taking over management of the property. (Housing Act 2004, ss.101–131)</p>
+              <p>The council will use management orders only as a last resort, after other enforcement options have been exhausted.</p>
+            </div>
+          </details>
+
+        </div>
+
+        <!-- schema-source: localPolicy.tenantEnforcementContact.councilResponsibility | SRC-01 -->
+        <section id="contact" aria-labelledby="contact-h" style="margin-top: var(--s-6);" data-schema-source="localPolicy.tenantEnforcementContact.councilResponsibility">
+          <h2 id="contact-h">Still need help?</h2>
+          <p>If your question is not answered here, please get in touch:</p>
+          <ul>
+            <li><strong>Phone:</strong> <a href="tel:01452396396">01452 396 396</a> (Monday to Friday, 9am to 5pm; Wednesday 10am to 5pm)</li>
+            <li><strong>Email:</strong> <a href="mailto:heretohelp@gloucester.gov.uk">heretohelp@gloucester.gov.uk</a></li>
+          </ul>
+        </section>
+
+      </div>
+
+      <aside class="sidebar" aria-label="Related information">
+        <div class="sidebar-card">
+          <h2>Categories</h2>
+          <ul>
+            <li><a href="#cat-1">For residents and tenants</a></li>
+            <li><a href="#cat-2">For landlords and managers</a></li>
+            <li><a href="#cat-3">Enforcement and complaints</a></li>
+            <li><a href="#contact">Still need help?</a></li>
+          </ul>
+        </div>
+
+        <div class="sidebar-card contact">
+          <h2>Quick contact</h2>
+          <p style="font-weight:700;font-size:1.125rem;margin:0 0 8px;">
+            <a href="tel:01452396396">01452 396 396</a>
+          </p>
+          <p style="font-size:.9375rem;margin:0 0 var(--s-2);">Monday to Friday, 9am to 5pm (Wednesday: 10am to 5pm)</p>
+          <p style="margin:0;"><a href="mailto:heretohelp@gloucester.gov.uk">heretohelp@gloucester.gov.uk</a></p>
+        </div>
+
+        <div class="sidebar-card">
+          <h2>Related</h2>
+          <ul>
+            <li><a href="index.html">HMO home</a></li>
+            <li><a href="licensing.html">HMO licensing information</a></li>
+            <li><a href="standards.html">HMO standards and safety</a></li>
+            <li><a href="apply.html">Apply for an HMO licence</a></li>
+          </ul>
+        </div>
+      </aside>
+    </div>
+  </div>
+</main>
+
+<footer class="site-footer" role="contentinfo">
+  <div class="container">
+    <div class="footer-grid">
+      <div>
+        <h2>Services</h2>
+        <ul>
+          <li><a href="licensing.html">HMO licensing</a></li>
+          <li><a href="standards.html">HMO standards</a></li>
+          <li><a href="planning.html">Planning guidance</a></li>
+          <li><a href="faq.html">FAQ</a></li>
+        </ul>
+      </div>
+      <div>
+        <h2>About</h2>
+        <ul>
+          <li><a href="#">About the council</a></li>
+          <li><a href="#">News</a></li>
+          <li><a href="#">Jobs</a></li>
+          <li><a href="#">Contact us</a></li>
+        </ul>
+      </div>
+      <div>
+        <h2>Help</h2>
+        <ul>
+          <li><a href="#">Accessibility statement</a></li>
+          <li><a href="#">Cookies</a></li>
+          <li><a href="#">Privacy</a></li>
+          <li><a href="#">Terms</a></li>
+        </ul>
+      </div>
+      <div>
+        <h2>Get in touch</h2>
+        <p style="margin: 0 0 8px;"><strong>Our opening hours are:</strong></p>
+        <ul>
+          <li>Mon, Tue, Thu, Fri: 9am to 5pm</li>
+          <li>Wednesday: 10am to 5pm</li>
+        </ul>
+        <p style="margin: 8px 0 4px;"><a href="tel:01452396396">01452 396 396</a></p>
+        <p style="margin: 0;"><a href="mailto:heretohelp@gloucester.gov.uk">heretohelp@gloucester.gov.uk</a></p>
+      </div>
+    </div>
+    <div class="legal">
+      <span>© Gloucester City Council 2026</span>
+      <span>All content available under the Open Government Licence v3.0, except where otherwise stated.</span>
+    </div>
+  </div>
+</footer>
+
+<script src="../../templates/assets/site.js"></script>
+</body>
+</html>

--- a/HMO/web/index.html
+++ b/HMO/web/index.html
@@ -1,0 +1,221 @@
+<!DOCTYPE html>
+<!--
+  Gloucester City Council — HMO Service Landing Page
+  Template: service-landing.html
+  Output: /HMO/web/index.html
+-->
+<html lang="en-GB">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Houses in Multiple Occupation (HMO) — Gloucester City Council</title>
+  <meta name="description" content="Find information about HMO licensing, standards and tenant rights in Gloucester.">
+  <meta name="theme-color" content="#0054a4">
+  <link rel="stylesheet" href="../../templates/assets/styles.css">
+  <link rel="stylesheet" href="../../templates/assets/a11y.css">
+</head>
+<body>
+
+<a class="skip-link" href="#main">Skip to main content</a>
+
+<header class="site-header" role="banner">
+  <div class="container header-inner">
+    <a href="index.html" class="brand" aria-label="Gloucester City Council home">
+      <img src="../../templates/assets/GCC_logo.svg" alt="Gloucester City Council" class="brand-logo">
+    </a>
+    <form class="header-search" role="search" action="#" onsubmit="event.preventDefault();">
+      <label for="site-search" class="visually-hidden">Search the site</label>
+      <input type="search" id="site-search" placeholder="Search Gloucester.gov.uk" autocomplete="off">
+      <button type="submit" aria-label="Search">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/>
+        </svg>
+      </button>
+    </form>
+  </div>
+</header>
+
+<div class="container">
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <ol>
+      <li><a href="#">Home</a></li>
+      <li><span aria-current="page">Houses in Multiple Occupation (HMO)</span></li>
+    </ol>
+  </nav>
+</div>
+
+<main id="main" role="main" tabindex="-1" data-screen-label="01 Service landing">
+
+  <!-- schema-source: localPolicy.hmoDefinitions.generalDefinition | SRC-01 -->
+  <section class="hero" data-schema-source="localPolicy.hmoDefinitions.generalDefinition">
+    <div class="container">
+      <p style="margin:0 0 12px;font-size:.9375rem;color:#d6e4f4;letter-spacing:.04em;text-transform:uppercase;font-weight:600;">Service</p>
+      <h1>Houses in Multiple Occupation (HMO)</h1>
+      <p class="lede">Find information about HMO licensing, standards and tenant rights in Gloucester.</p>
+    </div>
+    <svg class="hero-decoration" viewBox="0 0 200 200" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2">
+      <circle cx="100" cy="100" r="90" stroke="#fff"/>
+      <circle cx="100" cy="100" r="60" stroke="#fff"/>
+      <path d="M30 100h140M100 30v140" stroke="#fff"/>
+    </svg>
+  </section>
+
+  <!-- schema-source: localPolicy.hmoDefinitions.generalDefinition | SRC-01 -->
+  <div class="container" style="padding-top:var(--s-6);" data-schema-source="localPolicy.hmoDefinitions.generalDefinition">
+    <div class="section-title">
+      <h2>What we can help with</h2>
+    </div>
+    <p class="lede">Choose the service you need.</p>
+
+    <div class="service-grid" role="list">
+
+      <a href="residents.html" class="service-card" role="listitem">
+        <span class="icon" aria-hidden="true">
+          <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+        </span>
+        <h3>I'm a resident in an HMO</h3>
+        <p>Your rights as a tenant, what to expect and how to report problems.</p>
+      </a>
+
+      <a href="landlords.html" class="service-card" role="listitem">
+        <span class="icon" aria-hidden="true">
+          <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+        </span>
+        <h3>I'm a landlord or manager</h3>
+        <p>Licensing, standards and compliance information for landlords and managers.</p>
+      </a>
+
+      <a href="apply.html" class="service-card" role="listitem">
+        <span class="icon" aria-hidden="true">
+          <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="6" width="18" height="13" rx="2"/><path d="M7 10h10M7 14h6"/></svg>
+        </span>
+        <h3>Apply for an HMO licence</h3>
+        <p>Apply for a new or renewal HMO licence for a property in Gloucester.</p>
+      </a>
+
+      <a href="standards.html" class="service-card" role="listitem">
+        <span class="icon" aria-hidden="true">
+          <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+        </span>
+        <h3>HMO standards and safety</h3>
+        <p>Minimum standards for fire safety, space, washing facilities and property management.</p>
+      </a>
+
+      <a href="planning.html" class="service-card" role="listitem">
+        <span class="icon" aria-hidden="true">
+          <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 8v5M12 16h.01"/></svg>
+        </span>
+        <h3>Planning permission for HMOs</h3>
+        <p>When you need planning permission to convert a property to an HMO.</p>
+      </a>
+
+      <a href="faq.html" class="service-card" role="listitem">
+        <span class="icon" aria-hidden="true">
+          <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 9a3 3 0 116 0c0 2-3 2-3 5"/><path d="M12 17h.01"/></svg>
+        </span>
+        <h3>Frequently asked questions</h3>
+        <p>Answers to the most common questions about HMOs in Gloucester.</p>
+      </a>
+
+    </div>
+  </div>
+
+  <!-- schema-source: localPolicy.hmoDefinitions.generalDefinition | SRC-01 -->
+  <section class="tasks-strip" aria-labelledby="popular-title" data-schema-source="localPolicy.hmoDefinitions.generalDefinition">
+    <div class="container">
+      <div class="section-title">
+        <h2 id="popular-title">Popular tasks</h2>
+      </div>
+      <div class="tasks-grid">
+        <a class="task-link" href="apply.html">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+          Apply for an HMO licence
+        </a>
+        <a class="task-link" href="#">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+          Check if an HMO is licensed
+        </a>
+        <a class="task-link" href="#">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+          Report a problem in an HMO
+        </a>
+        <a class="task-link" href="apply.html">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+          Renew an HMO licence
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <div class="container" style="padding-top: var(--s-6);">
+    <div class="help-grid" style="display:grid;grid-template-columns:1fr 1fr;gap:var(--s-4);">
+      <div class="help-card" style="background:var(--bg-card);border:1px solid var(--border);border-radius:var(--radius-lg);padding:var(--s-4);">
+        <h3 style="margin-top:0;">Looking for something else?</h3>
+        <p>HMO licensing is managed by Gloucester City Council. For planning and building control matters, some services may be shared with Gloucestershire County Council.</p>
+        <p><a href="planning.html">Planning permission for HMOs</a></p>
+      </div>
+      <div class="help-card" style="background:var(--bg-card);border:1px solid var(--border);border-radius:var(--radius-lg);padding:var(--s-4);">
+        <h3 style="margin-top:0;">Contact us</h3>
+        <p>For general enquiries about HMO licensing and standards:</p>
+        <p style="margin:0;">
+          <strong>Phone:</strong> <a href="tel:01452396396">01452 396 396</a><br>
+          <strong>Email:</strong> <a href="mailto:heretohelp@gloucester.gov.uk">heretohelp@gloucester.gov.uk</a><br>
+          <strong>Monday to Friday:</strong> 9am to 5pm (Wednesday: 10am to 5pm)
+        </p>
+      </div>
+    </div>
+  </div>
+
+</main>
+
+<footer class="site-footer" role="contentinfo">
+  <div class="container">
+    <div class="footer-grid">
+      <div>
+        <h2>Services</h2>
+        <ul>
+          <li><a href="licensing.html">HMO licensing</a></li>
+          <li><a href="standards.html">HMO standards</a></li>
+          <li><a href="planning.html">Planning guidance</a></li>
+          <li><a href="faq.html">FAQ</a></li>
+        </ul>
+      </div>
+      <div>
+        <h2>About</h2>
+        <ul>
+          <li><a href="#">About the council</a></li>
+          <li><a href="#">News</a></li>
+          <li><a href="#">Jobs</a></li>
+          <li><a href="#">Contact us</a></li>
+        </ul>
+      </div>
+      <div>
+        <h2>Help</h2>
+        <ul>
+          <li><a href="#">Accessibility statement</a></li>
+          <li><a href="#">Cookies</a></li>
+          <li><a href="#">Privacy</a></li>
+          <li><a href="#">Terms</a></li>
+        </ul>
+      </div>
+      <div>
+        <h2>Get in touch</h2>
+        <p style="margin: 0 0 8px;"><strong>Our opening hours are:</strong></p>
+        <ul>
+          <li>Mon, Tue, Thu, Fri: 9am to 5pm</li>
+          <li>Wednesday: 10am to 5pm</li>
+        </ul>
+        <p style="margin: 8px 0 4px;"><a href="tel:01452396396">01452 396 396</a></p>
+        <p style="margin: 0;"><a href="mailto:heretohelp@gloucester.gov.uk">heretohelp@gloucester.gov.uk</a></p>
+      </div>
+    </div>
+    <div class="legal">
+      <span>© Gloucester City Council 2026</span>
+      <span>All content available under the Open Government Licence v3.0, except where otherwise stated.</span>
+    </div>
+  </div>
+</footer>
+
+<script src="../../templates/assets/site.js"></script>
+</body>
+</html>

--- a/HMO/web/landlords.html
+++ b/HMO/web/landlords.html
@@ -1,0 +1,217 @@
+<!DOCTYPE html>
+<!--
+  Gloucester City Council — HMO Landlord Hub
+  Template: service-landing.html
+  Output: /HMO/web/landlords.html
+-->
+<html lang="en-GB">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>HMO landlord and manager information — Gloucester City Council</title>
+  <meta name="description" content="Everything you need to know about licensing, standards and compliance for Houses in Multiple Occupation in Gloucester.">
+  <meta name="theme-color" content="#0054a4">
+  <link rel="stylesheet" href="../../templates/assets/styles.css">
+  <link rel="stylesheet" href="../../templates/assets/a11y.css">
+</head>
+<body>
+
+<a class="skip-link" href="#main">Skip to main content</a>
+
+<header class="site-header" role="banner">
+  <div class="container header-inner">
+    <a href="index.html" class="brand" aria-label="Gloucester City Council home">
+      <img src="../../templates/assets/GCC_logo.svg" alt="Gloucester City Council" class="brand-logo">
+    </a>
+    <form class="header-search" role="search" action="#" onsubmit="event.preventDefault();">
+      <label for="site-search" class="visually-hidden">Search the site</label>
+      <input type="search" id="site-search" placeholder="Search Gloucester.gov.uk" autocomplete="off">
+      <button type="submit" aria-label="Search">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/>
+        </svg>
+      </button>
+    </form>
+  </div>
+</header>
+
+<div class="container">
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <ol>
+      <li><a href="#">Home</a></li>
+      <li><a href="index.html">Houses in Multiple Occupation (HMO)</a></li>
+      <li><span aria-current="page">HMO landlord and manager information</span></li>
+    </ol>
+  </nav>
+</div>
+
+<main id="main" role="main" tabindex="-1" data-screen-label="01 Service landing">
+
+  <!-- schema-source: localPolicy.licensingPolicy.tenantLicensingStatement | SRC-01 -->
+  <section class="hero" data-schema-source="localPolicy.licensingPolicy.tenantLicensingStatement">
+    <div class="container">
+      <p style="margin:0 0 12px;font-size:.9375rem;color:#d6e4f4;letter-spacing:.04em;text-transform:uppercase;font-weight:600;">Service</p>
+      <h1>HMO landlord and manager information</h1>
+      <p class="lede">Everything you need to know about licensing, standards and compliance for Houses in Multiple Occupation in Gloucester.</p>
+    </div>
+    <svg class="hero-decoration" viewBox="0 0 200 200" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2">
+      <circle cx="100" cy="100" r="90" stroke="#fff"/>
+      <circle cx="100" cy="100" r="60" stroke="#fff"/>
+      <path d="M30 100h140M100 30v140" stroke="#fff"/>
+    </svg>
+  </section>
+
+  <!-- schema-source: localPolicy.licensingPolicy.planningAndLicensingDistinction | SRC-03 -->
+  <div class="container" style="padding-top:var(--s-6);" data-schema-source="localPolicy.licensingPolicy.planningAndLicensingDistinction">
+    <div class="inset-panel info">
+      <p><strong>Planning and licensing:</strong> Planning and licensing are two different matters. You may not need planning permission but could still need a licence from the Council to operate.</p>
+    </div>
+  </div>
+
+  <!-- schema-source: localPolicy.licensingPolicy.tenantLicensingStatement | SRC-01 -->
+  <div class="container" style="padding-top:var(--s-4);" data-schema-source="localPolicy.licensingPolicy.tenantLicensingStatement">
+    <div class="section-title">
+      <h2>What we can help with</h2>
+    </div>
+    <p class="lede">Choose the service you need.</p>
+
+    <div class="service-grid" role="list">
+
+      <!-- schema-source: localPolicy.licensingPolicy.fees.feesFrom1April2026 | SRC-01 -->
+      <a href="apply.html" class="service-card" role="listitem" data-schema-source="localPolicy.licensingPolicy.fees.feesFrom1April2026">
+        <span class="icon" aria-hidden="true">
+          <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="6" width="18" height="13" rx="2"/><path d="M7 10h10M7 14h6"/></svg>
+        </span>
+        <h3>Apply for or renew an HMO licence</h3>
+        <p>Apply for a new licence or renew an existing one. Fees apply.</p>
+      </a>
+
+      <!-- schema-source: localPolicy.fireSafetyPolicy | SRC-02 -->
+      <a href="standards.html" class="service-card" role="listitem" data-schema-source="localPolicy.fireSafetyPolicy">
+        <span class="icon" aria-hidden="true">
+          <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+        </span>
+        <h3>HMO standards and safety requirements</h3>
+        <p>Minimum standards for fire safety, space, washing facilities and property management.</p>
+      </a>
+
+      <!-- schema-source: localPolicy.planningPolicy.policyA2 | SRC-03 -->
+      <a href="planning.html" class="service-card" role="listitem" data-schema-source="localPolicy.planningPolicy.policyA2">
+        <span class="icon" aria-hidden="true">
+          <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 8v5M12 16h.01"/></svg>
+        </span>
+        <h3>Planning permission for HMOs</h3>
+        <p>When you need planning permission and how local planning policy applies.</p>
+      </a>
+
+      <!-- schema-source: localPolicy.hmoDefinitions.generalDefinition | SRC-01 -->
+      <a href="faq.html" class="service-card" role="listitem" data-schema-source="localPolicy.hmoDefinitions.generalDefinition">
+        <span class="icon" aria-hidden="true">
+          <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 9a3 3 0 116 0c0 2-3 2-3 5"/><path d="M12 17h.01"/></svg>
+        </span>
+        <h3>Frequently asked questions</h3>
+        <p>Quick answers to the most common questions from landlords and managers.</p>
+      </a>
+
+    </div>
+  </div>
+
+  <!-- schema-source: localPolicy.licensingPolicy.tenantLicensingStatement | SRC-01 -->
+  <section class="tasks-strip" aria-labelledby="popular-title" data-schema-source="localPolicy.licensingPolicy.tenantLicensingStatement">
+    <div class="container">
+      <div class="section-title">
+        <h2 id="popular-title">Popular tasks</h2>
+      </div>
+      <div class="tasks-grid">
+        <a class="task-link" href="apply.html">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+          Apply for a new HMO licence
+        </a>
+        <a class="task-link" href="apply.html">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+          Renew an existing licence
+        </a>
+        <a class="task-link" href="planning.html">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+          Check planning requirements
+        </a>
+        <a class="task-link" href="standards.html">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+          Read the HMO standards
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <div class="container" style="padding-top: var(--s-6);">
+    <div class="help-grid" style="display:grid;grid-template-columns:1fr 1fr;gap:var(--s-4);">
+      <div class="help-card" style="background:var(--bg-card);border:1px solid var(--border);border-radius:var(--radius-lg);padding:var(--s-4);">
+        <h3 style="margin-top:0;">Looking for something else?</h3>
+        <p>For licensing information and detailed guidance on what the council checks before granting a licence, see the full HMO licensing information page.</p>
+        <p><a href="licensing.html">HMO licensing information</a></p>
+      </div>
+      <div class="help-card" style="background:var(--bg-card);border:1px solid var(--border);border-radius:var(--radius-lg);padding:var(--s-4);">
+        <h3 style="margin-top:0;">Contact us</h3>
+        <p>For general enquiries about HMO licensing and standards:</p>
+        <p style="margin:0;">
+          <strong>Phone:</strong> <a href="tel:01452396396">01452 396 396</a><br>
+          <strong>Email:</strong> <a href="mailto:heretohelp@gloucester.gov.uk">heretohelp@gloucester.gov.uk</a><br>
+          <strong>Monday to Friday:</strong> 9am to 5pm (Wednesday: 10am to 5pm)
+        </p>
+      </div>
+    </div>
+  </div>
+
+</main>
+
+<footer class="site-footer" role="contentinfo">
+  <div class="container">
+    <div class="footer-grid">
+      <div>
+        <h2>Services</h2>
+        <ul>
+          <li><a href="licensing.html">HMO licensing</a></li>
+          <li><a href="standards.html">HMO standards</a></li>
+          <li><a href="planning.html">Planning guidance</a></li>
+          <li><a href="faq.html">FAQ</a></li>
+        </ul>
+      </div>
+      <div>
+        <h2>About</h2>
+        <ul>
+          <li><a href="#">About the council</a></li>
+          <li><a href="#">News</a></li>
+          <li><a href="#">Jobs</a></li>
+          <li><a href="#">Contact us</a></li>
+        </ul>
+      </div>
+      <div>
+        <h2>Help</h2>
+        <ul>
+          <li><a href="#">Accessibility statement</a></li>
+          <li><a href="#">Cookies</a></li>
+          <li><a href="#">Privacy</a></li>
+          <li><a href="#">Terms</a></li>
+        </ul>
+      </div>
+      <div>
+        <h2>Get in touch</h2>
+        <p style="margin: 0 0 8px;"><strong>Our opening hours are:</strong></p>
+        <ul>
+          <li>Mon, Tue, Thu, Fri: 9am to 5pm</li>
+          <li>Wednesday: 10am to 5pm</li>
+        </ul>
+        <p style="margin: 8px 0 4px;"><a href="tel:01452396396">01452 396 396</a></p>
+        <p style="margin: 0;"><a href="mailto:heretohelp@gloucester.gov.uk">heretohelp@gloucester.gov.uk</a></p>
+      </div>
+    </div>
+    <div class="legal">
+      <span>© Gloucester City Council 2026</span>
+      <span>All content available under the Open Government Licence v3.0, except where otherwise stated.</span>
+    </div>
+  </div>
+</footer>
+
+<script src="../../templates/assets/site.js"></script>
+</body>
+</html>

--- a/HMO/web/licensing.html
+++ b/HMO/web/licensing.html
@@ -1,0 +1,280 @@
+<!DOCTYPE html>
+<!--
+  Gloucester City Council — HMO Licensing Information Page
+  Template: information.html
+  Output: /HMO/web/licensing.html
+-->
+<html lang="en-GB">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>HMO licensing in Gloucester — Gloucester City Council</title>
+  <meta name="description" content="Who needs a licence, how to apply, fees and what the council checks before granting an HMO licence in Gloucester.">
+  <meta name="theme-color" content="#0054a4">
+  <link rel="stylesheet" href="../../templates/assets/styles.css">
+  <link rel="stylesheet" href="../../templates/assets/a11y.css">
+</head>
+<body>
+
+<a class="skip-link" href="#main">Skip to main content</a>
+
+<header class="site-header" role="banner">
+  <div class="container header-inner">
+    <a href="index.html" class="brand" aria-label="Gloucester City Council home">
+      <img src="../../templates/assets/GCC_logo.svg" alt="Gloucester City Council" class="brand-logo">
+    </a>
+    <form class="header-search" role="search" action="#" onsubmit="event.preventDefault();">
+      <label for="site-search" class="visually-hidden">Search the site</label>
+      <input type="search" id="site-search" placeholder="Search Gloucester.gov.uk" autocomplete="off">
+      <button type="submit" aria-label="Search">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/>
+        </svg>
+      </button>
+    </form>
+  </div>
+</header>
+
+<div class="container">
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <ol>
+      <li><a href="#">Home</a></li>
+      <li><a href="index.html">Houses in Multiple Occupation (HMO)</a></li>
+      <li><span aria-current="page">HMO licensing in Gloucester</span></li>
+    </ol>
+  </nav>
+</div>
+
+<main id="main" role="main" tabindex="-1" data-screen-label="03 Information">
+  <div class="container">
+    <h1>HMO licensing in Gloucester</h1>
+    <p class="lede">Who needs a licence, how to apply, fees and what the council checks before granting a licence.</p>
+
+    <nav class="tab-bar" aria-label="Sections on this page">
+      <a href="#do-you-need" class="active" aria-current="true">Do you need a licence?</a>
+      <a href="#what-council-checks">What the council checks</a>
+      <a href="#licence-duration">Licence duration</a>
+      <a href="#fees">Fees</a>
+      <a href="#licence-conditions">Licence conditions</a>
+    </nav>
+
+    <div class="page-layout">
+      <div class="main-content">
+
+        <!-- schema-source: localPolicy.licensingPolicy.licensingRequirement | SRC-02 -->
+        <section id="do-you-need" data-schema-source="localPolicy.licensingPolicy.licensingRequirement">
+          <h2>Do you need a licence?</h2>
+          <p>A licence is required for all HMOs that are occupied by five or more people belonging to 2 or more households and who share a facility or amenity.</p>
+
+          <!-- schema-source: localPolicy.licensingPolicy.mandatoryLicensingStatement | SRC-01 -->
+          <div data-schema-source="localPolicy.licensingPolicy.mandatoryLicensingStatement">
+            <p>If your HMO property has 5 persons or more who form more than one household and share facilities it must now be licensed.</p>
+          </div>
+
+          <!-- schema-source: localPolicy.hmoDefinitions.smallHMO | SRC-03 -->
+          <div data-schema-source="localPolicy.hmoDefinitions.smallHMO">
+            <h3>Small HMOs</h3>
+            <p>A small HMO is a property occupied by between three and six unrelated individuals, as their only or main residence, who share basic amenities such as a kitchen or bathroom. Change of use to a small HMO does not typically require planning permission but will require licensing where five or more people are involved.</p>
+          </div>
+
+          <!-- schema-source: localPolicy.hmoDefinitions.largeHMO | SRC-03 -->
+          <div data-schema-source="localPolicy.hmoDefinitions.largeHMO">
+            <h3>Large HMOs</h3>
+            <p>A large HMO is a property occupied by 7 or more people who form more than 1 household. These require planning permission and licensing.</p>
+          </div>
+        </section>
+
+        <!-- schema-source: localPolicy.licensingPolicy.preGrantConditions | SRC-02 -->
+        <section id="what-council-checks" data-schema-source="localPolicy.licensingPolicy.preGrantConditions">
+          <h2>What the council checks</h2>
+          <p>Before granting a licence the Council will determine if the proposed licence holder and manager is fit and proper persons, that suitable financial and management arrangements are in place for the management of the HMO and that the HMO is suitable for occupation by a specified number of tenants based on the minimum standards in this document.</p>
+
+          <!-- schema-source: localPolicy.licensingPolicy.licenceApplicationGuidanceNotes.namedPersonRequirement | SRC-05 -->
+          <div data-schema-source="localPolicy.licensingPolicy.licenceApplicationGuidanceNotes.namedPersonRequirement">
+            <div class="inset-panel info">
+              <p><strong>Named person requirement:</strong> Gloucester City Council will only accept licence applications with a named person as the licence holder. If a company wishes to licence a property the licence holder must be a named person within the company.</p>
+            </div>
+          </div>
+        </section>
+
+        <!-- schema-source: localPolicy.licensingPolicy.licenceApplicationGuidanceNotes.licenceDurationStatement | SRC-05 -->
+        <section id="licence-duration" data-schema-source="localPolicy.licensingPolicy.licenceApplicationGuidanceNotes.licenceDurationStatement">
+          <h2>Licence duration</h2>
+          <p>The licence is valid for a period of up to five years. New applications are dated from when the application is deemed valid.</p>
+
+          <table class="gov-table">
+            <caption>Licence duration categories</caption>
+            <thead>
+              <tr>
+                <th scope="col">Category</th>
+                <th scope="col">Duration</th>
+                <th scope="col">Notes</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row">New licence</th>
+                <td>Up to 5 years</td>
+                <td>Dated from when application is deemed valid</td>
+              </tr>
+              <tr>
+                <th scope="row">Renewal licence</th>
+                <td>Up to 5 years</td>
+                <td>Dated from expiry of previous licence</td>
+              </tr>
+            </tbody>
+          </table>
+
+          <p>Where a licence holder fails to comply with licence conditions, the council may reduce the duration of a licence as part of any enforcement action taken.</p>
+        </section>
+
+        <!-- schema-source: localPolicy.licensingPolicy.fees | SRC-01 -->
+        <section id="fees" data-schema-source="localPolicy.licensingPolicy.fees">
+          <h2>Fees</h2>
+          <p>The following fees apply to HMO licence applications in Gloucester.</p>
+
+          <table class="gov-table">
+            <caption>HMO licence fees from 1 April 2026</caption>
+            <thead>
+              <tr>
+                <th scope="col">Licence type</th>
+                <th scope="col">Duration</th>
+                <th scope="col" class="num">Fee</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row">New licence</th>
+                <td>Up to 5 years</td>
+                <td class="num">£1,260.00</td>
+              </tr>
+              <tr>
+                <th scope="row">Renewal</th>
+                <td>Up to 5 years</td>
+                <td class="num">£900.00</td>
+              </tr>
+            </tbody>
+          </table>
+
+          <div class="inset-panel info">
+            <p><strong>Previous fees (up to April 2026):</strong> New licence £947.00 | Renewal £797.00. These fees applied before 1 April 2026.</p>
+          </div>
+        </section>
+
+        <!-- schema-source: localPolicy.licensingPolicy.licenceConditionsStatement | SRC-02 -->
+        <section id="licence-conditions" data-schema-source="localPolicy.licensingPolicy.licenceConditionsStatement">
+          <h2>Licence conditions</h2>
+          <p>Each HMO licence that is granted will come with specific conditions that the licence holder will be bound to comply with. These conditions relate to the management and maintenance of the property and the safety of occupants.</p>
+
+          <!-- schema-source: centralGovernmentLegislationAndGuidance.complianceFramework.licensing.mandatoryLicence | SRC-01 -->
+          <div data-schema-source="centralGovernmentLegislationAndGuidance.complianceFramework.licensing.mandatoryLicence">
+            <div class="inset-panel warning">
+              <p><strong>Important:</strong> Failure to comply with the conditions of a HMO licence is an offence for each breach and may lead to enforcement action being taken.</p>
+              <p>Penalties for operating an unlicensed HMO:</p>
+              <ul>
+                <li>Unlimited fine on conviction (Housing Act 2004, s.72)</li>
+                <li>Civil penalty of up to £30,000 (Housing and Planning Act 2016, ss.28–31)</li>
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        <div class="cta-block">
+          <h2 style="margin-top:0;">Ready to apply?</h2>
+          <p>Apply for a new or renewal HMO licence online.</p>
+          <a class="btn btn-primary" href="apply.html">
+            Apply for an HMO licence
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M5 12h14M13 5l7 7-7 7"/>
+            </svg>
+          </a>
+        </div>
+
+      </div>
+
+      <aside class="sidebar" aria-label="Related information">
+        <div class="sidebar-card contact">
+          <h2>Contact</h2>
+          <p style="margin:0 0 4px;"><strong>Phone</strong></p>
+          <p style="font-weight:700;font-size:1.125rem;margin:0 0 var(--s-2);">
+            <a href="tel:01452396396">01452 396 396</a>
+          </p>
+          <p style="font-size:.9375rem;margin:0 0 var(--s-2);">Monday to Friday, 9am to 5pm (Wednesday: 10am to 5pm)</p>
+          <p style="margin:0;"><strong>Email:</strong> <a href="mailto:heretohelp@gloucester.gov.uk">heretohelp@gloucester.gov.uk</a></p>
+        </div>
+
+        <div class="sidebar-card">
+          <h2>On this page</h2>
+          <ul>
+            <li><a href="#do-you-need">Do you need a licence?</a></li>
+            <li><a href="#what-council-checks">What the council checks</a></li>
+            <li><a href="#licence-duration">Licence duration</a></li>
+            <li><a href="#fees">Fees</a></li>
+            <li><a href="#licence-conditions">Licence conditions</a></li>
+          </ul>
+        </div>
+
+        <div class="sidebar-card">
+          <h2>Related</h2>
+          <ul>
+            <li><a href="apply.html">Apply for an HMO licence</a></li>
+            <li><a href="standards.html">HMO standards and safety</a></li>
+            <li><a href="faq.html">Frequently asked questions</a></li>
+          </ul>
+        </div>
+      </aside>
+    </div>
+  </div>
+</main>
+
+<footer class="site-footer" role="contentinfo">
+  <div class="container">
+    <div class="footer-grid">
+      <div>
+        <h2>Services</h2>
+        <ul>
+          <li><a href="licensing.html">HMO licensing</a></li>
+          <li><a href="standards.html">HMO standards</a></li>
+          <li><a href="planning.html">Planning guidance</a></li>
+          <li><a href="faq.html">FAQ</a></li>
+        </ul>
+      </div>
+      <div>
+        <h2>About</h2>
+        <ul>
+          <li><a href="#">About the council</a></li>
+          <li><a href="#">News</a></li>
+          <li><a href="#">Jobs</a></li>
+          <li><a href="#">Contact us</a></li>
+        </ul>
+      </div>
+      <div>
+        <h2>Help</h2>
+        <ul>
+          <li><a href="#">Accessibility statement</a></li>
+          <li><a href="#">Cookies</a></li>
+          <li><a href="#">Privacy</a></li>
+          <li><a href="#">Terms</a></li>
+        </ul>
+      </div>
+      <div>
+        <h2>Get in touch</h2>
+        <p style="margin: 0 0 8px;"><strong>Our opening hours are:</strong></p>
+        <ul>
+          <li>Mon, Tue, Thu, Fri: 9am to 5pm</li>
+          <li>Wednesday: 10am to 5pm</li>
+        </ul>
+        <p style="margin: 8px 0 4px;"><a href="tel:01452396396">01452 396 396</a></p>
+        <p style="margin: 0;"><a href="mailto:heretohelp@gloucester.gov.uk">heretohelp@gloucester.gov.uk</a></p>
+      </div>
+    </div>
+    <div class="legal">
+      <span>© Gloucester City Council 2026</span>
+      <span>All content available under the Open Government Licence v3.0, except where otherwise stated.</span>
+    </div>
+  </div>
+</footer>
+
+<script src="../../templates/assets/site.js"></script>
+</body>
+</html>

--- a/HMO/web/planning.html
+++ b/HMO/web/planning.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<!--
+  Gloucester City Council — Planning Permission for HMOs
+  Template: information.html
+  Output: /HMO/web/planning.html
+-->
+<html lang="en-GB">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Planning permission for Houses in Multiple Occupation — Gloucester City Council</title>
+  <meta name="description" content="When you need planning permission to convert a property to an HMO in Gloucester, including local planning policy for HMOs.">
+  <meta name="theme-color" content="#0054a4">
+  <link rel="stylesheet" href="../../templates/assets/styles.css">
+  <link rel="stylesheet" href="../../templates/assets/a11y.css">
+</head>
+<body>
+
+<a class="skip-link" href="#main">Skip to main content</a>
+
+<header class="site-header" role="banner">
+  <div class="container header-inner">
+    <a href="index.html" class="brand" aria-label="Gloucester City Council home">
+      <img src="../../templates/assets/GCC_logo.svg" alt="Gloucester City Council" class="brand-logo">
+    </a>
+    <form class="header-search" role="search" action="#" onsubmit="event.preventDefault();">
+      <label for="site-search" class="visually-hidden">Search the site</label>
+      <input type="search" id="site-search" placeholder="Search Gloucester.gov.uk" autocomplete="off">
+      <button type="submit" aria-label="Search">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/>
+        </svg>
+      </button>
+    </form>
+  </div>
+</header>
+
+<div class="container">
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <ol>
+      <li><a href="#">Home</a></li>
+      <li><a href="index.html">Houses in Multiple Occupation (HMO)</a></li>
+      <li><span aria-current="page">Planning permission for Houses in Multiple Occupation</span></li>
+    </ol>
+  </nav>
+</div>
+
+<main id="main" role="main" tabindex="-1" data-screen-label="03 Information">
+  <div class="container">
+    <h1>Planning permission for Houses in Multiple Occupation</h1>
+    <p class="lede">When you need planning permission to convert a property to an HMO in Gloucester.</p>
+
+    <!-- schema-source: localPolicy.licensingPolicy.planningAndLicensingDistinction | SRC-03 -->
+    <div class="inset-panel warning" data-schema-source="localPolicy.licensingPolicy.planningAndLicensingDistinction">
+      <p><strong>Important:</strong> Planning and licensing are two different matters. Failure to meet the requirements for either planning or licensing can result in enforcement action and fines.</p>
+    </div>
+
+    <nav class="tab-bar" aria-label="Sections on this page">
+      <a href="#small-hmos" class="active" aria-current="true">Small HMOs (use class C4)</a>
+      <a href="#large-hmos">Large HMOs (Sui Generis)</a>
+      <a href="#policy-a2">Policy A2: HMO planning policy</a>
+      <a href="#upcoming-changes">Upcoming changes</a>
+    </nav>
+
+    <div class="page-layout">
+      <div class="main-content">
+
+        <!-- schema-source: localPolicy.hmoDefinitions.smallHMO | SRC-03 -->
+        <section id="small-hmos" data-schema-source="localPolicy.hmoDefinitions.smallHMO">
+          <h2>Small HMOs (use class C4)</h2>
+          <p>A small HMO is a property occupied by between three and six unrelated individuals, as their only or main residence, who share basic amenities such as a kitchen or bathroom. Change of use to a small HMO does not typically require planning permission but will require licensing where five or more people are involved.</p>
+          <p>The permitted development right for change of use from a dwelling house (C3) to a small HMO (C4) is set out in the Town and Country Planning (General Permitted Development) Order 2015 (GPDO 2015), Schedule 2, Part 3, Class L. This right allows conversion without a full planning application in most circumstances.</p>
+          <p>You should note that even where planning permission is not required, an HMO licence may still be required. You should also check whether any Article 4 Directions apply to your area, as these may remove permitted development rights.</p>
+        </section>
+
+        <!-- schema-source: localPolicy.hmoDefinitions.largeHMO | SRC-03 -->
+        <section id="large-hmos" data-schema-source="localPolicy.hmoDefinitions.largeHMO">
+          <h2>Large HMOs (Sui Generis)</h2>
+          <p>A large HMO is a property occupied by 7 or more people who form more than 1 household. These require planning permission and licensing.</p>
+
+          <!-- schema-source: localPolicy.hmoDefinitions.planningPermissionLawfulUse | SRC-02 -->
+          <div data-schema-source="localPolicy.hmoDefinitions.planningPermissionLawfulUse">
+            <p>Planning permission is required for all large HMOs that are occupied by more than six people who are not related. All works carried out in an HMO must comply with Building Regulation requirements.</p>
+          </div>
+        </section>
+
+        <!-- schema-source: localPolicy.planningPolicy.policyA2 | SRC-03 -->
+        <section id="policy-a2" data-schema-source="localPolicy.planningPolicy.policyA2">
+          <h2>Policy A2: HMO planning policy</h2>
+
+          <!-- schema-source: localPolicy.planningPolicy.developmentPlanReference | SRC-03 -->
+          <div data-schema-source="localPolicy.planningPolicy.developmentPlanReference">
+            <p>The Gloucester City Plan (2011–2031) (GCP) sets out when planning permission will be granted. Policy A2 of the City Plan sets out the criteria that planning applications for new HMOs must meet.</p>
+          </div>
+
+          <p>Planning permission for the creation of a House in Multiple Occupation (HMO) will be permitted where:</p>
+          <ol>
+            <li>The development would not result in any existing residential property (C3 use) being 'sandwiched' between two HMOs; and</li>
+            <li>The development would not result in the creation of more than two adjacent properties in HMO use; and</li>
+            <li>HMOs, including the proposed development, would represent no more than 10% of properties within a 100-metre radius of the application property.</li>
+          </ol>
+
+          <!-- schema-source: localPolicy.planningPolicy.saturationCalculationRules | SRC-03 -->
+          <div data-schema-source="localPolicy.planningPolicy.saturationCalculationRules">
+            <h3>How the 10% saturation limit is calculated</h3>
+            <ul>
+              <li>The 100-metre radius is measured from the application property.</li>
+              <li>All properties (including the application property) within that radius are counted.</li>
+              <li>Existing HMOs and the proposed HMO are counted as HMO properties.</li>
+              <li>The percentage of HMO properties must not exceed 10% of all properties within the radius.</li>
+              <li>Properties of all tenures are included in the total count.</li>
+            </ul>
+          </div>
+        </section>
+
+        <!-- schema-source: councilStrategy.hmoExplicitCommitments | HMO-C1 -->
+        <section id="upcoming-changes" data-schema-source="councilStrategy.hmoExplicitCommitments">
+          <h2>Upcoming changes</h2>
+          <p>A public consultation on an Article 4 Direction ran from 2 March 2026 to 11 May 2026. A confirmed direction has not yet been published. Check gloucester.gov.uk for updates.</p>
+
+          <div class="inset-panel info">
+            <p><strong>Corporate Plan commitment:</strong> The council has committed to introduce stronger mechanisms and regulatory powers, such as an Article 4 Direction, to control the proliferation of Houses in Multiple Occupation and improve standards in the private rented sector.</p>
+          </div>
+
+          <p>An Article 4 Direction, if confirmed, would remove the permitted development right to convert a dwelling (C3) to a small HMO (C4) without planning permission. This would mean that all conversions to HMO use — including small HMOs — would require a planning application in the affected area.</p>
+        </section>
+
+      </div>
+
+      <aside class="sidebar" aria-label="Related information">
+        <div class="sidebar-card contact">
+          <h2>Contact</h2>
+          <p style="margin:0 0 4px;"><strong>Phone</strong></p>
+          <p style="font-weight:700;font-size:1.125rem;margin:0 0 var(--s-2);">
+            <a href="tel:01452396396">01452 396 396</a>
+          </p>
+          <p style="font-size:.9375rem;margin:0 0 var(--s-2);">Monday to Friday, 9am to 5pm (Wednesday: 10am to 5pm)</p>
+          <p style="margin:0;"><strong>Email:</strong> <a href="mailto:heretohelp@gloucester.gov.uk">heretohelp@gloucester.gov.uk</a></p>
+        </div>
+
+        <div class="sidebar-card">
+          <h2>On this page</h2>
+          <ul>
+            <li><a href="#small-hmos">Small HMOs (use class C4)</a></li>
+            <li><a href="#large-hmos">Large HMOs (Sui Generis)</a></li>
+            <li><a href="#policy-a2">Policy A2: HMO planning policy</a></li>
+            <li><a href="#upcoming-changes">Upcoming changes</a></li>
+          </ul>
+        </div>
+
+        <div class="sidebar-card">
+          <h2>Related</h2>
+          <ul>
+            <li><a href="licensing.html">HMO licensing</a></li>
+            <li><a href="apply.html">Apply for an HMO licence</a></li>
+            <li><a href="faq.html">Frequently asked questions</a></li>
+          </ul>
+        </div>
+      </aside>
+    </div>
+  </div>
+</main>
+
+<footer class="site-footer" role="contentinfo">
+  <div class="container">
+    <div class="footer-grid">
+      <div>
+        <h2>Services</h2>
+        <ul>
+          <li><a href="licensing.html">HMO licensing</a></li>
+          <li><a href="standards.html">HMO standards</a></li>
+          <li><a href="planning.html">Planning guidance</a></li>
+          <li><a href="faq.html">FAQ</a></li>
+        </ul>
+      </div>
+      <div>
+        <h2>About</h2>
+        <ul>
+          <li><a href="#">About the council</a></li>
+          <li><a href="#">News</a></li>
+          <li><a href="#">Jobs</a></li>
+          <li><a href="#">Contact us</a></li>
+        </ul>
+      </div>
+      <div>
+        <h2>Help</h2>
+        <ul>
+          <li><a href="#">Accessibility statement</a></li>
+          <li><a href="#">Cookies</a></li>
+          <li><a href="#">Privacy</a></li>
+          <li><a href="#">Terms</a></li>
+        </ul>
+      </div>
+      <div>
+        <h2>Get in touch</h2>
+        <p style="margin: 0 0 8px;"><strong>Our opening hours are:</strong></p>
+        <ul>
+          <li>Mon, Tue, Thu, Fri: 9am to 5pm</li>
+          <li>Wednesday: 10am to 5pm</li>
+        </ul>
+        <p style="margin: 8px 0 4px;"><a href="tel:01452396396">01452 396 396</a></p>
+        <p style="margin: 0;"><a href="mailto:heretohelp@gloucester.gov.uk">heretohelp@gloucester.gov.uk</a></p>
+      </div>
+    </div>
+    <div class="legal">
+      <span>© Gloucester City Council 2026</span>
+      <span>All content available under the Open Government Licence v3.0, except where otherwise stated.</span>
+    </div>
+  </div>
+</footer>
+
+<script src="../../templates/assets/site.js"></script>
+</body>
+</html>

--- a/HMO/web/residents.html
+++ b/HMO/web/residents.html
@@ -1,0 +1,228 @@
+<!DOCTYPE html>
+<!--
+  Gloucester City Council — HMO Residents Information Page
+  Template: information.html
+  Output: /HMO/web/residents.html
+-->
+<html lang="en-GB">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Living in an HMO — your rights and what to expect — Gloucester City Council</title>
+  <meta name="description" content="Information for tenants living in a House in Multiple Occupation (HMO) in Gloucester.">
+  <meta name="theme-color" content="#0054a4">
+  <link rel="stylesheet" href="../../templates/assets/styles.css">
+  <link rel="stylesheet" href="../../templates/assets/a11y.css">
+</head>
+<body>
+
+<a class="skip-link" href="#main">Skip to main content</a>
+
+<header class="site-header" role="banner">
+  <div class="container header-inner">
+    <a href="index.html" class="brand" aria-label="Gloucester City Council home">
+      <img src="../../templates/assets/GCC_logo.svg" alt="Gloucester City Council" class="brand-logo">
+    </a>
+    <form class="header-search" role="search" action="#" onsubmit="event.preventDefault();">
+      <label for="site-search" class="visually-hidden">Search the site</label>
+      <input type="search" id="site-search" placeholder="Search Gloucester.gov.uk" autocomplete="off">
+      <button type="submit" aria-label="Search">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/>
+        </svg>
+      </button>
+    </form>
+  </div>
+</header>
+
+<div class="container">
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <ol>
+      <li><a href="#">Home</a></li>
+      <li><a href="index.html">Houses in Multiple Occupation (HMO)</a></li>
+      <li><span aria-current="page">Living in an HMO — your rights and what to expect</span></li>
+    </ol>
+  </nav>
+</div>
+
+<main id="main" role="main" tabindex="-1" data-screen-label="03 Information">
+  <div class="container">
+    <h1>Living in an HMO — your rights and what to expect</h1>
+    <p class="lede">Information for tenants living in a House in Multiple Occupation (HMO) in Gloucester.</p>
+
+    <nav class="tab-bar" aria-label="Sections on this page">
+      <a href="#what-is-hmo" class="active" aria-current="true">What is an HMO?</a>
+      <a href="#your-rights">Your rights</a>
+      <a href="#licensing">Licensing</a>
+      <a href="#reporting">Reporting problems</a>
+    </nav>
+
+    <div class="page-layout">
+      <div class="main-content">
+
+        <!-- schema-source: localPolicy.hmoDefinitions.generalDefinition | SRC-01 -->
+        <section id="what-is-hmo" data-schema-source="localPolicy.hmoDefinitions.generalDefinition">
+          <h2>What is an HMO?</h2>
+          <p>A HMO is a house in multiple occupation and applies to buildings that are either a single dwelling or a flat where one or more separate households share facilities such as; kitchens, toilet and bathroom.</p>
+
+          <!-- schema-source: localPolicy.hmoDefinitions.hmoTypes | SRC-02 -->
+          <div data-schema-source="localPolicy.hmoDefinitions.hmoTypes">
+            <h3>Types of HMO</h3>
+            <p>There are four main types of HMO:</p>
+            <ol>
+              <li><strong>Bedsits</strong> — self-contained rooms where occupants share some or all facilities such as bathrooms and kitchens.</li>
+              <li><strong>Shared houses or flats</strong> — a property let to a group of people who are not related, sharing kitchen, bathroom and living facilities.</li>
+              <li><strong>Lodgings</strong> — a property where a landlord lives and rents rooms to three or more lodgers who are not related to the owner.</li>
+              <li><strong>Hostels and bed and breakfast accommodation</strong> — where the main use is not a hotel or guest house and the accommodation provides the main or only residence for occupants.</li>
+            </ol>
+          </div>
+        </section>
+
+        <!-- schema-source: centralGovernmentLegislationAndGuidance.complianceFramework.tenantRights | SRC-01 -->
+        <section id="your-rights" data-schema-source="centralGovernmentLegislationAndGuidance.complianceFramework.tenantRights">
+          <h2>Your rights</h2>
+          <p>As a tenant in an HMO you have a number of important legal rights. These include protections introduced by recent legislation.</p>
+
+          <ul>
+            <li><strong>Right to periodic assured tenancy</strong> — you cannot be locked into a fixed-term tenancy from 1 May 2026. (Renters' Rights Act 2025, ss.1–7)</li>
+            <li><strong>Protection from no-fault eviction</strong> — Section 21 "no-fault" evictions have been abolished. Your landlord must have a valid reason to end your tenancy. (Renters' Rights Act 2025, s.8)</li>
+            <li><strong>Rent increase limits</strong> — rent can only be increased once per 12 months. (Renters' Rights Act 2025, ss.124–130)</li>
+            <li><strong>Tenancy deposit cap</strong> — your deposit is capped at 5 weeks' rent. (Tenant Fees Act 2019)</li>
+            <li><strong>Protection from fees</strong> — most fees charged by landlords or agents are prohibited. (Tenant Fees Act 2019)</li>
+            <li><strong>Rent Repayment Order</strong> — you may be able to apply to the First-tier Tribunal for a Rent Repayment Order of up to 12 months' rent where your HMO is unlicensed. (Housing and Planning Act 2016, ss.40–41)</li>
+            <li><strong>Access to information about your landlord</strong> — you have the right to access information about your landlord on the Private Rented Sector (PRS) Database. (Renters' Rights Act 2025, ss.56–82)</li>
+            <li><strong>Right to complain to the Landlord Ombudsman</strong> — all private landlords must belong to a landlord ombudsman scheme. (Renters' Rights Act 2025, ss.83–99)</li>
+            <li><strong>Protection from discrimination</strong> — landlords and agents cannot discriminate against tenants with children or those in receipt of benefits. (Renters' Rights Act 2025, ss.131–135)</li>
+          </ul>
+        </section>
+
+        <!-- schema-source: localPolicy.licensingPolicy.tenantLicensingStatement | SRC-01 -->
+        <section id="licensing" data-schema-source="localPolicy.licensingPolicy.tenantLicensingStatement">
+          <h2>Licensing — what your landlord must do</h2>
+          <p>Your landlord must have a licence for all HMO properties which are occupied by five or more people forming two or more households.</p>
+
+          <!-- schema-source: localPolicy.hmoDefinitions.whatIsNotAnHMO | SRC-02 -->
+          <div data-schema-source="localPolicy.hmoDefinitions.whatIsNotAnHMO">
+            <h3>What is not an HMO?</h3>
+            <p>The following are not classified as HMOs:</p>
+            <ul>
+              <li>An entire flat or house let to one person, a couple, a family or two people sharing.</li>
+              <li>Two lodgers with an owner occupier living in the house.</li>
+            </ul>
+          </div>
+
+          <div class="inset-panel warning">
+            <p><strong>Important:</strong> If your HMO is unlicensed you may be able to apply to the First-tier Tribunal for a Rent Repayment Order (up to 12 months' rent). [Housing and Planning Act 2016, ss.40–41]</p>
+          </div>
+        </section>
+
+        <!-- schema-source: localPolicy.tenantEnforcementContact.councilResponsibility | SRC-01 -->
+        <section id="reporting" data-schema-source="localPolicy.tenantEnforcementContact.councilResponsibility">
+          <h2>Reporting problems</h2>
+          <p>The council is responsible for enforcing HMO standards, so if you are a tenant living in a HMO and feel there are any unreasonable hazards which your private landlord is not dealing with, please report it.</p>
+
+          <p>Contact us to report a problem:</p>
+          <ul>
+            <li><strong>Phone:</strong> <a href="tel:01452396396">01452 396 396</a></li>
+            <li><strong>Email:</strong> <a href="mailto:heretohelp@gloucester.gov.uk">heretohelp@gloucester.gov.uk</a></li>
+          </ul>
+
+          <!-- schema-source: localPolicy.tenantEnforcementContact.publicRegisterStatement | SRC-01 -->
+          <div data-schema-source="localPolicy.tenantEnforcementContact.publicRegisterStatement">
+            <p>The council must maintain a public register of all the premises licensed as a house in multiple occupation. You can contact us to check whether a property is registered.</p>
+          </div>
+
+          <!-- schema-source: localPolicy.managementRegulationsPolicy.tenantDuties | SRC-02 -->
+          <div data-schema-source="localPolicy.managementRegulationsPolicy.tenantDuties">
+            <h3>Your duties as a tenant</h3>
+            <p>The management regulations also place a duty on tenants not to hinder managers in complying with these duties. As a tenant you must cooperate with your landlord or manager when they are carrying out work or inspections required by law.</p>
+          </div>
+        </section>
+
+      </div>
+
+      <aside class="sidebar" aria-label="Related information">
+        <div class="sidebar-card contact">
+          <h2>Contact</h2>
+          <p style="margin:0 0 4px;"><strong>Phone</strong></p>
+          <p style="font-weight:700;font-size:1.125rem;margin:0 0 var(--s-2);">
+            <a href="tel:01452396396">01452 396 396</a>
+          </p>
+          <p style="font-size:.9375rem;margin:0 0 var(--s-2);">Monday to Friday, 9am to 5pm (Wednesday: 10am to 5pm)</p>
+          <p style="margin:0;"><strong>Email:</strong> <a href="mailto:heretohelp@gloucester.gov.uk">heretohelp@gloucester.gov.uk</a></p>
+        </div>
+
+        <div class="sidebar-card">
+          <h2>On this page</h2>
+          <ul>
+            <li><a href="#what-is-hmo">What is an HMO?</a></li>
+            <li><a href="#your-rights">Your rights</a></li>
+            <li><a href="#licensing">Licensing</a></li>
+            <li><a href="#reporting">Reporting problems</a></li>
+          </ul>
+        </div>
+
+        <div class="sidebar-card">
+          <h2>Related</h2>
+          <ul>
+            <li><a href="standards.html">HMO standards and safety</a></li>
+            <li><a href="faq.html">Frequently asked questions</a></li>
+            <li><a href="apply.html">Apply for an HMO licence</a></li>
+          </ul>
+        </div>
+      </aside>
+    </div>
+  </div>
+</main>
+
+<footer class="site-footer" role="contentinfo">
+  <div class="container">
+    <div class="footer-grid">
+      <div>
+        <h2>Services</h2>
+        <ul>
+          <li><a href="licensing.html">HMO licensing</a></li>
+          <li><a href="standards.html">HMO standards</a></li>
+          <li><a href="planning.html">Planning guidance</a></li>
+          <li><a href="faq.html">FAQ</a></li>
+        </ul>
+      </div>
+      <div>
+        <h2>About</h2>
+        <ul>
+          <li><a href="#">About the council</a></li>
+          <li><a href="#">News</a></li>
+          <li><a href="#">Jobs</a></li>
+          <li><a href="#">Contact us</a></li>
+        </ul>
+      </div>
+      <div>
+        <h2>Help</h2>
+        <ul>
+          <li><a href="#">Accessibility statement</a></li>
+          <li><a href="#">Cookies</a></li>
+          <li><a href="#">Privacy</a></li>
+          <li><a href="#">Terms</a></li>
+        </ul>
+      </div>
+      <div>
+        <h2>Get in touch</h2>
+        <p style="margin: 0 0 8px;"><strong>Our opening hours are:</strong></p>
+        <ul>
+          <li>Mon, Tue, Thu, Fri: 9am to 5pm</li>
+          <li>Wednesday: 10am to 5pm</li>
+        </ul>
+        <p style="margin: 8px 0 4px;"><a href="tel:01452396396">01452 396 396</a></p>
+        <p style="margin: 0;"><a href="mailto:heretohelp@gloucester.gov.uk">heretohelp@gloucester.gov.uk</a></p>
+      </div>
+    </div>
+    <div class="legal">
+      <span>© Gloucester City Council 2026</span>
+      <span>All content available under the Open Government Licence v3.0, except where otherwise stated.</span>
+    </div>
+  </div>
+</footer>
+
+<script src="../../templates/assets/site.js"></script>
+</body>
+</html>

--- a/HMO/web/standards.html
+++ b/HMO/web/standards.html
@@ -1,0 +1,468 @@
+<!DOCTYPE html>
+<!--
+  Gloucester City Council — HMO Standards and Safety
+  Template: information.html
+  Output: /HMO/web/standards.html
+-->
+<html lang="en-GB">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>HMO standards and safety requirements — Gloucester City Council</title>
+  <meta name="description" content="The minimum standards landlords and managers must meet for fire safety, space, washing facilities and property management in HMOs in Gloucester.">
+  <meta name="theme-color" content="#0054a4">
+  <link rel="stylesheet" href="../../templates/assets/styles.css">
+  <link rel="stylesheet" href="../../templates/assets/a11y.css">
+</head>
+<body>
+
+<a class="skip-link" href="#main">Skip to main content</a>
+
+<header class="site-header" role="banner">
+  <div class="container header-inner">
+    <a href="index.html" class="brand" aria-label="Gloucester City Council home">
+      <img src="../../templates/assets/GCC_logo.svg" alt="Gloucester City Council" class="brand-logo">
+    </a>
+    <form class="header-search" role="search" action="#" onsubmit="event.preventDefault();">
+      <label for="site-search" class="visually-hidden">Search the site</label>
+      <input type="search" id="site-search" placeholder="Search Gloucester.gov.uk" autocomplete="off">
+      <button type="submit" aria-label="Search">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/>
+        </svg>
+      </button>
+    </form>
+  </div>
+</header>
+
+<div class="container">
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <ol>
+      <li><a href="#">Home</a></li>
+      <li><a href="index.html">Houses in Multiple Occupation (HMO)</a></li>
+      <li><span aria-current="page">HMO standards and safety requirements</span></li>
+    </ol>
+  </nav>
+</div>
+
+<main id="main" role="main" tabindex="-1" data-screen-label="03 Information">
+  <div class="container">
+    <h1>HMO standards and safety requirements</h1>
+    <p class="lede">The minimum standards landlords and managers must meet for fire safety, space, washing facilities and property management.</p>
+
+    <nav class="tab-bar" aria-label="Sections on this page">
+      <a href="#fire-safety" class="active" aria-current="true">Fire safety</a>
+      <a href="#space-standards">Space standards</a>
+      <a href="#washing-facilities">Washing facilities</a>
+      <a href="#management-duties">Management duties</a>
+      <a href="#health-safety">Health and safety inspection</a>
+    </nav>
+
+    <div class="page-layout">
+      <div class="main-content">
+
+        <!-- schema-source: localPolicy.fireSafetyPolicy | SRC-02 -->
+        <section id="fire-safety" data-schema-source="localPolicy.fireSafetyPolicy">
+          <h2>Fire safety</h2>
+          <p>Landlords and managers must ensure their HMO meets fire safety standards. The council will assess fire safety as part of the licensing process.</p>
+
+          <h3>General considerations</h3>
+          <ul>
+            <li>All means of escape from fire must be maintained in good order and free from obstruction at all times.</li>
+            <li>All fire detection and alarm systems must be maintained in working order.</li>
+            <li>All fire fighting equipment must be provided and maintained in accordance with requirements.</li>
+            <li>All fire doors must be maintained in good order and must be self-closing.</li>
+            <li>No combustible materials should be stored in the means of escape.</li>
+            <li>Tenants must be made aware of the fire safety arrangements for the property.</li>
+            <li>A fire risk assessment must be carried out for the common parts of the property and reviewed periodically.</li>
+            <li>All furnishings provided by the landlord must comply with relevant fire safety regulations.</li>
+          </ul>
+
+          <h3>Fire detection</h3>
+          <p>All HMOs must have interlinked smoke detectors fitted in hallways and on landings, and a heat detector fitted in the kitchen. These must comply with BS 5839:2019 part 6 — Grade D:LD2.</p>
+
+          <h3>Protected route</h3>
+          <p>The means of escape must provide 30-minute fire resistance. No items must be stored within the protected route, and all doors on the protected route must be operable without a key.</p>
+
+          <h3>Fire doors</h3>
+          <p>Requirements for fire doors depend on the number of storeys in the property:</p>
+          <ul>
+            <li><strong>Three or more storeys:</strong> 30-minute fire doors are required on all bedroom doors, kitchen doors and living room doors that open onto the protected route.</li>
+            <li><strong>Fewer than three storeys:</strong> Fire doors are only required on rooms that contain kitchen facilities.</li>
+          </ul>
+
+          <p>All fire doors must meet the following requirements:</p>
+          <ul>
+            <li>Must be self-closing and fitted with an appropriate closer device.</li>
+            <li>Must be maintained in a good state of repair with no gaps around the frame.</li>
+            <li>Must be fitted with intumescent strips and cold smoke seals.</li>
+            <li>Must be capable of being opened from both sides without a key.</li>
+            <li>Must be marked as a fire door and kept shut when not in use.</li>
+          </ul>
+
+          <h3>Emergency lighting</h3>
+          <p>Emergency lighting is required in all HMOs of three or more storeys. Emergency lighting must be mains-wired with battery backup to ensure it operates in the event of a power failure.</p>
+
+          <h3>Fire blankets</h3>
+          <p>A fire blanket must be provided in all rooms used for cooking facilities. Fire blankets must be wall-mounted at a height of between 1.2 and 1.5 metres from the floor.</p>
+
+          <h3>Furniture</h3>
+          <p>All furniture provided by the landlord must comply with the Furniture and Furnishings (Fire Safety) Regulations 1988.</p>
+        </section>
+
+        <!-- schema-source: localPolicy.spaceStandards | SRC-02 -->
+        <section id="space-standards" data-schema-source="localPolicy.spaceStandards">
+          <h2>Space standards</h2>
+          <p>All bedrooms must meet minimum size requirements. The minimum sizes depend on whether the room has shared facilities or its own cooking facilities.</p>
+
+          <h3>Bedroom sizes — shared facilities</h3>
+          <table class="gov-table">
+            <caption>Minimum bedroom sizes where occupants share kitchen and bathroom facilities</caption>
+            <thead>
+              <tr>
+                <th scope="col">Occupancy</th>
+                <th scope="col" class="num">Minimum floor area</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row">1 person</th>
+                <td class="num">6.5 sqm</td>
+              </tr>
+              <tr>
+                <th scope="row">2 persons</th>
+                <td class="num">10.2 sqm</td>
+              </tr>
+            </tbody>
+          </table>
+
+          <h3>Bedroom sizes — with cooking facilities</h3>
+          <table class="gov-table">
+            <caption>Minimum bedroom sizes where the room includes cooking facilities</caption>
+            <thead>
+              <tr>
+                <th scope="col">Occupancy</th>
+                <th scope="col" class="num">Minimum floor area</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row">1 person</th>
+                <td class="num">12.5 sqm</td>
+              </tr>
+              <tr>
+                <th scope="row">2 persons</th>
+                <td class="num">15.5 sqm</td>
+              </tr>
+            </tbody>
+          </table>
+
+          <h3>Communal space requirements</h3>
+          <table class="gov-table">
+            <caption>Minimum communal space requirements by number of occupants</caption>
+            <thead>
+              <tr>
+                <th scope="col">Number of occupants</th>
+                <th scope="col" class="num">Minimum kitchen area</th>
+                <th scope="col" class="num">Minimum total communal space</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row">Up to 3</th>
+                <td class="num">7.0 sqm</td>
+                <td class="num">10.0 sqm</td>
+              </tr>
+              <tr>
+                <th scope="row">4–5</th>
+                <td class="num">8.0 sqm</td>
+                <td class="num">14.0 sqm</td>
+              </tr>
+              <tr>
+                <th scope="row">6–7</th>
+                <td class="num">9.0 sqm</td>
+                <td class="num">18.0 sqm</td>
+              </tr>
+              <tr>
+                <th scope="row">8–9</th>
+                <td class="num">10.0 sqm</td>
+                <td class="num">22.0 sqm</td>
+              </tr>
+              <tr>
+                <th scope="row">10+</th>
+                <td class="num">11.0 sqm</td>
+                <td class="num">26.0 sqm</td>
+              </tr>
+            </tbody>
+          </table>
+
+          <div class="inset-panel info">
+            <p><strong>Note:</strong> Rooms that open directly off a kitchen are not suitable for use as sleeping accommodation.</p>
+          </div>
+        </section>
+
+        <!-- schema-source: localPolicy.washingFacilitiesStandards | SRC-02 -->
+        <section id="washing-facilities" data-schema-source="localPolicy.washingFacilitiesStandards">
+          <h2>Washing facilities</h2>
+          <p>All HMOs must provide adequate bathroom and toilet facilities for the number of occupants.</p>
+
+          <table class="gov-table">
+            <caption>Minimum washing facilities required by number of occupants</caption>
+            <thead>
+              <tr>
+                <th scope="col">Number of occupants</th>
+                <th scope="col">Required facilities</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row">Up to 5 people</th>
+                <td>One bathroom containing a toilet, washbasin and a bath or shower</td>
+              </tr>
+              <tr>
+                <th scope="row">Up to 6 people</th>
+                <td>One bathroom as above, plus an additional WC and washbasin</td>
+              </tr>
+              <tr>
+                <th scope="row">Up to 10 people</th>
+                <td>Two bathrooms each containing a toilet, washbasin and a bath or shower</td>
+              </tr>
+            </tbody>
+          </table>
+
+          <p>All baths, showers and washbasins must be supplied with both hot and cold running water.</p>
+        </section>
+
+        <!-- schema-source: localPolicy.managementRegulationsPolicy | SRC-02 -->
+        <section id="management-duties" data-schema-source="localPolicy.managementRegulationsPolicy">
+          <h2>Management duties</h2>
+          <p>The Management of Houses in Multiple Occupation (England) Regulations 2006 set out the duties of managers of HMOs. These regulations apply to all HMOs regardless of whether they require a licence.</p>
+
+          <ol class="steps">
+            <li>
+              <h3>Regulation 3 — Manager's duties to provide information</h3>
+              <p>The manager must display their name, address and contact telephone number in a prominent position in the HMO.</p>
+            </li>
+            <li>
+              <h3>Regulation 4 — Manager's duties to maintain the water supply and drainage</h3>
+              <p>The manager must ensure that the water supply and drainage system serving the HMO are maintained in good working order and not unreasonably interrupted.</p>
+            </li>
+            <li>
+              <h3>Regulation 5 — Manager's duties in respect of the supply of gas and electricity</h3>
+              <p>The manager must ensure that all gas and electrical installations and appliances are maintained in a safe condition and that annual gas safety checks and five-yearly electrical installation condition reports are carried out.</p>
+            </li>
+            <li>
+              <h3>Regulation 6 — Manager's duties to maintain common parts, fixtures, fittings and appliances</h3>
+              <p>The manager must maintain the common parts of the HMO in good and clean decorative repair, in a safe and working condition and free from obstruction.</p>
+            </li>
+            <li>
+              <h3>Regulation 7 — Manager's duties to maintain living accommodation</h3>
+              <p>The manager must ensure that all living accommodation and furniture provided for the use of the occupier is clean at the beginning of each occupation and maintained in good repair.</p>
+            </li>
+            <li>
+              <h3>Regulation 8 — Manager's duties in respect of means of escape from fire</h3>
+              <p>The manager must ensure that all means of escape from fire are maintained in good order and repair and kept free from obstruction at all times.</p>
+            </li>
+            <li>
+              <h3>Regulation 9 — Manager's duties to maintain outbuildings, yards and forecourts</h3>
+              <p>The manager must maintain in repair and good order all outbuildings, yards and forecourts that are used by or accessible to the occupiers of the HMO.</p>
+            </li>
+          </ol>
+
+          <!-- schema-source: localPolicy.managementRegulationsPolicy.tenantDuties | SRC-02 -->
+          <div data-schema-source="localPolicy.managementRegulationsPolicy.tenantDuties">
+            <h3>Tenant duties</h3>
+            <p>The management regulations also place a duty on tenants not to hinder managers in complying with these duties. Tenants must cooperate with their landlord or manager when they are carrying out work or inspections required by law.</p>
+          </div>
+        </section>
+
+        <!-- schema-source: localPolicy.hhsrsPolicy | SRC-02 -->
+        <section id="health-safety" data-schema-source="localPolicy.hhsrsPolicy">
+          <h2>Health and safety inspection</h2>
+          <p>The council uses the Housing Health and Safety Rating System (HHSRS) to assess hazards in HMOs. This is a risk-based evaluation tool used to identify and protect against potential risks and hazards to health and safety from deficiencies identified in dwellings.</p>
+
+          <h3>Hazard groups assessed</h3>
+          <p>The HHSRS covers 29 hazard groups, including:</p>
+          <ul>
+            <li>Damp and mould growth</li>
+            <li>Excess cold</li>
+            <li>Excess heat</li>
+            <li>Asbestos and manufactured mineral fibres</li>
+            <li>Biocides</li>
+            <li>Carbon monoxide and fuel combustion products</li>
+            <li>Lead</li>
+            <li>Radiation</li>
+            <li>Uncombusted fuel gas</li>
+            <li>Volatile organic compounds</li>
+            <li>Crowding and space</li>
+            <li>Entry by intruders</li>
+            <li>Lighting</li>
+            <li>Noise</li>
+            <li>Domestic hygiene, pests and refuse</li>
+            <li>Food safety</li>
+            <li>Personal hygiene, sanitation and drainage</li>
+            <li>Water supply</li>
+            <li>Falls associated with baths</li>
+            <li>Falling on level surfaces</li>
+            <li>Falling on stairs</li>
+            <li>Falling between levels</li>
+            <li>Electrical hazards</li>
+            <li>Fire</li>
+            <li>Flames, hot surfaces</li>
+            <li>Collision and entrapment</li>
+            <li>Explosions</li>
+            <li>Position and operability of amenities</li>
+            <li>Structural collapse and falling elements</li>
+          </ul>
+
+          <h3>Enforcement approach</h3>
+          <p>The council will first seek to resolve hazards through informal action, working with landlords to agree remedial works. Formal enforcement action will be taken where informal approaches are not effective.</p>
+
+          <h3>Formal enforcement</h3>
+          <p>Where formal enforcement is necessary, the council may:</p>
+          <ul>
+            <li><strong>Improvement Notice</strong> — requires the landlord to carry out specified works within a set timescale.</li>
+            <li><strong>Prohibition Order</strong> — prohibits the use of part or all of the property, or restricts the number of occupants, until remedial works are completed.</li>
+          </ul>
+
+          <h3>Hazard awareness notice</h3>
+          <p>Where a hazard does not warrant formal enforcement action, the council may serve a Hazard Awareness Notice to notify the owner of the hazard and recommend remedial action.</p>
+        </section>
+
+        <!-- schema-source: centralGovernmentLegislationAndGuidance.complianceFramework.safetyCertificates | SRC-01 -->
+        <section id="safety-certificates" data-schema-source="centralGovernmentLegislationAndGuidance.complianceFramework.safetyCertificates">
+          <h2>Safety certificates required</h2>
+          <p>Landlords must hold current safety certificates for their HMO property.</p>
+
+          <table class="gov-table">
+            <caption>Safety certificate requirements for HMO landlords</caption>
+            <thead>
+              <tr>
+                <th scope="col">Certificate</th>
+                <th scope="col">Frequency</th>
+                <th scope="col">Penalty for non-compliance</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row">Gas Safety Certificate (CP12)</th>
+                <td>Annual</td>
+                <td>Criminal offence</td>
+              </tr>
+              <tr>
+                <th scope="row">Electrical Installation Condition Report (EICR)</th>
+                <td>Every 5 years</td>
+                <td>Civil penalty up to £30,000</td>
+              </tr>
+              <tr>
+                <th scope="row">Smoke alarm on every storey</th>
+                <td>Test at start of each tenancy</td>
+                <td>Civil penalty up to £5,000</td>
+              </tr>
+              <tr>
+                <th scope="row">Carbon monoxide alarm (rooms with solid fuel appliances)</th>
+                <td>Test at start of each tenancy</td>
+                <td>Civil penalty up to £5,000</td>
+              </tr>
+              <tr>
+                <th scope="row">Fire risk assessment (common parts)</th>
+                <td>Periodically — review as needed</td>
+                <td>Unlimited fine</td>
+              </tr>
+              <tr>
+                <th scope="row">Energy Performance Certificate (EPC) — minimum E rating</th>
+                <td>Before letting</td>
+                <td>Civil penalty up to £4,000</td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+
+      </div>
+
+      <aside class="sidebar" aria-label="Related information">
+        <div class="sidebar-card contact">
+          <h2>Contact</h2>
+          <p style="margin:0 0 4px;"><strong>Phone</strong></p>
+          <p style="font-weight:700;font-size:1.125rem;margin:0 0 var(--s-2);">
+            <a href="tel:01452396396">01452 396 396</a>
+          </p>
+          <p style="font-size:.9375rem;margin:0 0 var(--s-2);">Monday to Friday, 9am to 5pm (Wednesday: 10am to 5pm)</p>
+          <p style="margin:0;"><strong>Email:</strong> <a href="mailto:heretohelp@gloucester.gov.uk">heretohelp@gloucester.gov.uk</a></p>
+        </div>
+
+        <div class="sidebar-card">
+          <h2>On this page</h2>
+          <ul>
+            <li><a href="#fire-safety">Fire safety</a></li>
+            <li><a href="#space-standards">Space standards</a></li>
+            <li><a href="#washing-facilities">Washing facilities</a></li>
+            <li><a href="#management-duties">Management duties</a></li>
+            <li><a href="#health-safety">Health and safety inspection</a></li>
+          </ul>
+        </div>
+
+        <div class="sidebar-card">
+          <h2>Related</h2>
+          <ul>
+            <li><a href="licensing.html">HMO licensing</a></li>
+            <li><a href="apply.html">Apply for an HMO licence</a></li>
+            <li><a href="faq.html">Frequently asked questions</a></li>
+          </ul>
+        </div>
+      </aside>
+    </div>
+  </div>
+</main>
+
+<footer class="site-footer" role="contentinfo">
+  <div class="container">
+    <div class="footer-grid">
+      <div>
+        <h2>Services</h2>
+        <ul>
+          <li><a href="licensing.html">HMO licensing</a></li>
+          <li><a href="standards.html">HMO standards</a></li>
+          <li><a href="planning.html">Planning guidance</a></li>
+          <li><a href="faq.html">FAQ</a></li>
+        </ul>
+      </div>
+      <div>
+        <h2>About</h2>
+        <ul>
+          <li><a href="#">About the council</a></li>
+          <li><a href="#">News</a></li>
+          <li><a href="#">Jobs</a></li>
+          <li><a href="#">Contact us</a></li>
+        </ul>
+      </div>
+      <div>
+        <h2>Help</h2>
+        <ul>
+          <li><a href="#">Accessibility statement</a></li>
+          <li><a href="#">Cookies</a></li>
+          <li><a href="#">Privacy</a></li>
+          <li><a href="#">Terms</a></li>
+        </ul>
+      </div>
+      <div>
+        <h2>Get in touch</h2>
+        <p style="margin: 0 0 8px;"><strong>Our opening hours are:</strong></p>
+        <ul>
+          <li>Mon, Tue, Thu, Fri: 9am to 5pm</li>
+          <li>Wednesday: 10am to 5pm</li>
+        </ul>
+        <p style="margin: 8px 0 4px;"><a href="tel:01452396396">01452 396 396</a></p>
+        <p style="margin: 0;"><a href="mailto:heretohelp@gloucester.gov.uk">heretohelp@gloucester.gov.uk</a></p>
+      </div>
+    </div>
+    <div class="legal">
+      <span>© Gloucester City Council 2026</span>
+      <span>All content available under the Open Government Licence v3.0, except where otherwise stated.</span>
+    </div>
+  </div>
+</footer>
+
+<script src="../../templates/assets/site.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
This PR adds a complete Houses in Multiple Occupation (HMO) service section to the Gloucester City Council website, providing comprehensive information for residents, landlords, and managers about HMO licensing, standards, and compliance requirements.

## Key Changes
- **Service landing page** (`index.html`) - Main HMO service hub with navigation to key sections
- **Landlord hub** (`landlords.html`) - Dedicated information page for landlords and property managers
- **Resident information** (`residents.html`) - Tenant rights, HMO definitions, and guidance for residents
- **Licensing information** (`licensing.html`) - Details on licensing requirements, fees, duration, and conditions
- **Standards and safety** (`standards.html`) - Comprehensive fire safety, space standards, washing facilities, and management duty requirements
- **Planning guidance** (`planning.html`) - Planning permission requirements for small and large HMOs
- **FAQ page** (`faq.html`) - Common questions for both residents and landlords with answers
- **Application page** (`apply.html`) - Transaction page for applying for new or renewal HMO licences

## Implementation Details
- All pages follow the Gloucester City Council website template structure with consistent header, navigation, and footer patterns
- Pages include semantic HTML with proper ARIA labels for accessibility
- Schema source annotations (`data-schema-source`) embedded throughout to track policy mappings
- Comprehensive tables for space standards, washing facilities requirements, and fee schedules
- Breadcrumb navigation and tab-based section navigation for improved UX
- Inset panels for important notices and warnings
- Responsive design using existing CSS framework (`styles.css` and `a11y.css`)

https://claude.ai/code/session_013aBVA9jUyiBBXLwL1iKMeE