### PR TITLE
Polish homepage: SVG icons, register button, hero text wrap fix

### DIFF
--- a/HMO/web/index.html
+++ b/HMO/web/index.html
@@ -46,10 +46,18 @@
       outline-offset: 2px;
     }
     .journey-card .jc-icon {
-      font-size: 2.25rem;
-      line-height: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 52px;
+      height: 52px;
+      background: var(--primary-light, #EBF3FB);
+      border-radius: 50%;
       margin-bottom: var(--s-3);
+      color: var(--primary-base, #0054a4);
+      flex-shrink: 0;
     }
+    [data-theme="dark"] .journey-card .jc-icon { background: rgba(255,255,255,0.08); }
     .journey-card h2 {
       font-size: var(--fs-h3, 1.25rem);
       color: var(--primary-base, #0054a4);
@@ -150,7 +158,7 @@
   <section class="hero" data-schema-source="localPolicy.hmoDefinitions.generalDefinition">
     <div class="container">
       <h1>Houses in Multiple Occupation (HMO)</h1>
-      <p class="lede">Find information about HMO licensing, standards and tenant rights <span style="white-space:nowrap">in Gloucester.</span></p>
+      <p class="lede">Find information about HMO licensing, standards and tenant rights in Gloucester.</p>
     </div>
   </section>
 
@@ -160,21 +168,27 @@
     <div class="journey-grid">
 
       <a href="residents.html" class="journey-card">
-        <div class="jc-icon" aria-hidden="true">👥</div>
+        <div class="jc-icon" aria-hidden="true">
+          <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+        </div>
         <h2>I'm a Resident or Tenant</h2>
         <p>Learn your rights, understand standards, and report problems.</p>
         <span class="jc-btn">Learn more</span>
       </a>
 
       <a href="landlords.html" class="journey-card">
-        <div class="jc-icon" aria-hidden="true">👨‍💼</div>
+        <div class="jc-icon" aria-hidden="true">
+          <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+        </div>
         <h2>I'm a Landlord or Manager</h2>
         <p>Understand licensing, standards, and stay compliant.</p>
         <span class="jc-btn">Learn more</span>
       </a>
 
       <a href="apply.html" class="journey-card">
-        <div class="jc-icon" aria-hidden="true">📝</div>
+        <div class="jc-icon" aria-hidden="true">
+          <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="6" width="18" height="13" rx="2"/><path d="M7 10h10M7 14h6"/></svg>
+        </div>
         <h2>I Want to Apply or Renew</h2>
         <p>Submit a new licence application or renew an existing one.</p>
         <span class="jc-btn">Get started</span>
@@ -183,12 +197,13 @@
     </div>
 
     <!-- Check register -->
-    <div class="inset-panel warning" style="margin-top:var(--s-6);">
-      <p style="margin-bottom:var(--s-2);">Need to check if a property is licensed?</p>
+    <div class="inset-panel warning" style="margin-top:var(--s-6); display:flex; flex-wrap:wrap; align-items:center; gap:var(--s-3);">
+      <p style="margin:0; flex:1; min-width:200px;">Need to check if a property is licensed?</p>
       <a href="https://www.gloucester.gov.uk/media/yg5l1ndz/hmo-licence-register-december-2025.xlsx"
          rel="external"
-         style="font-weight:600;">
-        📋 View HMO Licence Register (Excel)
+         style="display:inline-flex; align-items:center; gap:8px; background:#fff; color:var(--primary-base,#0054a4); border:2px solid var(--primary-base,#0054a4); font-weight:600; font-size:1rem; padding:10px 20px; border-radius:4px; text-decoration:none; white-space:nowrap; min-height:48px; transition:background 0.15s,color 0.15s;">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>
+        View HMO Licence Register (Excel)
       </a>
     </div>
 


### PR DESCRIPTION
- Replace emoji icons with clean SVG icons in circular coloured containers
- Style check register link as an outlined button with document icon
- Remove white-space:nowrap from hero lede (let browser wrap naturally)

https://claude.ai/code/session_01Xw9yTSyMQpiKaXXa3usDhd