### PR TITLE
Increase hero lede max-width from 55ch to 75ch

### DIFF
--- a/templates/assets/styles.css
+++ b/templates/assets/styles.css
@@ -542,7 +542,7 @@ main[tabindex="-1"]:focus-visible { outline: none; }
 [data-theme="dark"] .landing-stats .stat span { color: #d6e4f4 !important; }
 
 .hero h1 { color: #fff; font-size: clamp(2rem, 4vw, var(--fs-display)); margin-bottom: var(--s-3); }
-.hero p.lede { color: #e8f0fb; font-size: clamp(1.0625rem, 1.6vw, 1.375rem); max-width: 55ch; }
+.hero p.lede { color: #e8f0fb; font-size: clamp(1.0625rem, 1.6vw, 1.375rem); max-width: 75ch; }
 [data-contrast="high"] .hero p.lede { color: #fff; }
 
 .hero-decoration {


### PR DESCRIPTION
## Summary
Adjusted the maximum width constraint for the hero section's lede paragraph to improve text layout and readability on wider viewports.

## Changes
- Increased `.hero p.lede` max-width from `55ch` to `75ch`

## Details
This change allows the hero lede text to span a wider area on larger screens, providing better use of available space while maintaining the responsive design approach using the `clamp()` function. The adjustment affects both light and dark theme variants of the hero section.

https://claude.ai/code/session_01JqCXkVdjaphBWutK1LEnR1