### PR TITLE
Add Newstershire Council veneer proof-of-concept website

### DIFF
--- a/LGR/Veneer/index.html
+++ b/LGR/Veneer/index.html
@@ -1,0 +1,197 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Newstershire Council</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <header class="site-header">
+    <div class="container">
+      <div class="logo-lockup">
+        <svg class="logo-icon" aria-hidden="true" focusable="false" width="48" height="48" viewBox="0 0 48 48">
+          <circle cx="24" cy="24" r="24" fill="#1d4477"/>
+          <path d="M12 30 L24 14 L36 30 Z" fill="#ffffff" opacity="0.9"/>
+          <rect x="20" y="30" width="8" height="6" fill="#ffffff" opacity="0.7"/>
+        </svg>
+        <div>
+          <span class="org-name">Newstershire Council</span>
+          <span class="org-tagline">Your new unitary council</span>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main id="main-content">
+    <div class="container">
+
+      <!-- New council notice -->
+      <div class="notice-banner" role="note" aria-label="Important: This is a new council">
+        <svg aria-hidden="true" focusable="false" width="20" height="20" viewBox="0 0 20 20" fill="none">
+          <circle cx="10" cy="10" r="9" stroke="#1d4477" stroke-width="2"/>
+          <path d="M10 6v4M10 14v.5" stroke="#1d4477" stroke-width="2" stroke-linecap="round"/>
+        </svg>
+        <p>
+          <strong>Newstershire Council is a new unitary authority</strong> created from the reorganisation of local government in Gloucestershire.
+          It brings together services previously delivered by the county council and the district and borough councils into one organisation.
+        </p>
+      </div>
+
+      <h1 class="page-title">Find your local council service</h1>
+      <p class="page-intro">Answer the questions below and we'll direct you to the right place.</p>
+
+      <!-- === STEP 1: area === -->
+      <section id="step-area" class="step" aria-labelledby="step-area-heading">
+        <h2 id="step-area-heading" class="step-heading">
+          <span class="step-number" aria-hidden="true">1</span>
+          Which area do you live in?
+        </h2>
+        <fieldset>
+          <legend class="sr-only">Select your district or borough</legend>
+          <div class="radio-group">
+            <label class="radio-card">
+              <input type="radio" name="area" value="cheltenham">
+              <span class="radio-label">Cheltenham</span>
+            </label>
+            <label class="radio-card">
+              <input type="radio" name="area" value="cotswold">
+              <span class="radio-label">Cotswold</span>
+            </label>
+            <label class="radio-card">
+              <input type="radio" name="area" value="forest-of-dean">
+              <span class="radio-label">Forest of Dean</span>
+            </label>
+            <label class="radio-card">
+              <input type="radio" name="area" value="gloucester">
+              <span class="radio-label">Gloucester</span>
+            </label>
+            <label class="radio-card">
+              <input type="radio" name="area" value="stroud">
+              <span class="radio-label">Stroud</span>
+            </label>
+            <label class="radio-card">
+              <input type="radio" name="area" value="tewkesbury">
+              <span class="radio-label">Tewkesbury</span>
+            </label>
+          </div>
+        </fieldset>
+      </section>
+
+      <!-- === STEP 2: service tier === -->
+      <section id="step-tier" class="step step--hidden" aria-labelledby="step-tier-heading" aria-hidden="true">
+        <h2 id="step-tier-heading" class="step-heading">
+          <span class="step-number" aria-hidden="true">2</span>
+          Is it a county-level or district-level service?
+        </h2>
+
+        <div class="help-text">
+          <details>
+            <summary>Not sure which one?</summary>
+            <div class="details-body">
+              <p><strong>County-level services</strong> (previously Gloucestershire County Council) include:</p>
+              <ul>
+                <li>Schools, education and libraries</li>
+                <li>Adult social care</li>
+                <li>Children's services</li>
+                <li>Roads, highways and transport</li>
+                <li>Waste disposal (tips/recycling centres)</li>
+                <li>Fire &amp; rescue</li>
+              </ul>
+              <p><strong>District-level services</strong> (previously your district or borough council) include:</p>
+              <ul>
+                <li>Bins and waste collection</li>
+                <li>Council tax and housing benefit</li>
+                <li>Planning and building control</li>
+                <li>Housing</li>
+                <li>Leisure and parks</li>
+                <li>Environmental health</li>
+              </ul>
+            </div>
+          </details>
+        </div>
+
+        <fieldset>
+          <legend class="sr-only">Select service type</legend>
+          <div class="radio-group">
+            <label class="radio-card">
+              <input type="radio" name="tier" value="county">
+              <span class="radio-label">County service</span>
+            </label>
+            <label class="radio-card">
+              <input type="radio" name="tier" value="district">
+              <span class="radio-label">District / borough service</span>
+            </label>
+          </div>
+        </fieldset>
+      </section>
+
+      <!-- === STEP 3: result === -->
+      <section id="step-result" class="step step--hidden" aria-labelledby="step-result-heading" aria-live="polite" aria-atomic="true" aria-hidden="true">
+        <h2 id="step-result-heading" class="step-heading">
+          <span class="step-number" aria-hidden="true">3</span>
+          Go to the right service
+        </h2>
+        <div id="result-content" class="result-links">
+          <!-- filled by JS -->
+        </div>
+      </section>
+
+      <!-- === NO-JS FALLBACK === -->
+      <noscript>
+        <section class="nojs-fallback" aria-label="Find your service without JavaScript">
+          <h2>Find your service</h2>
+          <p>JavaScript is not available in your browser. Use the direct links below to find the right service for your area.</p>
+
+          <h3>Cheltenham</h3>
+          <ul>
+            <li><a href="https://www.gloucestershire.gov.uk/">County services (Gloucestershire County Council)</a></li>
+            <li><a href="https://www.cheltenham.gov.uk/">District services (Cheltenham Borough Council)</a></li>
+          </ul>
+
+          <h3>Cotswold</h3>
+          <ul>
+            <li><a href="https://www.gloucestershire.gov.uk/">County services (Gloucestershire County Council)</a></li>
+            <li><a href="https://www.cotswold.gov.uk/">District services (Cotswold District Council)</a></li>
+          </ul>
+
+          <h3>Forest of Dean</h3>
+          <ul>
+            <li><a href="https://www.gloucestershire.gov.uk/">County services (Gloucestershire County Council)</a></li>
+            <li><a href="https://www.fdean.gov.uk/">District services (Forest of Dean District Council)</a></li>
+          </ul>
+
+          <h3>Gloucester</h3>
+          <ul>
+            <li><a href="https://www.gloucestershire.gov.uk/">County services (Gloucestershire County Council)</a></li>
+            <li><a href="https://www.gloucester.gov.uk/">District services (Gloucester City Council)</a></li>
+          </ul>
+
+          <h3>Stroud</h3>
+          <ul>
+            <li><a href="https://www.gloucestershire.gov.uk/">County services (Gloucestershire County Council)</a></li>
+            <li><a href="https://www.stroud.gov.uk/">District services (Stroud District Council)</a></li>
+          </ul>
+
+          <h3>Tewkesbury</h3>
+          <ul>
+            <li><a href="https://www.gloucestershire.gov.uk/">County services (Gloucestershire County Council)</a></li>
+            <li><a href="https://www.tewkesbury.gov.uk/">District services (Tewkesbury Borough Council)</a></li>
+          </ul>
+        </section>
+      </noscript>
+
+    </div>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+      <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning.</p>
+    </div>
+  </footer>
+
+  <script src="veneer.js"></script>
+</body>
+</html>

--- a/LGR/Veneer/style.css
+++ b/LGR/Veneer/style.css
@@ -1,0 +1,371 @@
+/* =============================================
+   Newstershire Council – Veneer proof of concept
+   LGR brand palette / GOV.UK-influenced layout
+   ============================================= */
+
+:root {
+  --blue-dark:   #1d4477;
+  --blue-mid:    #2b5eac;
+  --blue-light:  #d6e4f7;
+  --gold:        #c8a951;
+  --text:        #0b0c0c;
+  --text-muted:  #505a5f;
+  --bg:          #f3f2f1;
+  --white:       #ffffff;
+  --border:      #b1b4b6;
+  --focus:       #ffdd00;
+  --green:       #00703c;
+  --radius:      4px;
+  --max-w:       960px;
+  --transition:  0.15s ease;
+}
+
+/* ---- Reset / base ---- */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html { font-size: 100%; scroll-behavior: smooth; }
+
+body {
+  font-family: "GDS Transport", Arial, sans-serif;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: var(--text);
+  background: var(--bg);
+}
+
+/* ---- Focus ---- */
+:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 2px;
+}
+
+/* ---- Skip link ---- */
+.sr-only {
+  position: absolute;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden;
+  clip: rect(0,0,0,0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ---- Container ---- */
+.container {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  padding: 0 1.25rem;
+}
+
+/* =====================
+   Header
+   ===================== */
+.site-header {
+  background: var(--blue-dark);
+  border-bottom: 4px solid var(--gold);
+  padding: 1rem 0;
+}
+
+.logo-lockup {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.logo-icon { flex-shrink: 0; }
+
+.org-name {
+  display: block;
+  color: var(--white);
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.org-tagline {
+  display: block;
+  color: var(--blue-light);
+  font-size: 0.8125rem;
+  letter-spacing: 0.02em;
+}
+
+/* =====================
+   Main content
+   ===================== */
+main { padding: 2rem 0 3rem; }
+
+/* =====================
+   Notice banner
+   ===================== */
+.notice-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  background: var(--blue-light);
+  border-left: 5px solid var(--blue-dark);
+  border-radius: var(--radius);
+  padding: 1rem 1.25rem;
+  margin-bottom: 2rem;
+}
+
+.notice-banner svg { flex-shrink: 0; margin-top: 0.15rem; }
+
+.notice-banner p { font-size: 0.9375rem; }
+
+/* =====================
+   Page heading
+   ===================== */
+.page-title {
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  font-weight: 700;
+  color: var(--blue-dark);
+  margin-bottom: 0.35rem;
+}
+
+.page-intro {
+  color: var(--text-muted);
+  margin-bottom: 2rem;
+}
+
+/* =====================
+   Steps
+   ===================== */
+.step {
+  background: var(--white);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.step--hidden {
+  display: none;
+}
+
+.step-heading {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: var(--blue-dark);
+  margin-bottom: 1.25rem;
+}
+
+.step-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem; height: 1.75rem;
+  background: var(--blue-dark);
+  color: var(--white);
+  border-radius: 50%;
+  font-size: 0.875rem;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+/* ---- Radio cards ---- */
+fieldset { border: none; }
+
+.radio-group {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.radio-card {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  cursor: pointer;
+  border: 2px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0.75rem 1rem;
+  background: var(--white);
+  transition: border-color var(--transition), background var(--transition);
+  user-select: none;
+}
+
+.radio-card:hover {
+  border-color: var(--blue-mid);
+  background: var(--blue-light);
+}
+
+.radio-card input[type="radio"] {
+  width: 1.25rem; height: 1.25rem;
+  accent-color: var(--blue-dark);
+  flex-shrink: 0;
+  cursor: pointer;
+}
+
+.radio-card:has(input:checked) {
+  border-color: var(--blue-dark);
+  background: var(--blue-light);
+  box-shadow: 0 0 0 2px var(--blue-dark);
+}
+
+.radio-label { font-size: 0.9375rem; font-weight: 500; }
+
+/* ---- Help details ---- */
+.help-text { margin-bottom: 1.25rem; }
+
+details summary {
+  cursor: pointer;
+  color: var(--blue-mid);
+  font-size: 0.9375rem;
+  font-weight: 600;
+  list-style: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+details summary::before {
+  content: "▶";
+  font-size: 0.65rem;
+  transition: transform var(--transition);
+}
+
+details[open] summary::before { transform: rotate(90deg); }
+
+.details-body {
+  margin-top: 0.75rem;
+  padding: 1rem;
+  background: var(--bg);
+  border-radius: var(--radius);
+  font-size: 0.875rem;
+}
+
+.details-body p { margin-bottom: 0.5rem; }
+.details-body ul { padding-left: 1.25rem; margin-bottom: 0.75rem; }
+.details-body li { margin-bottom: 0.25rem; }
+
+/* ---- Result links ---- */
+.result-links {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+}
+
+.result-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  border: 2px solid var(--blue-dark);
+  border-radius: var(--radius);
+  padding: 1.25rem;
+  background: var(--white);
+  text-decoration: none;
+  color: var(--text);
+  transition: background var(--transition), transform var(--transition);
+}
+
+.result-card:hover {
+  background: var(--blue-light);
+  transform: translateY(-2px);
+}
+
+.result-card:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 2px;
+}
+
+.result-card-badge {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--blue-dark);
+}
+
+.result-card-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--blue-dark);
+}
+
+.result-card-desc {
+  font-size: 0.875rem;
+  color: var(--text-muted);
+  flex: 1;
+}
+
+.result-card-arrow {
+  font-size: 1.125rem;
+  color: var(--blue-mid);
+  align-self: flex-end;
+}
+
+/* ---- Reset button ---- */
+.reset-btn {
+  margin-top: 1.25rem;
+  background: none;
+  border: 2px solid var(--blue-dark);
+  border-radius: var(--radius);
+  padding: 0.5rem 1rem;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--blue-dark);
+  cursor: pointer;
+  transition: background var(--transition);
+}
+
+.reset-btn:hover { background: var(--blue-light); }
+
+/* =====================
+   No-JS fallback
+   ===================== */
+.nojs-fallback {
+  background: var(--white);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  margin-top: 1.5rem;
+}
+
+.nojs-fallback h2 {
+  font-size: 1.25rem;
+  color: var(--blue-dark);
+  margin-bottom: 0.75rem;
+}
+
+.nojs-fallback h3 {
+  font-size: 1rem;
+  margin-top: 1.25rem;
+  margin-bottom: 0.4rem;
+  color: var(--blue-dark);
+}
+
+.nojs-fallback ul { padding-left: 1.25rem; }
+
+.nojs-fallback li { margin-bottom: 0.25rem; }
+
+.nojs-fallback a {
+  color: var(--blue-mid);
+  font-weight: 500;
+}
+
+/* =====================
+   Footer
+   ===================== */
+.site-footer {
+  background: var(--blue-dark);
+  color: var(--blue-light);
+  padding: 1.5rem 0;
+  font-size: 0.875rem;
+  border-top: 4px solid var(--gold);
+}
+
+.site-footer p + p { margin-top: 0.25rem; }
+
+.footer-note { color: #8ba8d4; font-style: italic; }
+
+/* =====================
+   Responsive tweaks
+   ===================== */
+@media (max-width: 480px) {
+  .radio-group { grid-template-columns: 1fr 1fr; }
+  .result-links { grid-template-columns: 1fr; }
+}

--- a/LGR/Veneer/veneer.js
+++ b/LGR/Veneer/veneer.js
@@ -1,0 +1,145 @@
+/* Veneer – progressive enhancement router */
+(function () {
+  'use strict';
+
+  // Service URLs for each area × tier combination
+  var SERVICES = {
+    cheltenham: {
+      county:   { name: 'Gloucestershire County Council', url: 'https://www.gloucestershire.gov.uk/', desc: 'Education, roads, adult social care, libraries and more.' },
+      district: { name: 'Cheltenham Borough Council',     url: 'https://www.cheltenham.gov.uk/',     desc: 'Bins, council tax, planning, housing and leisure.' }
+    },
+    cotswold: {
+      county:   { name: 'Gloucestershire County Council', url: 'https://www.gloucestershire.gov.uk/', desc: 'Education, roads, adult social care, libraries and more.' },
+      district: { name: 'Cotswold District Council',      url: 'https://www.cotswold.gov.uk/',       desc: 'Bins, council tax, planning, housing and leisure.' }
+    },
+    'forest-of-dean': {
+      county:   { name: 'Gloucestershire County Council', url: 'https://www.gloucestershire.gov.uk/', desc: 'Education, roads, adult social care, libraries and more.' },
+      district: { name: 'Forest of Dean District Council',url: 'https://www.fdean.gov.uk/',          desc: 'Bins, council tax, planning, housing and leisure.' }
+    },
+    gloucester: {
+      county:   { name: 'Gloucestershire County Council', url: 'https://www.gloucestershire.gov.uk/', desc: 'Education, roads, adult social care, libraries and more.' },
+      district: { name: 'Gloucester City Council',        url: 'https://www.gloucester.gov.uk/',     desc: 'Bins, council tax, planning, housing and leisure.' }
+    },
+    stroud: {
+      county:   { name: 'Gloucestershire County Council', url: 'https://www.gloucestershire.gov.uk/', desc: 'Education, roads, adult social care, libraries and more.' },
+      district: { name: 'Stroud District Council',        url: 'https://www.stroud.gov.uk/',         desc: 'Bins, council tax, planning, housing and leisure.' }
+    },
+    tewkesbury: {
+      county:   { name: 'Gloucestershire County Council', url: 'https://www.gloucestershire.gov.uk/', desc: 'Education, roads, adult social care, libraries and more.' },
+      district: { name: 'Tewkesbury Borough Council',    url: 'https://www.tewkesbury.gov.uk/',     desc: 'Bins, council tax, planning, housing and leisure.' }
+    }
+  };
+
+  var areaRadios = document.querySelectorAll('input[name="area"]');
+  var tierRadios = document.querySelectorAll('input[name="tier"]');
+  var stepTier   = document.getElementById('step-tier');
+  var stepResult = document.getElementById('step-result');
+  var resultContent = document.getElementById('result-content');
+
+  function showStep(el) {
+    el.classList.remove('step--hidden');
+    el.removeAttribute('aria-hidden');
+  }
+
+  function hideStep(el) {
+    el.classList.add('step--hidden');
+    el.setAttribute('aria-hidden', 'true');
+  }
+
+  function getCheckedValue(radios) {
+    for (var i = 0; i < radios.length; i++) {
+      if (radios[i].checked) return radios[i].value;
+    }
+    return null;
+  }
+
+  function buildResultCard(service, tierLabel) {
+    var a = document.createElement('a');
+    a.href = service.url;
+    a.className = 'result-card';
+    a.setAttribute('target', '_blank');
+    a.setAttribute('rel', 'noopener noreferrer');
+
+    var badge = document.createElement('span');
+    badge.className = 'result-card-badge';
+    badge.textContent = tierLabel;
+
+    var title = document.createElement('span');
+    title.className = 'result-card-title';
+    title.textContent = service.name;
+
+    var desc = document.createElement('span');
+    desc.className = 'result-card-desc';
+    desc.textContent = service.desc;
+
+    var arrow = document.createElement('span');
+    arrow.className = 'result-card-arrow';
+    arrow.setAttribute('aria-hidden', 'true');
+    arrow.textContent = '→';
+
+    a.appendChild(badge);
+    a.appendChild(title);
+    a.appendChild(desc);
+    a.appendChild(arrow);
+    return a;
+  }
+
+  function showResult() {
+    var area = getCheckedValue(areaRadios);
+    var tier = getCheckedValue(tierRadios);
+    if (!area || !tier) return;
+
+    var areaData = SERVICES[area];
+    if (!areaData) return;
+
+    // Clear previous result
+    while (resultContent.firstChild) {
+      resultContent.removeChild(resultContent.firstChild);
+    }
+
+    if (tier === 'county') {
+      resultContent.appendChild(buildResultCard(areaData.county, 'County service'));
+    } else if (tier === 'district') {
+      resultContent.appendChild(buildResultCard(areaData.district, 'District / borough service'));
+    }
+
+    // Reset button
+    var btn = document.createElement('button');
+    btn.className = 'reset-btn';
+    btn.textContent = '← Start again';
+    btn.addEventListener('click', function () { resetAll(); });
+    resultContent.appendChild(btn);
+
+    showStep(stepResult);
+    stepResult.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
+  function resetAll() {
+    areaRadios.forEach(function (r) { r.checked = false; });
+    tierRadios.forEach(function (r) { r.checked = false; });
+    hideStep(stepTier);
+    hideStep(stepResult);
+    while (resultContent.firstChild) resultContent.removeChild(resultContent.firstChild);
+    document.getElementById('step-area').scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
+  // Step 1 → Step 2
+  areaRadios.forEach(function (radio) {
+    radio.addEventListener('change', function () {
+      hideStep(stepResult);
+      while (resultContent.firstChild) resultContent.removeChild(resultContent.firstChild);
+      // Reset tier selection when area changes
+      tierRadios.forEach(function (r) { r.checked = false; });
+      showStep(stepTier);
+      stepTier.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+  });
+
+  // Step 2 → Step 3
+  tierRadios.forEach(function (radio) {
+    radio.addEventListener('change', function () {
+      showResult();
+    });
+  });
+
+}());


### PR DESCRIPTION
## Summary

- Adds a three-step progressive-enhancement routing page (`LGR/Veneer/index.html`) for the post-LGR Newstershire Council veneer proof of concept
- Styles the page to local-government standards with navy/gold branding and a GOV.UK-influenced layout (`LGR/Veneer/style.css`)
- JavaScript (`LGR/Veneer/veneer.js`) drives the step-by-step flow: pick area → county or district → link card to the correct existing council website
- Full `<noscript>` fallback lists every area × tier link directly so the page works without JavaScript

## How it works

1. A prominent banner explains Newstershire is a new unitary authority formed from LGR
2. **Step 1** — user picks their area: Cheltenham, Cotswold, Forest of Dean, Gloucester, Stroud, or Tewkesbury
3. **Step 2** — user selects county-level or district-level service (with a collapsible "not sure?" guide)
4. **Step 3** — a link card appears pointing to the relevant existing council website

All files are self-contained within `LGR/Veneer/` — nothing in the repo root was touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJ29uNGieSuureHRDAyPKy)_