### PR TITLE
Make council tax tabs scroll at all widths

### DIFF
--- a/LGR/Consolidated/council-tax.css
+++ b/LGR/Consolidated/council-tax.css
@@ -111,10 +111,12 @@
 
 /* ---- Tab scroll wrapper ---- */
 .ct-tabs-wrap {
-  position: relative;
-  margin-bottom: 1.5rem;
-  /* scroll lives here on mobile so overflow doesn't clip bottom:-3px on tabs */
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+  margin-bottom: 1.25rem;
 }
+.ct-tabs-wrap::-webkit-scrollbar { display: none; }
 
 /* ---- No-area prompt ---- */
 .ct-prompt {
@@ -131,41 +133,69 @@
 .ct-prompt svg { flex-shrink: 0; color: var(--blue-dark); opacity: 0.5; }
 .ct-prompt p { font-size: 1rem; }
 
-/* ---- Tabs ---- */
+/* ---- Tabs — pill+scroll by default, border style at wide widths ---- */
 .ct-tabs {
   display: flex;
-  gap: 0.25rem;
-  flex-wrap: wrap;
-  border-bottom: 3px solid var(--blue-dark);
-  margin-bottom: 0;
+  gap: 0.4rem;
+  flex-wrap: nowrap;
+  padding-bottom: 0.1rem;
+  border-bottom: 2px solid var(--border);
 }
 
 .ct-tab {
-  padding: 0.6rem 1.1rem;
+  padding: 0.45rem 0.9rem;
   background: var(--white);
-  border: 1px solid var(--border);
-  border-bottom: none;
-  border-radius: var(--radius) var(--radius) 0 0;
-  font-size: 0.9rem;
+  border: 2px solid var(--border);
+  border-radius: 2rem;
+  font-size: 0.875rem;
   font-weight: 600;
   color: var(--blue-mid);
   cursor: pointer;
-  transition: background var(--transition), color var(--transition);
-  position: relative;
-  bottom: -3px;
+  white-space: nowrap;
+  flex-shrink: 0;
+  transition: background var(--transition), color var(--transition), border-color var(--transition);
 }
 
 .ct-tab:hover {
+  border-color: var(--blue-mid);
   background: var(--blue-xlight);
   color: var(--blue-dark);
 }
 
 .ct-tab--active {
-  background: var(--white);
+  background: var(--blue-dark);
   border-color: var(--blue-dark);
-  border-bottom-color: var(--white);
-  color: var(--blue-dark);
-  z-index: 1;
+  color: var(--white);
+}
+
+/* Wide screens: traditional underline tab style */
+@media (min-width: 700px) {
+  .ct-tabs-wrap { overflow: visible; }
+  .ct-tabs {
+    gap: 0.25rem;
+    flex-wrap: wrap;
+    border-bottom: 3px solid var(--blue-dark);
+    padding-bottom: 0;
+  }
+  .ct-tab {
+    padding: 0.6rem 1.1rem;
+    background: var(--white);
+    border: 1px solid var(--border);
+    border-bottom: none;
+    border-radius: var(--radius) var(--radius) 0 0;
+    font-size: 0.9rem;
+    white-space: normal;
+    flex-shrink: 1;
+    position: relative;
+    bottom: -3px;
+  }
+  .ct-tab--active {
+    background: var(--white);
+    border-color: var(--blue-dark);
+    border-bottom-color: var(--white);
+    color: var(--blue-dark);
+    z-index: 1;
+  }
 }
 
 /* ---- Panels ---- */
@@ -312,36 +342,6 @@
     border: 2px solid var(--blue-dark);
     border-radius: var(--radius);
     min-height: 0;
-  }
-
-  /* Pill-style tabs that scroll sideways — avoids the bottom:-3px clipping issue */
-  .ct-tabs-wrap {
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-    scrollbar-width: none;
-    margin-bottom: 1.25rem;
-  }
-  .ct-tabs-wrap::-webkit-scrollbar { display: none; }
-  .ct-tabs {
-    flex-wrap: nowrap;
-    border-bottom: none;
-    gap: 0.4rem;
-    padding-bottom: 0.1rem;
-  }
-  .ct-tab {
-    background: var(--white);
-    border: 2px solid var(--border);
-    border-radius: 2rem;
-    bottom: 0;
-    padding: 0.45rem 0.875rem;
-    font-size: 0.875rem;
-    white-space: nowrap;
-    flex-shrink: 0;
-  }
-  .ct-tab--active {
-    background: var(--blue-dark);
-    border-color: var(--blue-dark);
-    color: var(--white);
   }
 
   .ct-prompt { flex-direction: column; text-align: center; padding: 1.25rem; }


### PR DESCRIPTION
Tabs previously only scrolled inside `@media (max-width: 600px)`, so landscape phones and mid-size screens got wrapping instead. Now pill+scroll is the default for all widths; the traditional border underline style is only applied at ≥700px where there's enough room and the `bottom:-3px` overlap trick works correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJ29uNGieSuureHRDAyPKy)_