### PR TITLE
Show main content before sidebar on mobile

### DIFF
--- a/LGR/Consolidated/style.css
+++ b/LGR/Consolidated/style.css
@@ -736,7 +736,6 @@ details[open] summary::before { transform: rotate(90deg); }
    ===================== */
 @media (max-width: 860px) {
   .main-grid { grid-template-columns: 1fr; }
-  .sidebar { order: -1; }
   .hero__stats { justify-content: flex-start; }
 }
 
@@ -748,7 +747,6 @@ details[open] summary::before { transform: rotate(90deg); }
 @media (max-width: 640px) {
   .utility-bar { display: none; }
   .main-grid { grid-template-columns: 1fr; }
-  .sidebar { order: -1; }
 }
 
 @media (max-width: 540px) {

--- a/LGR/Veneer/style.css
+++ b/LGR/Veneer/style.css
@@ -645,7 +645,6 @@ details[open] summary::before { transform: rotate(90deg); }
    ===================== */
 @media (max-width: 860px) {
   .main-grid { grid-template-columns: 1fr; }
-  .sidebar { order: -1; }
   .hero__stats { justify-content: flex-start; }
 }
 
@@ -658,7 +657,6 @@ details[open] summary::before { transform: rotate(90deg); }
 @media (max-width: 640px) {
   .utility-bar { display: none; }
   .main-grid { grid-template-columns: 1fr; }
-  .sidebar { order: -1; }
 }
 
 @media (max-width: 540px) {


### PR DESCRIPTION
Remove `order: -1` from the sidebar so the "Find your service" tool and service tiles appear before Popular services / Latest news / Contact on mobile, matching source order.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJ29uNGieSuureHRDAyPKy)_