### PR TITLE
Refine licence register section layout for better spacing

### DIFF
--- a/HMO/web/index.html
+++ b/HMO/web/index.html
@@ -197,17 +197,21 @@
     </div>
 
     <!-- Check register -->
-    <a href="https://www.gloucester.gov.uk/media/yg5l1ndz/hmo-licence-register-december-2025.xlsx"
-       rel="external"
-       class="journey-card"
-       style="margin-top:var(--s-6); display:flex; flex-direction:column;">
-      <div class="jc-icon" aria-hidden="true">
-        <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="12" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
+    <div style="margin-top:var(--s-6); background: var(--bg-card, #fff); border: 1px solid var(--border, #d1dce9); border-top: 4px solid var(--primary-base, #0054a4); border-radius: 4px; padding: var(--s-4); display: flex; align-items: center; gap: var(--s-4);">
+      <div style="display: flex; align-items: center; justify-content: center; width: 48px; height: 48px; background: var(--primary-light, #EBF3FB); border-radius: 50%; flex-shrink: 0; color: var(--primary-base, #0054a4);" aria-hidden="true">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="12" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
       </div>
-      <h2>Check if a Property is Licensed</h2>
-      <p>Search the HMO licence register to verify if a property requires licensing.</p>
-      <span class="jc-btn">View HMO Licence Register (Excel)</span>
-    </a>
+      <div style="flex: 1;">
+        <h3 style="margin: 0 0 var(--s-1) 0; font-size: var(--fs-h3, 1.25rem); color: var(--primary-base, #0054a4);">Check if a Property is Licensed</h3>
+        <p style="margin: 0; font-size: 1rem; color: var(--text, #1a2332);">Search the HMO licence register to verify if a property requires licensing.</p>
+      </div>
+      <a href="https://www.gloucester.gov.uk/media/yg5l1ndz/hmo-licence-register-december-2025.xlsx"
+         rel="external"
+         style="display: inline-flex; align-items: center; gap: 8px; background: var(--primary-base, #0054a4); color: #fff; font-weight: 600; font-size: 1rem; padding: 12px var(--s-4); border-radius: 4px; text-decoration: none; white-space: nowrap; min-height: 48px; line-height: 1.5; transition: background 0.15s ease; flex-shrink: 0;">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
+        View Register
+      </a>
+    </div>
 
     <!-- Contact -->
     <section class="contact-section" aria-labelledby="contact-heading">


### PR DESCRIPTION
## Summary
Improved the layout of the "Check if a Property is Licensed" section with a horizontal design for better spacing and visual balance.

## Changes
- Icon now aligned horizontally with title
- Title and description positioned inline with icon
- Button moved to the right side of the card
- Reduced padding and icon size for more compact appearance
- Maintains card styling and accessibility

## Details
Creates a cleaner, more efficient use of space while keeping the content organized and readable.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JqCXkVdjaphBWutK1LEnR1)_