### PR TITLE
Move accessibility button into the top bar header

### DIFF
--- a/templates/assets/a11y.css
+++ b/templates/assets/a11y.css
@@ -1,38 +1,42 @@
 /* Accessibility widget styles */
 .a11y-widget { font-family: inherit; }
 
+/* Toggle button — lives inside .header-inner in the top bar.
+   Styled to sit on the blue header background. */
 .a11y-toggle {
-  position: fixed;
-  right: 16px;
-  bottom: 16px;
-  z-index: 900;
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  min-height: 48px;
-  padding: 12px 18px;
-  background: var(--primary-base);
+  min-height: 44px;
+  padding: 8px 14px;
+  background: rgba(255,255,255,0.12);
   color: #fff;
-  border: 3px solid var(--primary-base);
-  border-radius: 999px;
+  border: 2px solid rgba(255,255,255,0.4);
+  border-radius: var(--radius, 4px);
   font-family: inherit;
   font-weight: 600;
-  font-size: 1rem;
+  font-size: 0.9375rem;
   cursor: pointer;
-  box-shadow: 0 4px 14px rgba(0,0,0,0.18);
-  transition: background var(--transition);
+  flex-shrink: 0;
+  white-space: nowrap;
+  transition: background var(--transition), border-color var(--transition);
 }
-.a11y-toggle:hover { background: var(--primary-dark); border-color: var(--primary-dark); }
+.a11y-toggle:hover {
+  background: rgba(255,255,255,0.22);
+  border-color: rgba(255,255,255,0.65);
+}
 .a11y-toggle:focus-visible { outline: 3px solid var(--focus); outline-offset: 2px; }
-[data-contrast="high"] .a11y-toggle { background: #000; border-color: #000; }
+[data-contrast="high"] .a11y-toggle { background: transparent; border-color: #fff; color: #fff; }
+[data-contrast="high"] .a11y-toggle:hover { background: rgba(255,255,255,0.12); }
 
+/* Panel — drops down from the top bar; top value set by JS. */
 .a11y-panel {
   position: fixed;
   right: 16px;
-  bottom: 80px;
+  top: 100px; /* overridden by positionPanel() in site.js */
   z-index: 901;
   width: min(380px, calc(100vw - 32px));
-  max-height: calc(100vh - 120px);
+  max-height: calc(100vh - 120px); /* overridden by positionPanel() */
   overflow: auto;
   background: var(--bg);
   color: var(--text);
@@ -141,7 +145,7 @@
 
 @media (max-width: 480px) {
   .a11y-toggle span:not(.visually-hidden) { display: none; }
-  .a11y-toggle { padding: 12px; }
+  .a11y-toggle { padding: 8px 10px; }
 }
 
 /* ============================================================

--- a/templates/assets/site.js
+++ b/templates/assets/site.js
@@ -134,13 +134,15 @@
   function buildWidget() {
     if (document.getElementById('a11y-toggle')) return;
 
-    const wrap = document.createElement('div');
-    wrap.className = 'a11y-widget';
-    wrap.innerHTML = `
+    // The toggle button is injected into .header-inner so it sits in the top bar.
+    // The panel is appended to <body> separately so stacking context is never clipped.
+    const toggleWrap = document.createElement('div');
+    toggleWrap.className = 'a11y-widget';
+    toggleWrap.innerHTML = `
       <button type="button" id="a11y-toggle" class="a11y-toggle"
         aria-expanded="false" aria-controls="a11y-panel"
         aria-label="Accessibility tools">
-        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
           <circle cx="12" cy="4" r="2"/>
           <path d="M19 13c-2.5.6-4.5 1-7 1s-4.5-.4-7-1"/>
           <path d="M12 5v9"/>
@@ -148,6 +150,10 @@
         </svg>
         <span>Accessibility</span>
       </button>
+    `;
+
+    const panelWrap = document.createElement('div');
+    panelWrap.innerHTML = `
       <div id="a11y-panel" class="a11y-panel" role="dialog" aria-labelledby="a11y-title" hidden>
         <div class="a11y-panel-head">
           <h2 id="a11y-title">Accessibility tools</h2>
@@ -219,17 +225,35 @@
         </div>
       </div>
     `;
-    document.body.appendChild(wrap);
 
-    const toggle = wrap.querySelector('#a11y-toggle');
-    const panel  = wrap.querySelector('#a11y-panel');
-    const close  = wrap.querySelector('.a11y-close');
+    // Inject toggle into the header's inner flex row; fall back to body.
+    const headerInner = document.querySelector('.header-inner');
+    if (headerInner) {
+      headerInner.appendChild(toggleWrap);
+    } else {
+      document.body.appendChild(toggleWrap);
+    }
+    document.body.appendChild(panelWrap);
+
+    const toggle = document.getElementById('a11y-toggle');
+    const panel  = document.getElementById('a11y-panel');
+    const close  = panelWrap.querySelector('.a11y-close');
+
+    // Position the panel directly below the site header.
+    function positionPanel() {
+      const header = document.querySelector('.site-header');
+      if (!header) return;
+      const bottom = header.getBoundingClientRect().bottom;
+      panel.style.top = Math.round(bottom + 8) + 'px';
+      panel.style.maxHeight = Math.round(window.innerHeight - bottom - 24) + 'px';
+    }
 
     // Focus management — when the panel opens, move focus into it,
     // and when it closes, return focus to the toggle button.
     function openPanel() {
       panel.hidden = false;
       toggle.setAttribute('aria-expanded', 'true');
+      positionPanel();
       panel.querySelector('.a11y-close').focus();
     }
     function closePanel() {
@@ -239,6 +263,7 @@
     }
     toggle.addEventListener('click', () => panel.hidden ? openPanel() : closePanel());
     close.addEventListener('click', closePanel);
+    window.addEventListener('resize', () => { if (!panel.hidden) positionPanel(); });
 
     // Escape closes the panel from anywhere on the page.
     document.addEventListener('keydown', e => {
@@ -253,11 +278,11 @@
     });
 
     // Wire each option button.
-    wrap.querySelectorAll('[data-a11y-key]').forEach(btn => {
+    panelWrap.querySelectorAll('[data-a11y-key]').forEach(btn => {
       btn.addEventListener('click',
         () => setPref(btn.dataset.a11yKey, btn.dataset.a11yValue));
     });
-    wrap.querySelector('.a11y-reset').addEventListener('click', reset);
+    panelWrap.querySelector('.a11y-reset').addEventListener('click', reset);
 
     syncPanel();
   }


### PR DESCRIPTION
Previously the Accessibility button was a floating pill fixed to the bottom-right corner of the viewport. It now lives inside .header-inner alongside the logo and search, making it immediately visible and reachable from the top bar on every page.

CSS (a11y.css):
- .a11y-toggle: remove fixed positioning; restyle as an inline-flex button that sits on the blue header background (semi-transparent white border/background so it reads clearly on any header colour or theme).
- .a11y-panel: change from bottom: 80px to top-anchored; initial top value overridden by JS once the real header height is known.

JS (site.js):
- buildWidget() now creates the toggle and panel as separate elements.
- Toggle is injected into .header-inner (the header flex row); falls back to <body> if no header is found.
- Panel is appended to <body> so z-index stacking is never clipped.
- positionPanel() calculates the header's actual bottom edge and sets the panel top + max-height accordingly; called on open and resize.

https://claude.ai/code/session_01NyigmPCgCiAgyEojTy6xLK