### PR TITLE
Refine home page wording and remove duplication

### DIFF
--- a/LGR/Consolidated/index.html
+++ b/LGR/Consolidated/index.html
@@ -59,7 +59,7 @@
     <div class="container hero__inner">
       <div class="hero__text">
         <h1 class="hero__title">Welcome to Newstershire Council</h1>
-        <p class="hero__sub">We're the new unitary authority for Gloucestershire, bringing county and district services together under one roof. Use the tool below to find the right service for where you live.</p>
+        <p class="hero__sub">The new single council for the whole of Gloucestershire. Tell us where you live and we'll take you straight to the service you need.</p>
       </div>
       <div class="hero__stats" aria-label="Key figures">
         <div class="stat-card">
@@ -67,8 +67,8 @@
           <span class="stat-label">Residents served</span>
         </div>
         <div class="stat-card">
-          <span class="stat-num">6</span>
-          <span class="stat-label">Districts &amp; boroughs</span>
+          <span class="stat-num">7</span>
+          <span class="stat-label">Councils merged into one</span>
         </div>
         <div class="stat-card">
           <span class="stat-num">300+</span>
@@ -91,14 +91,14 @@
             <path d="M10 6v4M10 14v.5" stroke="#1d4477" stroke-width="2" stroke-linecap="round"/>
           </svg>
           <p>
-            <strong>Newstershire Council is a new unitary authority</strong> formed from the reorganisation of local government in Gloucestershire.
-            It brings together services previously delivered by the county council and the district and borough councils.
+            <strong>Newstershire Council is a new unitary authority.</strong> We've replaced Gloucestershire County Council and the six district and borough councils with one council for the whole county.
+            While we bring everything together, some services still live on the former councils' websites.
           </p>
         </div>
 
         <!-- Consolidated services -->
         <h2 class="section-title">Services on this site</h2>
-        <p class="page-intro">These topics are handled directly here — no redirect needed.</p>
+        <p class="page-intro">These services are now handled right here on the new council website — no redirect needed.</p>
         <div class="service-tiles" aria-label="Consolidated services">
           <div class="service-tile">
             <span class="service-tile__badge">Available here</span>
@@ -121,8 +121,8 @@
           </div>
         </div>
 
-        <h2 class="section-title section-title--router">Not sure which council to contact?</h2>
-        <p class="page-intro">Use the tool below — it will open the right existing council website in a new tab.</p>
+        <h2 class="section-title section-title--router">Looking for another service?</h2>
+        <p class="page-intro">We're still moving some services across from the former councils. Tell us where you live and we'll open the right website in a new tab.</p>
 
         <!-- === STEP 1: area === -->
         <section id="step-area" class="step" aria-labelledby="step-area-heading">

--- a/LGR/Veneer/index.html
+++ b/LGR/Veneer/index.html
@@ -59,7 +59,7 @@
     <div class="container hero__inner">
       <div class="hero__text">
         <h1 class="hero__title">Welcome to Newstershire Council</h1>
-        <p class="hero__sub">We're the new unitary authority for Gloucestershire, bringing county and district services together under one roof. Use the tool below to find the right service for where you live.</p>
+        <p class="hero__sub">The new single council for the whole of Gloucestershire. Tell us where you live and we'll take you straight to the service you need.</p>
       </div>
       <div class="hero__stats" aria-label="Key figures">
         <div class="stat-card">
@@ -67,8 +67,8 @@
           <span class="stat-label">Residents served</span>
         </div>
         <div class="stat-card">
-          <span class="stat-num">6</span>
-          <span class="stat-label">Districts &amp; boroughs</span>
+          <span class="stat-num">7</span>
+          <span class="stat-label">Councils merged into one</span>
         </div>
         <div class="stat-card">
           <span class="stat-num">300+</span>
@@ -91,8 +91,8 @@
             <path d="M10 6v4M10 14v.5" stroke="#1d4477" stroke-width="2" stroke-linecap="round"/>
           </svg>
           <p>
-            <strong>Newstershire Council is a new unitary authority</strong> formed from the reorganisation of local government in Gloucestershire.
-            It brings together services previously delivered by the county council and the district and borough councils.
+            <strong>Newstershire Council is a new unitary authority.</strong> We've replaced Gloucestershire County Council and the six district and borough councils with one council for the whole county.
+            While we bring everything together, some services still live on the former councils' websites — the tool below sends you to the right one.
           </p>
         </div>
 


### PR DESCRIPTION
## Summary

- **Removed duplication**: the hero subtitle and notice banner both stated "new unitary authority bringing county and district services together" — near-identical copy on both home pages. Hero now leads with the action ("tell us where you live"); the notice carries the what/when (replaced the county council + six districts) plus the transition caveat.
- **Concept framing**: reframed the former councils as *former/previous* rather than "existing" — the concept is one new unitary made from the county + six districts.
- Consolidated router heading "Not sure which council to contact?" → "Looking for another service?" with copy explaining services are still moving across from the former councils.
- Stat "6 Districts & boroughs" → "7 Councils merged into one" (six districts + the county) to reinforce the merger.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJ29uNGieSuureHRDAyPKy)_