### PR TITLE
Redesign licence register section as journey-card

### DIFF
--- a/HMO/web/index.html
+++ b/HMO/web/index.html
@@ -197,15 +197,17 @@
     </div>
 
     <!-- Check register -->
-    <div class="inset-panel warning" style="margin-top:var(--s-6); display:flex; flex-wrap:wrap; align-items:center; gap:var(--s-3);">
-      <p style="margin:0; flex:1; min-width:200px;">Need to check if a property is licensed?</p>
-      <a href="https://www.gloucester.gov.uk/media/yg5l1ndz/hmo-licence-register-december-2025.xlsx"
-         rel="external"
-         style="display:inline-flex; align-items:center; gap:8px; background:#fff; color:var(--primary-base,#0054a4); border:2px solid var(--primary-base,#0054a4); font-weight:600; font-size:1rem; padding:10px 20px; border-radius:4px; text-decoration:none; white-space:nowrap; min-height:48px; transition:background 0.15s,color 0.15s;">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>
-        View HMO Licence Register (Excel)
-      </a>
-    </div>
+    <a href="https://www.gloucester.gov.uk/media/yg5l1ndz/hmo-licence-register-december-2025.xlsx"
+       rel="external"
+       class="journey-card"
+       style="margin-top:var(--s-6); display:flex; flex-direction:column;">
+      <div class="jc-icon" aria-hidden="true">
+        <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="12" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
+      </div>
+      <h2>Check if a Property is Licensed</h2>
+      <p>Search the HMO licence register to verify if a property requires licensing.</p>
+      <span class="jc-btn">View HMO Licence Register (Excel)</span>
+    </a>
 
     <!-- Contact -->
     <section class="contact-section" aria-labelledby="contact-heading">


### PR DESCRIPTION
## Summary
Redesign the "Check if a property is licensed?" section to match the journey-card styling used for the three main service cards above it.

## Changes
- Replaced yellow warning panel with styled journey-card
- Added document/register icon matching other page icons  
- Updated heading and description text for clarity
- Made mobile-responsive (inherits responsive behavior from journey-card styles)
- Uses consistent blue color scheme instead of yellow

## Details
The section now has visual consistency with the rest of the page and provides a cleaner, more modern appearance while maintaining accessibility and responsiveness.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JqCXkVdjaphBWutK1LEnR1)_