### PR TITLE
Fix mobile responsiveness and accessibility across LGR sites

### DIFF
--- a/LGR/Consolidated/council-tax.css
+++ b/LGR/Consolidated/council-tax.css
@@ -124,10 +124,14 @@
 .ct-tabs {
   display: flex;
   gap: 0.25rem;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
   border-bottom: 3px solid var(--blue-dark);
   margin-bottom: 1.5rem;
 }
+.ct-tabs::-webkit-scrollbar { display: none; }
 
 .ct-tab {
   padding: 0.6rem 1.1rem;
@@ -139,6 +143,8 @@
   font-weight: 600;
   color: var(--blue-mid);
   cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
   transition: background var(--transition), color var(--transition);
   position: relative;
   bottom: -3px;
@@ -274,25 +280,13 @@
 .ct-nojs li { margin-bottom: 0.35rem; font-size: 0.9375rem; }
 
 /* ---- Responsive ---- */
-@media (max-width: 540px) {
-  .ct-picker { flex-direction: column; align-items: flex-start; }
-  .ct-picker__select { width: 100%; }
-  .ct-tabs { gap: 0.15rem; }
-  .ct-tab { font-size: 0.8125rem; padding: 0.5rem 0.7rem; }
-  .ct-prompt { flex-direction: column; text-align: center; }
-}
-
-@media (max-width: 400px) {
-  .ct-tabs { flex-direction: column; border-bottom: none; gap: 0.25rem; }
-  .ct-tab {
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    bottom: 0;
-    font-size: 0.9375rem;
-    padding: 0.6rem 1rem;
-  }
-  .ct-tab--active {
-    border-color: var(--blue-dark);
-    border-bottom-color: var(--blue-dark);
-  }
+@media (max-width: 600px) {
+  .ct-layout { padding: 1.25rem 0 2rem; }
+  .ct-picker { flex-direction: column; align-items: flex-start; gap: 0.5rem; }
+  .ct-picker__select { width: 100%; font-size: 1rem; padding: 0.65rem 0.75rem; }
+  .ct-picker__label { font-size: 1rem; }
+  .ct-tab { font-size: 0.875rem; padding: 0.55rem 0.9rem; }
+  .ct-prompt { flex-direction: column; text-align: center; padding: 1.25rem; }
+  .ct-hero { padding: 1.25rem 0; }
+  .ct-hero__title { font-size: 1.5rem; }
 }

--- a/LGR/Consolidated/council-tax.css
+++ b/LGR/Consolidated/council-tax.css
@@ -281,3 +281,18 @@
   .ct-tab { font-size: 0.8125rem; padding: 0.5rem 0.7rem; }
   .ct-prompt { flex-direction: column; text-align: center; }
 }
+
+@media (max-width: 400px) {
+  .ct-tabs { flex-direction: column; border-bottom: none; gap: 0.25rem; }
+  .ct-tab {
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    bottom: 0;
+    font-size: 0.9375rem;
+    padding: 0.6rem 1rem;
+  }
+  .ct-tab--active {
+    border-color: var(--blue-dark);
+    border-bottom-color: var(--blue-dark);
+  }
+}

--- a/LGR/Consolidated/council-tax.html
+++ b/LGR/Consolidated/council-tax.html
@@ -9,6 +9,8 @@
 </head>
 <body>
 
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+
   <!-- Top utility bar -->
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -40,7 +42,10 @@
           </div>
         </a>
       </div>
-      <nav class="header-nav" aria-label="Site navigation">
+      <button class="nav-toggle" aria-expanded="false" aria-controls="header-nav" aria-label="Open menu">
+        <svg aria-hidden="true" focusable="false" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+      </button>
+      <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
           <li><a href="#" class="nav-link">News</a></li>
@@ -103,19 +108,19 @@
       <div id="ct-content" class="ct-content" hidden>
 
         <!-- Tab nav -->
-        <nav class="ct-tabs" aria-label="Council tax topics">
-          <button class="ct-tab ct-tab--active" data-tab="exemptions"    aria-selected="true"  role="tab">Exemptions</button>
-          <button class="ct-tab"                data-tab="discounts"     aria-selected="false" role="tab">Discounts</button>
-          <button class="ct-tab"                data-tab="empty-homes"   aria-selected="false" role="tab">Empty homes</button>
-          <button class="ct-tab"                data-tab="second-homes"  aria-selected="false" role="tab">Second homes</button>
-          <button class="ct-tab"                data-tab="reduction"     aria-selected="false" role="tab">Reduction (CTR)</button>
-        </nav>
+        <div class="ct-tabs" role="tablist" aria-label="Council tax topics">
+          <button class="ct-tab ct-tab--active" data-tab="exemptions"   id="tab-btn-exemptions"  aria-selected="true"  role="tab" aria-controls="tab-exemptions">Exemptions</button>
+          <button class="ct-tab"               data-tab="discounts"     id="tab-btn-discounts"   aria-selected="false" role="tab" aria-controls="tab-discounts">Discounts</button>
+          <button class="ct-tab"               data-tab="empty-homes"   id="tab-btn-empty-homes" aria-selected="false" role="tab" aria-controls="tab-empty-homes">Empty homes</button>
+          <button class="ct-tab"               data-tab="second-homes"  id="tab-btn-second-homes" aria-selected="false" role="tab" aria-controls="tab-second-homes">Second homes</button>
+          <button class="ct-tab"               data-tab="reduction"     id="tab-btn-reduction"   aria-selected="false" role="tab" aria-controls="tab-reduction">Reduction (CTR)</button>
+        </div>
 
         <!-- ==============================
              TAB: EXEMPTIONS (01)
              All content is common
              ============================== -->
-        <div id="tab-exemptions" class="ct-panel" role="tabpanel">
+        <div id="tab-exemptions" class="ct-panel" role="tabpanel" aria-labelledby="tab-btn-exemptions">
           <h2>Council tax exemptions</h2>
 
           <div class="ct-block ct-block--common">
@@ -160,7 +165,7 @@
         <!-- ==============================
              TAB: DISCOUNTS (02)
              ============================== -->
-        <div id="tab-discounts" class="ct-panel ct-panel--hidden" role="tabpanel">
+        <div id="tab-discounts" class="ct-panel ct-panel--hidden" role="tabpanel" aria-labelledby="tab-btn-discounts">
           <h2>Council tax discounts</h2>
 
           <!-- Single person: common -->
@@ -227,7 +232,7 @@
         <!-- ==============================
              TAB: EMPTY HOMES (03)
              ============================== -->
-        <div id="tab-empty-homes" class="ct-panel ct-panel--hidden" role="tabpanel">
+        <div id="tab-empty-homes" class="ct-panel ct-panel--hidden" role="tabpanel" aria-labelledby="tab-btn-empty-homes">
           <h2>Long-term empty homes premium</h2>
 
           <!-- Common intro -->
@@ -319,7 +324,7 @@
         <!-- ==============================
              TAB: SECOND HOMES (04)
              ============================== -->
-        <div id="tab-second-homes" class="ct-panel ct-panel--hidden" role="tabpanel">
+        <div id="tab-second-homes" class="ct-panel ct-panel--hidden" role="tabpanel" aria-labelledby="tab-btn-second-homes">
           <h2>Second homes</h2>
 
           <!-- Common intro -->
@@ -395,7 +400,7 @@
         <!-- ==============================
              TAB: CTR (05)
              ============================== -->
-        <div id="tab-reduction" class="ct-panel ct-panel--hidden" role="tabpanel">
+        <div id="tab-reduction" class="ct-panel ct-panel--hidden" role="tabpanel" aria-labelledby="tab-btn-reduction">
           <h2>Council Tax Reduction (CTR)</h2>
 
           <!-- Common: pensioner route -->
@@ -561,5 +566,17 @@
 
   <script src="../area-cookie.js"></script>
   <script src="council-tax.js"></script>
+  <script>
+    (function () {
+      var btn = document.querySelector('.nav-toggle');
+      var nav = document.getElementById('header-nav');
+      if (!btn || !nav) return;
+      btn.addEventListener('click', function () {
+        var open = nav.classList.toggle('header-nav--open');
+        btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+        btn.setAttribute('aria-label', open ? 'Close menu' : 'Open menu');
+      });
+    }());
+  </script>
 </body>
 </html>

--- a/LGR/Consolidated/index.html
+++ b/LGR/Consolidated/index.html
@@ -8,6 +8,8 @@
 </head>
 <body>
 
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+
   <!-- Top utility bar -->
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -38,7 +40,10 @@
           <span class="org-tagline">Serving Gloucestershire together</span>
         </div>
       </div>
-      <nav class="header-nav" aria-label="Site navigation">
+      <button class="nav-toggle" aria-expanded="false" aria-controls="header-nav" aria-label="Open menu">
+        <svg aria-hidden="true" focusable="false" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+      </button>
+      <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="#" class="nav-link nav-link--active">Home</a></li>
           <li><a href="#" class="nav-link">News</a></li>
@@ -414,5 +419,17 @@
 
   <script src="../area-cookie.js"></script>
   <script src="veneer.js"></script>
+  <script>
+    (function () {
+      var btn = document.querySelector('.nav-toggle');
+      var nav = document.getElementById('header-nav');
+      if (!btn || !nav) return;
+      btn.addEventListener('click', function () {
+        var open = nav.classList.toggle('header-nav--open');
+        btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+        btn.setAttribute('aria-label', open ? 'Close menu' : 'Open menu');
+      });
+    }());
+  </script>
 </body>
 </html>

--- a/LGR/Consolidated/style.css
+++ b/LGR/Consolidated/style.css
@@ -37,6 +37,22 @@ body {
   outline-offset: 2px;
 }
 
+/* Skip link */
+.skip-link {
+  position: absolute;
+  top: -3rem;
+  left: 0;
+  padding: 0.75rem 1rem;
+  background: var(--focus);
+  color: var(--text);
+  font-weight: 700;
+  font-size: 0.9375rem;
+  z-index: 9999;
+  text-decoration: none;
+  transition: top 0.1s;
+}
+.skip-link:focus { top: 0; }
+
 .sr-only {
   position: absolute; width: 1px; height: 1px;
   padding: 0; margin: -1px; overflow: hidden;
@@ -123,9 +139,24 @@ a:hover { color: var(--blue-dark); }
   flex-wrap: wrap;
 }
 
+.nav-toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem; height: 2.75rem;
+  background: transparent;
+  border: 1px solid rgba(255,255,255,0.3);
+  border-radius: var(--radius);
+  color: var(--white);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
 .nav-link {
-  display: block;
-  padding: 0.4rem 0.75rem;
+  display: flex;
+  align-items: center;
+  padding: 0.5rem 0.75rem;
+  min-height: 2.75rem;
   color: var(--blue-light);
   text-decoration: none;
   font-size: 0.9375rem;
@@ -516,7 +547,7 @@ details[open] summary::before { transform: rotate(90deg); }
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 2.5rem; height: 2.5rem;
+  width: 2.75rem; height: 2.75rem;
   background: rgba(255,255,255,0.1);
   border: 1px solid rgba(255,255,255,0.2);
   border-radius: var(--radius);
@@ -564,6 +595,10 @@ details[open] summary::before { transform: rotate(90deg); }
 }
 
 .newsletter-form button:hover { background: #d4b460; }
+.newsletter-form button:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 2px;
+}
 
 /* =====================
    Footer
@@ -708,7 +743,32 @@ details[open] summary::before { transform: rotate(90deg); }
 @media (max-width: 540px) {
   .radio-group { grid-template-columns: 1fr 1fr; }
   .radio-group--two { grid-template-columns: 1fr; }
-  .header-nav { display: none; }
+  .nav-toggle { display: flex; }
+  .header-nav {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0; right: 0;
+    background: var(--blue-dark);
+    border-top: 2px solid var(--gold);
+    z-index: 100;
+    padding: 0.5rem 0;
+  }
+  .header-nav--open { display: block; }
+  .header-nav ul { flex-direction: column; gap: 0; }
+  .nav-link { border-radius: 0; padding: 0.75rem 1.25rem; min-height: 3rem; }
   .hero { padding: 1.5rem 0; }
   .prefooter__inner { gap: 1.5rem; }
+  .site-header { position: relative; }
+  .service-tiles { grid-template-columns: 1fr 1fr; }
+}
+
+@media (max-width: 400px) {
+  .radio-group { grid-template-columns: 1fr; }
+  .service-tiles { grid-template-columns: 1fr; }
+  .hero__stats { gap: 0.5rem; }
+  .stat-card { padding: 0.75rem 1rem; }
+  .step { padding: 1rem; }
+  .newsletter-form { flex-direction: column; }
+  .newsletter-form button { width: 100%; padding: 0.75rem; }
 }

--- a/LGR/Consolidated/style.css
+++ b/LGR/Consolidated/style.css
@@ -30,6 +30,7 @@ body {
   line-height: 1.6;
   color: var(--text);
   background: var(--bg);
+  overflow-x: hidden;
 }
 
 :focus-visible {
@@ -740,6 +741,17 @@ details[open] summary::before { transform: rotate(90deg); }
   .hero__stats { justify-content: flex-start; }
 }
 
+@media (max-width: 640px) {
+  .hero__stats { flex-wrap: nowrap; overflow-x: auto; scrollbar-width: none; }
+  .hero__stats::-webkit-scrollbar { display: none; }
+}
+
+@media (max-width: 640px) {
+  .utility-bar { display: none; }
+  .main-grid { grid-template-columns: 1fr; }
+  .sidebar { order: -1; }
+}
+
 @media (max-width: 540px) {
   .radio-group { grid-template-columns: 1fr 1fr; }
   .radio-group--two { grid-template-columns: 1fr; }
@@ -753,22 +765,30 @@ details[open] summary::before { transform: rotate(90deg); }
     border-top: 2px solid var(--gold);
     z-index: 100;
     padding: 0.5rem 0;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.25);
   }
   .header-nav--open { display: block; }
   .header-nav ul { flex-direction: column; gap: 0; }
   .nav-link { border-radius: 0; padding: 0.75rem 1.25rem; min-height: 3rem; }
-  .hero { padding: 1.5rem 0; }
+  .hero { padding: 1.25rem 0; }
+  .hero__title { font-size: 1.375rem; }
+  .hero__sub { font-size: 0.9375rem; }
+  .hero__stats { display: none; }
   .prefooter__inner { gap: 1.5rem; }
   .site-header { position: relative; }
   .service-tiles { grid-template-columns: 1fr 1fr; }
+  main { padding: 1.25rem 0 2rem; }
+  .step { padding: 1rem 1rem; }
+  .container { padding: 0 1rem; }
+  .section-title { font-size: 1.25rem; }
+  .notice-banner { padding: 0.875rem 1rem; }
 }
 
 @media (max-width: 400px) {
   .radio-group { grid-template-columns: 1fr; }
   .service-tiles { grid-template-columns: 1fr; }
-  .hero__stats { gap: 0.5rem; }
   .stat-card { padding: 0.75rem 1rem; }
-  .step { padding: 1rem; }
   .newsletter-form { flex-direction: column; }
   .newsletter-form button { width: 100%; padding: 0.75rem; }
+  .footer-grid { grid-template-columns: 1fr 1fr; }
 }

--- a/LGR/Veneer/index.html
+++ b/LGR/Veneer/index.html
@@ -8,6 +8,8 @@
 </head>
 <body>
 
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+
   <!-- Top utility bar -->
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -38,7 +40,10 @@
           <span class="org-tagline">Serving Gloucestershire together</span>
         </div>
       </div>
-      <nav class="header-nav" aria-label="Site navigation">
+      <button class="nav-toggle" aria-expanded="false" aria-controls="header-nav" aria-label="Open menu">
+        <svg aria-hidden="true" focusable="false" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+      </button>
+      <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="#" class="nav-link nav-link--active">Home</a></li>
           <li><a href="#" class="nav-link">News</a></li>
@@ -389,5 +394,17 @@
 
   <script src="../area-cookie.js"></script>
   <script src="veneer.js"></script>
+  <script>
+    (function () {
+      var btn = document.querySelector('.nav-toggle');
+      var nav = document.getElementById('header-nav');
+      if (!btn || !nav) return;
+      btn.addEventListener('click', function () {
+        var open = nav.classList.toggle('header-nav--open');
+        btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+        btn.setAttribute('aria-label', open ? 'Close menu' : 'Open menu');
+      });
+    }());
+  </script>
 </body>
 </html>

--- a/LGR/Veneer/style.css
+++ b/LGR/Veneer/style.css
@@ -37,6 +37,22 @@ body {
   outline-offset: 2px;
 }
 
+/* Skip link */
+.skip-link {
+  position: absolute;
+  top: -3rem;
+  left: 0;
+  padding: 0.75rem 1rem;
+  background: var(--focus);
+  color: var(--text);
+  font-weight: 700;
+  font-size: 0.9375rem;
+  z-index: 9999;
+  text-decoration: none;
+  transition: top 0.1s;
+}
+.skip-link:focus { top: 0; }
+
 .sr-only {
   position: absolute; width: 1px; height: 1px;
   padding: 0; margin: -1px; overflow: hidden;
@@ -123,9 +139,25 @@ a:hover { color: var(--blue-dark); }
   flex-wrap: wrap;
 }
 
+.nav-toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem; height: 2.75rem;
+  background: transparent;
+  border: 1px solid rgba(255,255,255,0.3);
+  border-radius: var(--radius);
+  color: var(--white);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
 .nav-link {
   display: block;
-  padding: 0.4rem 0.75rem;
+  padding: 0.5rem 0.75rem;
+  min-height: 2.75rem;
+  display: flex;
+  align-items: center;
   color: var(--blue-light);
   text-decoration: none;
   font-size: 0.9375rem;
@@ -516,7 +548,7 @@ details[open] summary::before { transform: rotate(90deg); }
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 2.5rem; height: 2.5rem;
+  width: 2.75rem; height: 2.75rem;
   background: rgba(255,255,255,0.1);
   border: 1px solid rgba(255,255,255,0.2);
   border-radius: var(--radius);
@@ -564,6 +596,10 @@ details[open] summary::before { transform: rotate(90deg); }
 }
 
 .newsletter-form button:hover { background: #d4b460; }
+.newsletter-form button:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 2px;
+}
 
 /* =====================
    Footer
@@ -616,7 +652,30 @@ details[open] summary::before { transform: rotate(90deg); }
 @media (max-width: 540px) {
   .radio-group { grid-template-columns: 1fr 1fr; }
   .radio-group--two { grid-template-columns: 1fr; }
-  .header-nav { display: none; }
+  .nav-toggle { display: flex; }
+  .header-nav {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0; right: 0;
+    background: var(--blue-dark);
+    border-top: 2px solid var(--gold);
+    z-index: 100;
+    padding: 0.5rem 0;
+  }
+  .header-nav--open { display: block; }
+  .header-nav ul { flex-direction: column; gap: 0; }
+  .nav-link { border-radius: 0; padding: 0.75rem 1.25rem; min-height: 3rem; }
   .hero { padding: 1.5rem 0; }
   .prefooter__inner { gap: 1.5rem; }
+  .site-header { position: relative; }
+}
+
+@media (max-width: 400px) {
+  .radio-group { grid-template-columns: 1fr; }
+  .hero__stats { gap: 0.5rem; }
+  .stat-card { padding: 0.75rem 1rem; }
+  .step { padding: 1rem; }
+  .newsletter-form { flex-direction: column; }
+  .newsletter-form button { width: 100%; padding: 0.75rem; }
 }

--- a/LGR/Veneer/style.css
+++ b/LGR/Veneer/style.css
@@ -30,6 +30,7 @@ body {
   line-height: 1.6;
   color: var(--text);
   background: var(--bg);
+  overflow-x: hidden;
 }
 
 :focus-visible {
@@ -649,6 +650,18 @@ details[open] summary::before { transform: rotate(90deg); }
   .hero__stats { justify-content: flex-start; }
 }
 
+/* Hero stats scroll on mid-size mobile */
+@media (max-width: 640px) {
+  .hero__stats { flex-wrap: nowrap; overflow-x: auto; scrollbar-width: none; }
+  .hero__stats::-webkit-scrollbar { display: none; }
+}
+
+@media (max-width: 640px) {
+  .utility-bar { display: none; }
+  .main-grid { grid-template-columns: 1fr; }
+  .sidebar { order: -1; }
+}
+
 @media (max-width: 540px) {
   .radio-group { grid-template-columns: 1fr 1fr; }
   .radio-group--two { grid-template-columns: 1fr; }
@@ -662,20 +675,28 @@ details[open] summary::before { transform: rotate(90deg); }
     border-top: 2px solid var(--gold);
     z-index: 100;
     padding: 0.5rem 0;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.25);
   }
   .header-nav--open { display: block; }
   .header-nav ul { flex-direction: column; gap: 0; }
   .nav-link { border-radius: 0; padding: 0.75rem 1.25rem; min-height: 3rem; }
-  .hero { padding: 1.5rem 0; }
+  .hero { padding: 1.25rem 0; }
+  .hero__title { font-size: 1.375rem; }
+  .hero__sub { font-size: 0.9375rem; }
+  .hero__stats { display: none; }
   .prefooter__inner { gap: 1.5rem; }
   .site-header { position: relative; }
+  main { padding: 1.25rem 0 2rem; }
+  .step { padding: 1rem; }
+  .container { padding: 0 1rem; }
+  .section-title { font-size: 1.25rem; }
+  .notice-banner { padding: 0.875rem 1rem; }
 }
 
 @media (max-width: 400px) {
   .radio-group { grid-template-columns: 1fr; }
-  .hero__stats { gap: 0.5rem; }
   .stat-card { padding: 0.75rem 1rem; }
-  .step { padding: 1rem; }
   .newsletter-form { flex-direction: column; }
   .newsletter-form button { width: 100%; padding: 0.75rem; }
+  .footer-grid { grid-template-columns: 1fr 1fr; }
 }


### PR DESCRIPTION
## Summary

- Add skip-to-content links on all three LGR pages
- Replace hidden header nav with a hamburger toggle on mobile (≤540px), with `aria-expanded` state management
- Council tax tabs now scroll horizontally instead of wrapping to two rows on mobile
- Hide utility bar below 640px to reduce header clutter on phones
- Hide hero stats on mobile; single-column layout triggers at 640px
- Increase social icon buttons and nav links to 44px touch targets
- Add `role="tablist"`, `aria-controls`, and `aria-labelledby` wiring to council tax tab widget
- Tighten container/step padding, section headings, and hero sizing on narrow screens
- Add `overflow-x: hidden` to body to prevent horizontal scroll bleed
- Explicit `:focus-visible` on newsletter submit button

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJ29uNGieSuureHRDAyPKy)_