### PR TITLE
Convert council tax service tile from link-card to tile with inline link

### DIFF
--- a/LGR/Consolidated/index.html
+++ b/LGR/Consolidated/index.html
@@ -95,12 +95,13 @@
         <h2 class="section-title">Services on this site</h2>
         <p class="page-intro">These topics are handled directly here — no redirect needed.</p>
         <div class="service-tiles" aria-label="Consolidated services">
-          <a href="council-tax.html" class="service-tile">
+          <div class="service-tile">
             <span class="service-tile__badge">Available here</span>
             <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><rect x="2" y="5" width="20" height="14" rx="2"/><line x1="2" y1="10" x2="22" y2="10"/></svg>
             <span class="service-tile__title">Council tax</span>
             <span class="service-tile__desc">Exemptions, discounts, empty homes, second homes and reductions</span>
-          </a>
+            <a href="council-tax.html" class="service-tile__link">View council tax →</a>
+          </div>
           <div class="service-tile service-tile--coming-soon" aria-label="Bins and recycling — coming soon">
             <span class="service-tile__badge service-tile__badge--soon">Coming soon</span>
             <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v6M14 11v6"/><path d="M9 6V4h6v2"/></svg>

--- a/LGR/Consolidated/style.css
+++ b/LGR/Consolidated/style.css
@@ -628,11 +628,17 @@ details[open] summary::before { transform: rotate(90deg); }
   transition: background var(--transition), transform var(--transition), box-shadow var(--transition);
 }
 
-a.service-tile:hover {
-  background: var(--blue-xlight);
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(29,68,119,0.12);
+.service-tile__link {
+  display: inline-block;
+  margin-top: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: var(--blue-mid);
+  text-decoration: none;
+  align-self: flex-start;
 }
+
+.service-tile__link:hover { color: var(--blue-dark); text-decoration: underline; }
 
 .service-tile--coming-soon {
   border-color: var(--border);


### PR DESCRIPTION
## Summary

- Council tax tile changed from a full `<a>` wrapper to a `<div>` card matching the coming-soon tiles, with a "View council tax →" link inside
- Removes the hover transform on the whole card; the inline link handles interaction instead
- All three tiles now look visually consistent as cards rather than links

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJ29uNGieSuureHRDAyPKy)_