### PR TITLE
Make entire licence register card clickable like journey cards

### DIFF
--- a/HMO/web/index.html
+++ b/HMO/web/index.html
@@ -197,21 +197,19 @@
     </div>
 
     <!-- Check register -->
-    <div style="margin-top:var(--s-6); background: var(--bg-card, #fff); border: 1px solid var(--border, #d1dce9); border-top: 4px solid var(--primary-base, #0054a4); border-radius: 4px; padding: var(--s-4); display: flex; align-items: center; gap: var(--s-4);">
-      <div style="display: flex; align-items: center; justify-content: center; width: 48px; height: 48px; background: var(--primary-light, #EBF3FB); border-radius: 50%; flex-shrink: 0; color: var(--primary-base, #0054a4);" aria-hidden="true">
+    <a href="https://www.gloucester.gov.uk/media/yg5l1ndz/hmo-licence-register-december-2025.xlsx"
+       rel="external"
+       class="journey-card"
+       style="margin-top:var(--s-6); display: flex; align-items: center; gap: var(--s-4); flex-direction: row;">
+      <div class="jc-icon" aria-hidden="true" style="margin-bottom: 0;">
         <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="12" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
       </div>
       <div style="flex: 1;">
-        <h3 style="margin: 0 0 var(--s-1) 0; font-size: var(--fs-h3, 1.25rem); color: var(--primary-base, #0054a4);">Check if a Property is Licensed</h3>
-        <p style="margin: 0; font-size: 1rem; color: var(--text, #1a2332);">Search the HMO licence register to verify if a property requires licensing.</p>
+        <h2 style="margin: 0 0 var(--s-1) 0;">Check if a Property is Licensed</h2>
+        <p style="margin: 0; font-size: 1rem;">Search the HMO licence register to verify if a property requires licensing.</p>
       </div>
-      <a href="https://www.gloucester.gov.uk/media/yg5l1ndz/hmo-licence-register-december-2025.xlsx"
-         rel="external"
-         style="display: inline-flex; align-items: center; gap: 8px; background: var(--primary-base, #0054a4); color: #fff; font-weight: 600; font-size: 1rem; padding: 12px var(--s-4); border-radius: 4px; text-decoration: none; white-space: nowrap; min-height: 48px; line-height: 1.5; transition: background 0.15s ease; flex-shrink: 0;">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
-        View Register
-      </a>
-    </div>
+      <span class="jc-btn" style="flex-shrink: 0;">View Register</span>
+    </a>
 
     <!-- Contact -->
     <section class="contact-section" aria-labelledby="contact-heading">

--- a/HMO/web/index.html
+++ b/HMO/web/index.html
@@ -121,6 +121,30 @@
       margin-bottom: 4px;
     }
     .contact-details a { font-size: 1.0625rem; font-weight: 600; }
+
+    /* Mobile optimizations for licence register card */
+    @media (max-width: 767px) {
+      .licence-register-card {
+        margin-left: calc(var(--s-4) * -1);
+        margin-right: calc(var(--s-4) * -1);
+        padding-left: var(--s-4) !important;
+        padding-right: var(--s-4) !important;
+        border-radius: 0;
+        gap: var(--s-3) !important;
+      }
+      .licence-register-card h2 {
+        font-size: 1.125rem;
+        margin-bottom: var(--s-1) !important;
+      }
+      .licence-register-card .jc-icon {
+        width: 40px;
+        height: 40px;
+      }
+      .licence-register-card .jc-btn {
+        font-size: 0.875rem;
+        padding: 10px var(--s-3) !important;
+      }
+    }
   </style>
 </head>
 <body>
@@ -199,7 +223,7 @@
     <!-- Check register -->
     <a href="https://www.gloucester.gov.uk/media/yg5l1ndz/hmo-licence-register-december-2025.xlsx"
        rel="external"
-       class="journey-card"
+       class="journey-card licence-register-card"
        style="margin-top:var(--s-6); display: flex; align-items: center; gap: var(--s-4); flex-direction: row;">
       <div class="jc-icon" aria-hidden="true" style="margin-bottom: 0;">
         <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="12" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>


### PR DESCRIPTION
## Summary
Fixed the entire "Check if a Property is Licensed" card to be clickable, matching the behavior of the 3 journey cards above it.

## Changes
- Wrapped entire card in `<a>` tag with `journey-card` class
- Maintained horizontal layout with icon, content, and button
- Whole card is now clickable like the journey cards

## Details
Now users can click anywhere on the card to access the HMO licence register, not just the button.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JqCXkVdjaphBWutK1LEnR1)_