### PR TITLE
Remove primary navigation block from all templates and HMO pages

### DIFF
--- a/HMO/web/apply.html
+++ b/HMO/web/apply.html
@@ -33,16 +33,6 @@
       </button>
     </form>
   </div>
-  <nav class="primary-nav" aria-label="Primary navigation">
-    <div class="container">
-      <a href="index.html">HMO home</a>
-      <a href="residents.html">Residents</a>
-      <a href="landlords.html">Landlords</a>
-      <a href="apply.html" aria-current="page">Apply for a licence</a>
-      <a href="standards.html">Standards &amp; safety</a>
-      <a href="faq.html">FAQ</a>
-    </div>
-  </nav>
 </header>
 
 <div class="container">

--- a/HMO/web/faq.html
+++ b/HMO/web/faq.html
@@ -33,16 +33,6 @@
       </button>
     </form>
   </div>
-  <nav class="primary-nav" aria-label="Primary navigation">
-    <div class="container">
-      <a href="index.html">HMO home</a>
-      <a href="residents.html">Residents</a>
-      <a href="landlords.html">Landlords</a>
-      <a href="apply.html">Apply for a licence</a>
-      <a href="standards.html">Standards &amp; safety</a>
-      <a href="faq.html" aria-current="page">FAQ</a>
-    </div>
-  </nav>
 </header>
 
 <div class="container">

--- a/HMO/web/index.html
+++ b/HMO/web/index.html
@@ -33,16 +33,6 @@
       </button>
     </form>
   </div>
-  <nav class="primary-nav" aria-label="Primary navigation">
-    <div class="container">
-      <a href="index.html" aria-current="page">HMO home</a>
-      <a href="residents.html">Residents</a>
-      <a href="landlords.html">Landlords</a>
-      <a href="apply.html">Apply for a licence</a>
-      <a href="standards.html">Standards &amp; safety</a>
-      <a href="faq.html">FAQ</a>
-    </div>
-  </nav>
 </header>
 
 <div class="container">

--- a/HMO/web/landlords.html
+++ b/HMO/web/landlords.html
@@ -33,16 +33,6 @@
       </button>
     </form>
   </div>
-  <nav class="primary-nav" aria-label="Primary navigation">
-    <div class="container">
-      <a href="index.html">HMO home</a>
-      <a href="residents.html">Residents</a>
-      <a href="landlords.html" aria-current="page">Landlords</a>
-      <a href="apply.html">Apply for a licence</a>
-      <a href="standards.html">Standards &amp; safety</a>
-      <a href="faq.html">FAQ</a>
-    </div>
-  </nav>
 </header>
 
 <div class="container">

--- a/HMO/web/licensing.html
+++ b/HMO/web/licensing.html
@@ -33,16 +33,6 @@
       </button>
     </form>
   </div>
-  <nav class="primary-nav" aria-label="Primary navigation">
-    <div class="container">
-      <a href="index.html">HMO home</a>
-      <a href="residents.html">Residents</a>
-      <a href="landlords.html">Landlords</a>
-      <a href="apply.html">Apply for a licence</a>
-      <a href="standards.html">Standards &amp; safety</a>
-      <a href="faq.html">FAQ</a>
-    </div>
-  </nav>
 </header>
 
 <div class="container">

--- a/HMO/web/planning.html
+++ b/HMO/web/planning.html
@@ -33,16 +33,6 @@
       </button>
     </form>
   </div>
-  <nav class="primary-nav" aria-label="Primary navigation">
-    <div class="container">
-      <a href="index.html">HMO home</a>
-      <a href="residents.html">Residents</a>
-      <a href="landlords.html">Landlords</a>
-      <a href="apply.html">Apply for a licence</a>
-      <a href="standards.html">Standards &amp; safety</a>
-      <a href="faq.html">FAQ</a>
-    </div>
-  </nav>
 </header>
 
 <div class="container">

--- a/HMO/web/residents.html
+++ b/HMO/web/residents.html
@@ -33,16 +33,6 @@
       </button>
     </form>
   </div>
-  <nav class="primary-nav" aria-label="Primary navigation">
-    <div class="container">
-      <a href="index.html">HMO home</a>
-      <a href="residents.html" aria-current="page">Residents</a>
-      <a href="landlords.html">Landlords</a>
-      <a href="apply.html">Apply for a licence</a>
-      <a href="standards.html">Standards &amp; safety</a>
-      <a href="faq.html">FAQ</a>
-    </div>
-  </nav>
 </header>
 
 <div class="container">

--- a/HMO/web/standards.html
+++ b/HMO/web/standards.html
@@ -33,16 +33,6 @@
       </button>
     </form>
   </div>
-  <nav class="primary-nav" aria-label="Primary navigation">
-    <div class="container">
-      <a href="index.html">HMO home</a>
-      <a href="residents.html">Residents</a>
-      <a href="landlords.html">Landlords</a>
-      <a href="apply.html">Apply for a licence</a>
-      <a href="standards.html" aria-current="page">Standards &amp; safety</a>
-      <a href="faq.html">FAQ</a>
-    </div>
-  </nav>
 </header>
 
 <div class="container">

--- a/templates/faq.html
+++ b/templates/faq.html
@@ -49,14 +49,6 @@
       </button>
     </form>
   </div>
-  <nav class="primary-nav" aria-label="Primary navigation">
-    <div class="container">
-      <a href="service-landing.html">[Service home]</a>
-      <a href="information.html">[Information]</a>
-      <a href="transaction.html">[Apply]</a>
-      <a href="faq.html" aria-current="page">FAQ</a>
-    </div>
-  </nav>
 </header>
 
 <!-- Breadcrumb — 3 levels for an FAQ page -->

--- a/templates/information.html
+++ b/templates/information.html
@@ -50,14 +50,6 @@
       </button>
     </form>
   </div>
-  <nav class="primary-nav" aria-label="Primary navigation">
-    <div class="container">
-      <a href="service-landing.html">[Service home]</a>
-      <a href="information.html" aria-current="page">[Information]</a>
-      <a href="transaction.html">[Apply]</a>
-      <a href="faq.html">FAQ</a>
-    </div>
-  </nav>
 </header>
 
 <!-- Breadcrumb — 3 levels for an information page -->

--- a/templates/service-landing.html
+++ b/templates/service-landing.html
@@ -56,19 +56,6 @@
       </button>
     </form>
   </div>
-  <!--
-    PRIMARY NAVIGATION — update links for your service area.
-    Mark the current page with aria-current="page".
-    Arrow Left/Right keys move between items (wired in site.js).
-  -->
-  <nav class="primary-nav" aria-label="Primary navigation">
-    <div class="container">
-      <a href="service-landing.html" aria-current="page">[Service home]</a>
-      <a href="information.html">[Information]</a>
-      <a href="transaction.html">[Apply]</a>
-      <a href="faq.html">FAQ</a>
-    </div>
-  </nav>
 </header>
 
 <!--

--- a/templates/transaction.html
+++ b/templates/transaction.html
@@ -49,14 +49,6 @@
       </button>
     </form>
   </div>
-  <nav class="primary-nav" aria-label="Primary navigation">
-    <div class="container">
-      <a href="service-landing.html">[Service home]</a>
-      <a href="information.html">[Information]</a>
-      <a href="transaction.html" aria-current="page">[Apply]</a>
-      <a href="faq.html">FAQ</a>
-    </div>
-  </nav>
 </header>
 
 <!-- Breadcrumb — 3 levels for a transaction page -->


### PR DESCRIPTION
The primary-nav bar added earlier was not the requested change — the accessibility widget belongs in the top bar, not a full site nav. Strips the <nav class="primary-nav"> block from all 12 HTML files.

https://claude.ai/code/session_01NyigmPCgCiAgyEojTy6xLK