### PR TITLE
Fix council tax page width, picker and tab layout on mobile

### DIFF
--- a/LGR/Consolidated/council-tax.css
+++ b/LGR/Consolidated/council-tax.css
@@ -56,6 +56,7 @@
 .ct-layout {
   padding: 2rem 0 3rem;
   max-width: 860px;
+  width: 100%;
 }
 
 /* ---- Area picker ---- */
@@ -112,15 +113,7 @@
 .ct-tabs-wrap {
   position: relative;
   margin-bottom: 1.5rem;
-}
-
-.ct-tabs-wrap::after {
-  content: '';
-  position: absolute;
-  right: 0; top: 0; bottom: 3px;
-  width: 2rem;
-  background: linear-gradient(to right, transparent, var(--bg));
-  pointer-events: none;
+  /* scroll lives here on mobile so overflow doesn't clip bottom:-3px on tabs */
 }
 
 /* ---- No-area prompt ---- */
@@ -142,15 +135,10 @@
 .ct-tabs {
   display: flex;
   gap: 0.25rem;
-  flex-wrap: nowrap;
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-  scrollbar-width: none;
+  flex-wrap: wrap;
   border-bottom: 3px solid var(--blue-dark);
   margin-bottom: 0;
-  padding-right: 2rem;
 }
-.ct-tabs::-webkit-scrollbar { display: none; }
 
 .ct-tab {
   padding: 0.6rem 1.1rem;
@@ -162,8 +150,6 @@
   font-weight: 600;
   color: var(--blue-mid);
   cursor: pointer;
-  white-space: nowrap;
-  flex-shrink: 0;
   transition: background var(--transition), color var(--transition);
   position: relative;
   bottom: -3px;
@@ -300,12 +286,65 @@
 
 /* ---- Responsive ---- */
 @media (max-width: 600px) {
-  .ct-layout { padding: 1.25rem 0 2rem; }
-  .ct-picker { flex-direction: column; align-items: flex-start; gap: 0.5rem; }
-  .ct-picker__select { width: 100%; font-size: 1rem; padding: 0.65rem 0.75rem; }
-  .ct-picker__label { font-size: 1rem; }
-  .ct-tab { font-size: 0.875rem; padding: 0.55rem 0.9rem; }
+  .ct-layout { padding: 1rem 0 2rem; }
+
+  /* Compact picker — just label above select, no heavy box */
+  .ct-picker {
+    background: none;
+    border: none;
+    padding: 0;
+    gap: 0.4rem;
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .ct-picker__label { font-size: 0.9375rem; }
+  .ct-picker__select {
+    width: 100%;
+    font-size: 1rem;
+    padding: 0.65rem 0.75rem;
+    border: 2px solid var(--blue-dark);
+    border-radius: var(--radius);
+  }
+  .ct-picker-wrap {
+    background: var(--white);
+    border: 2px solid var(--blue-dark);
+    border-radius: var(--radius);
+    padding: 0.875rem 1rem;
+    margin-bottom: 1rem;
+  }
+
+  /* Pill-style tabs that scroll sideways — avoids the bottom:-3px clipping issue */
+  .ct-tabs-wrap {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+    margin-bottom: 1.25rem;
+  }
+  .ct-tabs-wrap::-webkit-scrollbar { display: none; }
+  .ct-tabs {
+    flex-wrap: nowrap;
+    border-bottom: none;
+    gap: 0.4rem;
+    padding-bottom: 0.1rem;
+  }
+  .ct-tab {
+    background: var(--white);
+    border: 2px solid var(--border);
+    border-radius: 2rem;
+    bottom: 0;
+    padding: 0.45rem 0.875rem;
+    font-size: 0.875rem;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+  .ct-tab--active {
+    background: var(--blue-dark);
+    border-color: var(--blue-dark);
+    color: var(--white);
+  }
+
   .ct-prompt { flex-direction: column; text-align: center; padding: 1.25rem; }
   .ct-hero { padding: 1.25rem 0; }
   .ct-hero__title { font-size: 1.5rem; }
+  .ct-panel > h2 { font-size: 1.125rem; }
 }

--- a/LGR/Consolidated/council-tax.css
+++ b/LGR/Consolidated/council-tax.css
@@ -3,6 +3,9 @@
    Builds on top of style.css
    ============================================= */
 
+/* Ensure [hidden] attribute works even when CSS sets display on the element */
+[hidden] { display: none !important; }
+
 /* ---- Breadcrumb ---- */
 .breadcrumb {
   background: var(--white);
@@ -105,6 +108,21 @@
   margin-top: 0.5rem;
 }
 
+/* ---- Tab scroll wrapper ---- */
+.ct-tabs-wrap {
+  position: relative;
+  margin-bottom: 1.5rem;
+}
+
+.ct-tabs-wrap::after {
+  content: '';
+  position: absolute;
+  right: 0; top: 0; bottom: 3px;
+  width: 2rem;
+  background: linear-gradient(to right, transparent, var(--bg));
+  pointer-events: none;
+}
+
 /* ---- No-area prompt ---- */
 .ct-prompt {
   display: flex;
@@ -129,7 +147,8 @@
   -webkit-overflow-scrolling: touch;
   scrollbar-width: none;
   border-bottom: 3px solid var(--blue-dark);
-  margin-bottom: 1.5rem;
+  margin-bottom: 0;
+  padding-right: 2rem;
 }
 .ct-tabs::-webkit-scrollbar { display: none; }
 

--- a/LGR/Consolidated/council-tax.html
+++ b/LGR/Consolidated/council-tax.html
@@ -108,13 +108,15 @@
       <div id="ct-content" class="ct-content" hidden>
 
         <!-- Tab nav -->
+        <div class="ct-tabs-wrap">
         <div class="ct-tabs" role="tablist" aria-label="Council tax topics">
           <button class="ct-tab ct-tab--active" data-tab="exemptions"   id="tab-btn-exemptions"  aria-selected="true"  role="tab" aria-controls="tab-exemptions">Exemptions</button>
           <button class="ct-tab"               data-tab="discounts"     id="tab-btn-discounts"   aria-selected="false" role="tab" aria-controls="tab-discounts">Discounts</button>
           <button class="ct-tab"               data-tab="empty-homes"   id="tab-btn-empty-homes" aria-selected="false" role="tab" aria-controls="tab-empty-homes">Empty homes</button>
           <button class="ct-tab"               data-tab="second-homes"  id="tab-btn-second-homes" aria-selected="false" role="tab" aria-controls="tab-second-homes">Second homes</button>
           <button class="ct-tab"               data-tab="reduction"     id="tab-btn-reduction"   aria-selected="false" role="tab" aria-controls="tab-reduction">Reduction (CTR)</button>
-        </div>
+        </div><!-- /ct-tabs -->
+        </div><!-- /ct-tabs-wrap -->
 
         <!-- ==============================
              TAB: EXEMPTIONS (01)

--- a/LGR/Consolidated/style.css
+++ b/LGR/Consolidated/style.css
@@ -41,8 +41,8 @@ body {
 /* Skip link */
 .skip-link {
   position: absolute;
-  top: -3rem;
-  left: 0;
+  left: -999px;
+  top: 0;
   padding: 0.75rem 1rem;
   background: var(--focus);
   color: var(--text);
@@ -50,9 +50,8 @@ body {
   font-size: 0.9375rem;
   z-index: 9999;
   text-decoration: none;
-  transition: top 0.1s;
 }
-.skip-link:focus { top: 0; }
+.skip-link:focus { left: 0; }
 
 .sr-only {
   position: absolute; width: 1px; height: 1px;

--- a/LGR/Veneer/style.css
+++ b/LGR/Veneer/style.css
@@ -41,8 +41,8 @@ body {
 /* Skip link */
 .skip-link {
   position: absolute;
-  top: -3rem;
-  left: 0;
+  left: -999px;
+  top: 0;
   padding: 0.75rem 1rem;
   background: var(--focus);
   color: var(--text);
@@ -50,9 +50,8 @@ body {
   font-size: 0.9375rem;
   z-index: 9999;
   text-decoration: none;
-  transition: top 0.1s;
 }
-.skip-link:focus { top: 0; }
+.skip-link:focus { left: 0; }
 
 .sr-only {
   position: absolute; width: 1px; height: 1px;


### PR DESCRIPTION
## Summary

- **Page width**: add `width:100%` to `.ct-layout` so it fills the container on narrow screens
- **Hidden element bug**: add `[hidden] { display: none !important }` so the no-area prompt correctly hides when an area is selected (CSS `display:flex` was overriding the `hidden` attribute)
- **Skip link**: fix off-screen positioning from `top:-3rem` to `left:-999px` pattern
- **Oversized picker**: strip the nested border-box from `.ct-picker`, move the border to the outer `.ct-picker-wrap`, full-width select on mobile
- **Tab overlap**: `overflow-x:auto` forces `overflow-y` away from `visible`, clipping the `bottom:-3px` offset used by desktop tabs. On mobile, scroll is now on the wrapper only and tabs switch to horizontal-scroll pill style that doesn't rely on the border-overlap trick

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJ29uNGieSuureHRDAyPKy)_