### PR TITLE
Rework bins & recycling as a tiled hub with per-topic pages

### DIFF
--- a/LGR/Consolidated/council-tax.css
+++ b/LGR/Consolidated/council-tax.css
@@ -59,6 +59,18 @@
   width: 100%;
 }
 
+/* ---- Back link (topic detail pages) ---- */
+.ct-back {
+  margin-bottom: 1rem;
+  font-size: 0.9375rem;
+}
+.ct-back a {
+  color: var(--blue-mid);
+  text-decoration: none;
+  font-weight: 600;
+}
+.ct-back a:hover { text-decoration: underline; }
+
 /* ---- Area picker ---- */
 .ct-picker-wrap {
   margin-bottom: 1.75rem;

--- a/LGR/Consolidated/index.html
+++ b/LGR/Consolidated/index.html
@@ -273,7 +273,7 @@
               <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
               Apply for planning permission
             </a></li>
-            <li><a href="waste.html" class="quick-link">
+            <li><a href="waste-bulky.html" class="quick-link">
               <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
               Book a bulky waste collection
             </a></li>
@@ -281,7 +281,7 @@
               <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/></svg>
               Housing benefit claim
             </a></li>
-            <li><a href="waste.html" class="quick-link">
+            <li><a href="waste-bulky.html" class="quick-link">
               <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
               Find my nearest recycling centre
             </a></li>

--- a/LGR/Consolidated/style.css
+++ b/LGR/Consolidated/style.css
@@ -675,6 +675,23 @@ details[open] summary::before { transform: rotate(90deg); }
   transition: background var(--transition), transform var(--transition), box-shadow var(--transition);
 }
 
+/* Whole-tile link variant (topic hub) */
+.service-tile--link { cursor: pointer; }
+.service-tile--link:hover,
+.service-tile--link:focus-visible {
+  background: var(--blue-xlight);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.12);
+}
+.service-tile__cta {
+  margin-top: auto;
+  padding-top: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: var(--blue-mid);
+}
+.service-tile--link:hover .service-tile__cta { text-decoration: underline; }
+
 .service-tile__link {
   display: inline-block;
   margin-top: 0.5rem;

--- a/LGR/Consolidated/waste-bulky.html
+++ b/LGR/Consolidated/waste-bulky.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Bins and recycling – Newstershire Council</title>
+  <title>Bulky waste and recycling centres – Bins and recycling – Newstershire Council</title>
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="council-tax.css">
 </head>
@@ -11,7 +11,6 @@
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
 
-  <!-- Top utility bar -->
   <div class="utility-bar">
     <div class="container utility-bar__inner">
       <span class="utility-bar__item">
@@ -56,29 +55,29 @@
     </div>
   </header>
 
-  <!-- Breadcrumb -->
   <nav class="breadcrumb" aria-label="Breadcrumb">
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
         <li><a href="#">Residents</a></li>
-        <li aria-current="page">Bins and recycling</li>
+        <li><a href="waste.html">Bins and recycling</a></li>
+        <li aria-current="page">Bulky waste &amp; centres</li>
       </ol>
     </div>
   </nav>
 
-  <!-- Page hero -->
-  <section class="ct-hero" aria-label="Bins and recycling">
+  <section class="ct-hero" aria-label="General waste">
     <div class="container">
-      <h1 class="ct-hero__title">Bins and recycling</h1>
-      <p class="ct-hero__sub">Bin colours, collection days and what goes where are set locally and still differ across the county. Choose your area, then pick a topic below.</p>
+      <h1 class="ct-hero__title">Bulky waste and recycling centres</h1>
+      <p class="ct-hero__sub">Booking a large-item collection, and finding your nearest Household Recycling Centre — select your area.</p>
     </div>
   </section>
 
   <main id="main-content">
     <div class="container ct-layout">
 
-      <!-- Area picker -->
+      <p class="ct-back"><a href="waste.html">&larr; All bins and recycling topics</a></p>
+
       <div class="ct-picker-wrap">
         <div class="ct-picker">
           <label for="ct-area-select" class="ct-picker__label">
@@ -98,68 +97,79 @@
         <p id="ct-area-label" class="ct-area-label" aria-live="polite" hidden></p>
       </div>
 
-      <!-- Topic tiles -->
-      <h2 class="section-title">Choose a topic</h2>
-      <p class="page-intro">Your selected area is remembered as you move between these pages.</p>
-      <div class="service-tiles" aria-label="Bins and recycling topics">
-
-        <a href="waste-general-waste.html" class="service-tile service-tile--link">
-          <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v6M14 11v6"/><path d="M9 6V4h6v2"/></svg>
-          <span class="service-tile__title">General waste</span>
-          <span class="service-tile__desc">What goes in your refuse bin, collection frequency and extra capacity</span>
-          <span class="service-tile__cta" aria-hidden="true">View →</span>
-        </a>
-
-        <a href="waste-recycling.html" class="service-tile service-tile--link">
-          <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><polyline points="7 4 4 7 7 10"/><path d="M4 7h11a4 4 0 013.5 6"/><polyline points="17 20 20 17 17 14"/><path d="M20 17H9a4 4 0 01-3.5-6"/></svg>
-          <span class="service-tile__title">Recycling</span>
-          <span class="service-tile__desc">Boxes, bags and bins, and what each stream accepts in your area</span>
-          <span class="service-tile__cta" aria-hidden="true">View →</span>
-        </a>
-
-        <a href="waste-food-waste.html" class="service-tile service-tile--link">
-          <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M6 2v6a3 3 0 006 0V2"/><path d="M9 2v20"/><path d="M17 2c-1.5 0-3 1.5-3 4v6h3"/><path d="M17 12v10"/></svg>
-          <span class="service-tile__title">Food waste</span>
-          <span class="service-tile__desc">Weekly caddy collection, what's accepted and why it can't go in garden waste</span>
-          <span class="service-tile__cta" aria-hidden="true">View →</span>
-        </a>
-
-        <a href="waste-garden-waste.html" class="service-tile service-tile--link">
-          <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M12 22V11"/><path d="M12 11c0-4 3-7 8-7 0 4-3 7-8 7z"/><path d="M12 14C12 10 9 8 4 8c0 4 3 6 8 6z"/></svg>
-          <span class="service-tile__title">Garden waste</span>
-          <span class="service-tile__desc">The opt-in paid subscription, prices and season in your area</span>
-          <span class="service-tile__cta" aria-hidden="true">View →</span>
-        </a>
-
-        <a href="waste-bulky.html" class="service-tile service-tile--link">
-          <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><rect x="3" y="10" width="18" height="10" rx="1"/><path d="M6 10V7a3 3 0 013-3h6a3 3 0 013 3v3"/><path d="M9 14h6"/></svg>
-          <span class="service-tile__title">Bulky waste &amp; centres</span>
-          <span class="service-tile__desc">Booking a large-item collection and finding your Household Recycling Centre</span>
-          <span class="service-tile__cta" aria-hidden="true">View →</span>
-        </a>
-
+      <div class="ct-block ct-block--common">
+        <p>For items too big for the normal bin — furniture, white goods, large electricals — councils run a separate, chargeable, bookable collection. Across the board: book in advance, present items at the kerbside by <strong>7am</strong> on the agreed day, payment is non-refundable once made, and the service covers household items only — no DIY, commercial, industrial or trade waste, and no house clearances.</p>
+        <p>Housing Benefit and Council Tax Support claimants generally get a discounted rate if they give their benefit claim reference when booking. Commonly excluded everywhere: building/DIY materials, kitchen units, bathroom suites, plasterboard, windows, bricks, radiators, sheds, fencing.</p>
       </div>
 
-      <!-- No-JS note -->
-      <noscript>
-        <div class="ct-nojs">
-          <h2>Bins and recycling</h2>
-          <p>JavaScript is not available, so your area can't be remembered between pages — each topic page lets you choose your area again. You can also go directly to your council's bins and recycling pages:</p>
-          <ul>
-            <li><a href="https://www.cheltenham.gov.uk/bins-and-recycling">Cheltenham Borough Council — bins and recycling</a></li>
-            <li><a href="https://www.cotswold.gov.uk/bins-and-recycling">Cotswold District Council — bins and recycling</a></li>
-            <li><a href="https://www.fdean.gov.uk/bins-and-recycling">Forest of Dean District Council — bins and recycling</a></li>
-            <li><a href="https://www.gloucester.gov.uk/bins-and-recycling">Gloucester City Council — bins and recycling</a></li>
-            <li><a href="https://www.stroud.gov.uk/bins-and-recycling">Stroud District Council — bins and recycling</a></li>
-            <li><a href="https://www.tewkesbury.gov.uk/bins-and-recycling">Tewkesbury Borough Council — bins and recycling</a></li>
-          </ul>
+
+      <div id="ct-no-area" class="ct-prompt">
+        <svg aria-hidden="true" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M21 10c0 7-9 13-9 13S3 17 3 10a9 9 0 0118 0z"/><circle cx="12" cy="10" r="3"/></svg>
+        <p>Select your area above to see bulky waste collection details for your area.</p>
+      </div>
+
+      <div id="ct-content" class="ct-content" hidden>
+        <div class="ct-block ct-block--council ct-block--todo" data-council="gloucester">
+          <div class="ct-authority-card">
+            <h3>Gloucester City Council</h3>
+            <p>Book via "Book a Bulky Waste Collection" on the council's site. Nearest HRC: Hempsted.</p>
+            <p class="ct-todo">Current price per item and maximum item count are being confirmed — not captured in the source set for Gloucester.</p>
+          </div>
         </div>
-      </noscript>
+        <div class="ct-block ct-block--council" data-council="stroud">
+          <div class="ct-authority-card">
+            <h3>Stroud District Council</h3>
+            <p><strong>£25 for up to 3 items</strong>, £5 per additional item, paid by card at booking. Housing Benefit / Council Tax Support discount: £5 total for the first 3 items, £5 each additional. Only where a 3.5-tonne vehicle can access the property.</p>
+            <p>Excluded: builders waste, garage doors, commercial fridges/cookers, sheds/greenhouses, fixtures and fittings, fencing, fitted wardrobes, DIY waste, kitchen units, car parts, bathroom suites, asbestos, gas bottles, garden waste, guttering, radiators, decking, storage heaters.</p>
+            <p class="ct-authority-card__meta">Contact: recycling@stroud.gov.uk or 01453 766321 option 2.</p>
+          </div>
+        </div>
+        <div class="ct-block ct-block--council" data-council="cotswold">
+          <div class="ct-authority-card">
+            <h3>Cotswold District Council</h3>
+            <p><strong>£29 for up to 3 items</strong>, £5.50 per additional item, maximum 6 items. 50% reduction for Council Tax / Housing Benefit claimants. Not available on bank holidays.</p>
+            <p>Will collect: furniture, white goods, large electricals, outdoor equipment (bikes, non-ride-on lawnmowers, play equipment), one rolled carpet (max 15×13ft). Won't collect: kitchen units, bathroom suites, plasterboard, flooring, windows, bricks/blocks, radiators/storage heaters, sheds, DIY waste. A change in upholstered-seating disposal law means a booking may now be split into two visits.</p>
+            <p class="ct-authority-card__meta">Contact: 01285 623000.</p>
+          </div>
+        </div>
+        <div class="ct-block ct-block--council ct-block--todo" data-council="forest-of-dean">
+          <div class="ct-authority-card">
+            <h3>Forest of Dean District Council</h3>
+            <p>Booking terms match the common pattern (kerbside by 7am, no amendments once booked, no refunds). Terms are near-identical to Cotswold's, suggesting a shared service.</p>
+            <p class="ct-todo">The specific price per item is being confirmed — not captured separately in the current source set.</p>
+            <p class="ct-authority-card__meta">Contact: 01594 810000.</p>
+          </div>
+        </div>
+        <div class="ct-block ct-block--council ct-block--todo" data-council="tewkesbury">
+          <div class="ct-authority-card">
+            <h3>Tewkesbury Borough Council</h3>
+            <p class="ct-todo">Tewkesbury's bulky waste pricing and item list are being confirmed — not captured in the current source set.</p>
+          </div>
+        </div>
+        <div class="ct-block ct-block--council ct-block--todo" data-council="cheltenham">
+          <div class="ct-authority-card">
+            <h3>Cheltenham Borough Council</h3>
+            <p class="ct-todo">Cheltenham's bulky waste details are being confirmed. In the meantime, please contact Cheltenham Borough Council directly.</p>
+          </div>
+        </div>
+
+        <div class="ct-block ct-block--common">
+          <h3>Household Recycling Centres (HRCs)</h3>
+          <p>For anything that doesn't fit a bulky collection — or as a free alternative — Gloucestershire's Household Recycling Centres are run by <strong>Gloucestershire County Council</strong>, not the district or city councils, so the same network serves everyone regardless of who collects their bins:</p>
+          <ul>
+            <li><strong>Hempsted</strong> — serves Gloucester</li>
+            <li><strong>Wingmoor Farm</strong>, near Bishop's Cleeve — serves Tewkesbury; also processes garden waste by open windrow composting</li>
+            <li><strong>Oak Quarry and Hempsted</strong> — Forest of Dean residents are directed to both</li>
+            <li><strong>Pyke Quarry, Horsley, and Hempsted</strong> — Stroud residents</li>
+          </ul>
+          <p>Asbestos in small household quantities can be taken to an HRC but must be booked in advance. Find your nearest site and book where required via gloucestershirerecycles.com.</p>
+        </div>
+
+      </div><!-- /ct-content -->
 
     </div><!-- /ct-layout -->
   </main>
 
-  <!-- Pre-footer social / newsletter strip -->
   <section class="prefooter" aria-label="Stay connected">
     <div class="container prefooter__inner">
       <div class="prefooter__social">
@@ -242,7 +252,7 @@
   </footer>
 
   <script src="../area-cookie.js"></script>
-  <script src="waste-landing.js"></script>
+  <script src="topic-page.js"></script>
   <script>
     (function () {
       var btn = document.querySelector('.nav-toggle');

--- a/LGR/Consolidated/waste-food-waste.html
+++ b/LGR/Consolidated/waste-food-waste.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Bins and recycling – Newstershire Council</title>
+  <title>Food waste – Bins and recycling – Newstershire Council</title>
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="council-tax.css">
 </head>
@@ -11,7 +11,6 @@
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
 
-  <!-- Top utility bar -->
   <div class="utility-bar">
     <div class="container utility-bar__inner">
       <span class="utility-bar__item">
@@ -56,29 +55,29 @@
     </div>
   </header>
 
-  <!-- Breadcrumb -->
   <nav class="breadcrumb" aria-label="Breadcrumb">
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
         <li><a href="#">Residents</a></li>
-        <li aria-current="page">Bins and recycling</li>
+        <li><a href="waste.html">Bins and recycling</a></li>
+        <li aria-current="page">Food waste</li>
       </ol>
     </div>
   </nav>
 
-  <!-- Page hero -->
-  <section class="ct-hero" aria-label="Bins and recycling">
+  <section class="ct-hero" aria-label="General waste">
     <div class="container">
-      <h1 class="ct-hero__title">Bins and recycling</h1>
-      <p class="ct-hero__sub">Bin colours, collection days and what goes where are set locally and still differ across the county. Choose your area, then pick a topic below.</p>
+      <h1 class="ct-hero__title">Food waste</h1>
+      <p class="ct-hero__sub">Weekly caddy collections, what's accepted, and why food waste must never go in the garden bin.</p>
     </div>
   </section>
 
   <main id="main-content">
     <div class="container ct-layout">
 
-      <!-- Area picker -->
+      <p class="ct-back"><a href="waste.html">&larr; All bins and recycling topics</a></p>
+
       <div class="ct-picker-wrap">
         <div class="ct-picker">
           <label for="ct-area-select" class="ct-picker__label">
@@ -98,68 +97,66 @@
         <p id="ct-area-label" class="ct-area-label" aria-live="polite" hidden></p>
       </div>
 
-      <!-- Topic tiles -->
-      <h2 class="section-title">Choose a topic</h2>
-      <p class="page-intro">Your selected area is remembered as you move between these pages.</p>
-      <div class="service-tiles" aria-label="Bins and recycling topics">
-
-        <a href="waste-general-waste.html" class="service-tile service-tile--link">
-          <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v6M14 11v6"/><path d="M9 6V4h6v2"/></svg>
-          <span class="service-tile__title">General waste</span>
-          <span class="service-tile__desc">What goes in your refuse bin, collection frequency and extra capacity</span>
-          <span class="service-tile__cta" aria-hidden="true">View →</span>
-        </a>
-
-        <a href="waste-recycling.html" class="service-tile service-tile--link">
-          <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><polyline points="7 4 4 7 7 10"/><path d="M4 7h11a4 4 0 013.5 6"/><polyline points="17 20 20 17 17 14"/><path d="M20 17H9a4 4 0 01-3.5-6"/></svg>
-          <span class="service-tile__title">Recycling</span>
-          <span class="service-tile__desc">Boxes, bags and bins, and what each stream accepts in your area</span>
-          <span class="service-tile__cta" aria-hidden="true">View →</span>
-        </a>
-
-        <a href="waste-food-waste.html" class="service-tile service-tile--link">
-          <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M6 2v6a3 3 0 006 0V2"/><path d="M9 2v20"/><path d="M17 2c-1.5 0-3 1.5-3 4v6h3"/><path d="M17 12v10"/></svg>
-          <span class="service-tile__title">Food waste</span>
-          <span class="service-tile__desc">Weekly caddy collection, what's accepted and why it can't go in garden waste</span>
-          <span class="service-tile__cta" aria-hidden="true">View →</span>
-        </a>
-
-        <a href="waste-garden-waste.html" class="service-tile service-tile--link">
-          <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M12 22V11"/><path d="M12 11c0-4 3-7 8-7 0 4-3 7-8 7z"/><path d="M12 14C12 10 9 8 4 8c0 4 3 6 8 6z"/></svg>
-          <span class="service-tile__title">Garden waste</span>
-          <span class="service-tile__desc">The opt-in paid subscription, prices and season in your area</span>
-          <span class="service-tile__cta" aria-hidden="true">View →</span>
-        </a>
-
-        <a href="waste-bulky.html" class="service-tile service-tile--link">
-          <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><rect x="3" y="10" width="18" height="10" rx="1"/><path d="M6 10V7a3 3 0 013-3h6a3 3 0 013 3v3"/><path d="M9 14h6"/></svg>
-          <span class="service-tile__title">Bulky waste &amp; centres</span>
-          <span class="service-tile__desc">Booking a large-item collection and finding your Household Recycling Centre</span>
-          <span class="service-tile__cta" aria-hidden="true">View →</span>
-        </a>
-
+      <div class="ct-block ct-block--common">
+        <p>Food waste is collected <strong>weekly everywhere</strong> — this is the one collection where all five councils run the same frequency, even though recycling and general waste cycles differ. A small kitchen caddy is for day-to-day use indoors; it gets emptied into a larger outdoor caddy or bin for collection.</p>
+        <p>Food waste must <strong>never</strong> go in the garden waste bin. Garden waste is composted in the open air, and contamination from food or animal waste risks spreading bacteria behind outbreaks like BSE and foot-and-mouth — open windrow composting can't safely process it the way an anaerobic digester can. Collected food waste is generally sent to anaerobic digestion, producing biogas and a fertiliser by-product.</p>
+        <p>Pet waste, animal bedding, animal carcasses, nappies, packaging, metal and glass are excluded everywhere.</p>
       </div>
 
-      <!-- No-JS note -->
-      <noscript>
-        <div class="ct-nojs">
-          <h2>Bins and recycling</h2>
-          <p>JavaScript is not available, so your area can't be remembered between pages — each topic page lets you choose your area again. You can also go directly to your council's bins and recycling pages:</p>
-          <ul>
-            <li><a href="https://www.cheltenham.gov.uk/bins-and-recycling">Cheltenham Borough Council — bins and recycling</a></li>
-            <li><a href="https://www.cotswold.gov.uk/bins-and-recycling">Cotswold District Council — bins and recycling</a></li>
-            <li><a href="https://www.fdean.gov.uk/bins-and-recycling">Forest of Dean District Council — bins and recycling</a></li>
-            <li><a href="https://www.gloucester.gov.uk/bins-and-recycling">Gloucester City Council — bins and recycling</a></li>
-            <li><a href="https://www.stroud.gov.uk/bins-and-recycling">Stroud District Council — bins and recycling</a></li>
-            <li><a href="https://www.tewkesbury.gov.uk/bins-and-recycling">Tewkesbury Borough Council — bins and recycling</a></li>
-          </ul>
+
+      <div id="ct-no-area" class="ct-prompt">
+        <svg aria-hidden="true" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M21 10c0 7-9 13-9 13S3 17 3 10a9 9 0 0118 0z"/><circle cx="12" cy="10" r="3"/></svg>
+        <p>Select your area above to see the food waste arrangements that apply to you.</p>
+      </div>
+
+      <div id="ct-content" class="ct-content" hidden>
+        <div class="ct-block ct-block--council ct-block--todo" data-council="gloucester">
+          <div class="ct-authority-card">
+            <h3>Gloucester City Council</h3>
+            <p>Large outdoor food caddy plus a small indoor caddy.</p>
+            <p class="ct-todo">Gloucester's specific accepted / not-accepted list is being confirmed — the dedicated food waste page wasn't fully captured in the current source set.</p>
+          </div>
         </div>
-      </noscript>
+        <div class="ct-block ct-block--council" data-council="stroud">
+          <div class="ct-authority-card">
+            <h3>Stroud District Council</h3>
+            <p>Grey food bin (sealed) plus an indoor kitchen caddy; collected weekly on the same day as refuse or recycling. Can be lined with plastic bags, bin liners, biodegradable bags or newspaper. Small batteries and vapes are now also collected weekly alongside food waste.</p>
+            <p>Accepted: all cooked and raw food, meat and fish bones, pet food, tea bags, coffee grounds, food packaging. Not accepted: animal waste, pet bedding, nappies, garden waste.</p>
+          </div>
+        </div>
+        <div class="ct-block ct-block--council" data-council="cotswold">
+          <div class="ct-authority-card">
+            <h3>Cotswold District Council</h3>
+            <p>Kitchen caddy, emptied weekly. Accepted: uneaten food and plate scrapings, mouldy or out-of-date food, eggshells, small amounts of liquid/oil/fat including solid fats, tea bags, coffee grounds, newspaper or approved compostable liners, cat and dog food, animal hair, used kitchen roll and tissues.</p>
+            <p>Not accepted: plastic (except carrier/food/sandwich bags used as liners), packaging, metal, glass, other household waste, animal faeces, animal bedding, pet litter, pet/animal carcasses, cardboard, nappies.</p>
+          </div>
+        </div>
+        <div class="ct-block ct-block--council" data-council="forest-of-dean">
+          <div class="ct-authority-card">
+            <h3>Forest of Dean District Council</h3>
+            <p>Two containers: a 7-litre kitchen caddy and a 23-litre lidded outdoor bin — the largest outdoor capacity of the five councils' published figures. Collected weekly, out by 7am. Can be lined with plastic bags, compostable liners or newspaper.</p>
+            <p>Accepted: fish, meat and bones (raw or cooked), dairy, hard fats and lard, tea bags, coffee grounds, fruit and veg peelings, cereals, bread, pastries, rice, pasta, stale/out-of-date food (packaging removed), uneaten pet food, plate scrapings, kitchen towels. Not accepted: packaging/pots/punnets/film, large quantities of oil, dead animals, garden waste, animal bedding and litter, animal/pet faeces.</p>
+          </div>
+        </div>
+        <div class="ct-block ct-block--council" data-council="tewkesbury">
+          <div class="ct-authority-card">
+            <h3>Tewkesbury Borough Council</h3>
+            <p>Kitchen caddy lined with compostable liners, paper, or old carrier/bread/sandwich bags; emptied weekly, dishwasher-proof. Accepted: all uneaten food and plate scrapings, mouldy or out-of-date food, eggs and eggshells, small amounts of liquids/oil/fat including solid fats, tea bags, coffee grounds, cat and dog food, used kitchen roll and tissues, meat and fish bones, fruit stones.</p>
+            <p>Not accepted: plastic other than the bag types used as liners, packaging (including foil trays), metal and glass, other household waste, animal faeces, animal bedding, pet litter, pet/animal carcasses, cardboard, nappies.</p>
+          </div>
+        </div>
+        <div class="ct-block ct-block--council ct-block--todo" data-council="cheltenham">
+          <div class="ct-authority-card">
+            <h3>Cheltenham Borough Council</h3>
+            <p class="ct-todo">Cheltenham's food waste details are being confirmed. In the meantime, please contact Cheltenham Borough Council directly.</p>
+          </div>
+        </div>
+
+      </div><!-- /ct-content -->
 
     </div><!-- /ct-layout -->
   </main>
 
-  <!-- Pre-footer social / newsletter strip -->
   <section class="prefooter" aria-label="Stay connected">
     <div class="container prefooter__inner">
       <div class="prefooter__social">
@@ -242,7 +239,7 @@
   </footer>
 
   <script src="../area-cookie.js"></script>
-  <script src="waste-landing.js"></script>
+  <script src="topic-page.js"></script>
   <script>
     (function () {
       var btn = document.querySelector('.nav-toggle');

--- a/LGR/Consolidated/waste-garden-waste.html
+++ b/LGR/Consolidated/waste-garden-waste.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Bins and recycling – Newstershire Council</title>
+  <title>Garden waste – Bins and recycling – Newstershire Council</title>
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="council-tax.css">
 </head>
@@ -11,7 +11,6 @@
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
 
-  <!-- Top utility bar -->
   <div class="utility-bar">
     <div class="container utility-bar__inner">
       <span class="utility-bar__item">
@@ -56,29 +55,29 @@
     </div>
   </header>
 
-  <!-- Breadcrumb -->
   <nav class="breadcrumb" aria-label="Breadcrumb">
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
         <li><a href="#">Residents</a></li>
-        <li aria-current="page">Bins and recycling</li>
+        <li><a href="waste.html">Bins and recycling</a></li>
+        <li aria-current="page">Garden waste</li>
       </ol>
     </div>
   </nav>
 
-  <!-- Page hero -->
-  <section class="ct-hero" aria-label="Bins and recycling">
+  <section class="ct-hero" aria-label="General waste">
     <div class="container">
-      <h1 class="ct-hero__title">Bins and recycling</h1>
-      <p class="ct-hero__sub">Bin colours, collection days and what goes where are set locally and still differ across the county. Choose your area, then pick a topic below.</p>
+      <h1 class="ct-hero__title">Garden waste</h1>
+      <p class="ct-hero__sub">An opt-in paid subscription everywhere — select your area for prices, container and season.</p>
     </div>
   </section>
 
   <main id="main-content">
     <div class="container ct-layout">
 
-      <!-- Area picker -->
+      <p class="ct-back"><a href="waste.html">&larr; All bins and recycling topics</a></p>
+
       <div class="ct-picker-wrap">
         <div class="ct-picker">
           <label for="ct-area-select" class="ct-picker__label">
@@ -98,68 +97,65 @@
         <p id="ct-area-label" class="ct-area-label" aria-live="polite" hidden></p>
       </div>
 
-      <!-- Topic tiles -->
-      <h2 class="section-title">Choose a topic</h2>
-      <p class="page-intro">Your selected area is remembered as you move between these pages.</p>
-      <div class="service-tiles" aria-label="Bins and recycling topics">
-
-        <a href="waste-general-waste.html" class="service-tile service-tile--link">
-          <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v6M14 11v6"/><path d="M9 6V4h6v2"/></svg>
-          <span class="service-tile__title">General waste</span>
-          <span class="service-tile__desc">What goes in your refuse bin, collection frequency and extra capacity</span>
-          <span class="service-tile__cta" aria-hidden="true">View →</span>
-        </a>
-
-        <a href="waste-recycling.html" class="service-tile service-tile--link">
-          <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><polyline points="7 4 4 7 7 10"/><path d="M4 7h11a4 4 0 013.5 6"/><polyline points="17 20 20 17 17 14"/><path d="M20 17H9a4 4 0 01-3.5-6"/></svg>
-          <span class="service-tile__title">Recycling</span>
-          <span class="service-tile__desc">Boxes, bags and bins, and what each stream accepts in your area</span>
-          <span class="service-tile__cta" aria-hidden="true">View →</span>
-        </a>
-
-        <a href="waste-food-waste.html" class="service-tile service-tile--link">
-          <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M6 2v6a3 3 0 006 0V2"/><path d="M9 2v20"/><path d="M17 2c-1.5 0-3 1.5-3 4v6h3"/><path d="M17 12v10"/></svg>
-          <span class="service-tile__title">Food waste</span>
-          <span class="service-tile__desc">Weekly caddy collection, what's accepted and why it can't go in garden waste</span>
-          <span class="service-tile__cta" aria-hidden="true">View →</span>
-        </a>
-
-        <a href="waste-garden-waste.html" class="service-tile service-tile--link">
-          <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M12 22V11"/><path d="M12 11c0-4 3-7 8-7 0 4-3 7-8 7z"/><path d="M12 14C12 10 9 8 4 8c0 4 3 6 8 6z"/></svg>
-          <span class="service-tile__title">Garden waste</span>
-          <span class="service-tile__desc">The opt-in paid subscription, prices and season in your area</span>
-          <span class="service-tile__cta" aria-hidden="true">View →</span>
-        </a>
-
-        <a href="waste-bulky.html" class="service-tile service-tile--link">
-          <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><rect x="3" y="10" width="18" height="10" rx="1"/><path d="M6 10V7a3 3 0 013-3h6a3 3 0 013 3v3"/><path d="M9 14h6"/></svg>
-          <span class="service-tile__title">Bulky waste &amp; centres</span>
-          <span class="service-tile__desc">Booking a large-item collection and finding your Household Recycling Centre</span>
-          <span class="service-tile__cta" aria-hidden="true">View →</span>
-        </a>
-
+      <div class="ct-block ct-block--common">
+        <p>Garden waste collection is an <strong>opt-in, paid subscription</strong> everywhere in Gloucestershire — it isn't part of the standard council tax-funded service. Subscriptions typically run on an annual cycle (commonly 1 April to 31 March), collected fortnightly through the growing season, and councils generally state there's no refund for cancelling partway through, or for individual missed collections.</p>
+        <p>Accepted material is broadly consistent: grass cuttings, hedge/shrub clippings, plants, leaves, twigs and small branches, weeds. It's generally composted by open windrow, with some compost used to restore old landfill sites and the rest sold to farmers.</p>
+        <p>Universally excluded: food waste, soil and rubble in any quantity, plastic bags/pots/seed trays, animal faeces and bedding, chemicals/pesticides/herbicides, and invasive weeds like Japanese knotweed and ragwort.</p>
       </div>
 
-      <!-- No-JS note -->
-      <noscript>
-        <div class="ct-nojs">
-          <h2>Bins and recycling</h2>
-          <p>JavaScript is not available, so your area can't be remembered between pages — each topic page lets you choose your area again. You can also go directly to your council's bins and recycling pages:</p>
-          <ul>
-            <li><a href="https://www.cheltenham.gov.uk/bins-and-recycling">Cheltenham Borough Council — bins and recycling</a></li>
-            <li><a href="https://www.cotswold.gov.uk/bins-and-recycling">Cotswold District Council — bins and recycling</a></li>
-            <li><a href="https://www.fdean.gov.uk/bins-and-recycling">Forest of Dean District Council — bins and recycling</a></li>
-            <li><a href="https://www.gloucester.gov.uk/bins-and-recycling">Gloucester City Council — bins and recycling</a></li>
-            <li><a href="https://www.stroud.gov.uk/bins-and-recycling">Stroud District Council — bins and recycling</a></li>
-            <li><a href="https://www.tewkesbury.gov.uk/bins-and-recycling">Tewkesbury Borough Council — bins and recycling</a></li>
-          </ul>
+
+      <div id="ct-no-area" class="ct-prompt">
+        <svg aria-hidden="true" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M21 10c0 7-9 13-9 13S3 17 3 10a9 9 0 0118 0z"/><circle cx="12" cy="10" r="3"/></svg>
+        <p>Select your area above to see the garden waste subscription that applies to you.</p>
+      </div>
+
+      <div id="ct-content" class="ct-content" hidden>
+        <div class="ct-block ct-block--council ct-block--todo" data-council="gloucester">
+          <div class="ct-authority-card">
+            <h3>Gloucester City Council</h3>
+            <p class="ct-todo">Gloucester's garden waste subscription price, container type and collection season are being confirmed — the content wasn't captured in the current source set.</p>
+          </div>
         </div>
-      </noscript>
+        <div class="ct-block ct-block--council" data-council="stroud">
+          <div class="ct-authority-card">
+            <h3>Stroud District Council</h3>
+            <p>Two options: a 180-litre brown wheeled bin at <strong>£58.50</strong>, or a bag subscription (for narrow-access properties) at <strong>£48</strong> for 2026 — a reduced rate reflecting the later start date. Bag subscribers get 50 compostable sacks total (25 upfront, 25 more once down to six), can present up to two sacks per collection, and must pre-book each slot.</p>
+            <p>Season February to end of November, fortnightly; renewal each February. Crew-applied bin tags are a visual aid only — collections continue even if a bin isn't yet tagged. Lost or stolen bins aren't replaced free of charge.</p>
+          </div>
+        </div>
+        <div class="ct-block ct-block--council ct-block--todo" data-council="cotswold">
+          <div class="ct-authority-card">
+            <h3>Cotswold District Council</h3>
+            <p>Annual licence required, displayed on the bin; non-transferable if you move (leave it at the property). Council Tax and Housing Benefit claimants get a <strong>50% licence fee reduction</strong> if they provide their benefit reference at sign-up. Service paused two weeks over Christmas/New Year.</p>
+            <p class="ct-todo">The exact subscription price is being confirmed — it wasn't captured separately from Forest of Dean's near-identical shared-service terms.</p>
+          </div>
+        </div>
+        <div class="ct-block ct-block--council" data-council="forest-of-dean">
+          <div class="ct-authority-card">
+            <h3>Forest of Dean District Council</h3>
+            <p>Annual licence, 1 April to 31 March, displayed beneath the bin handles. Sacks available (50 per licence) where a bin can't be accommodated, following assessment. The service can't be used by a gardener or grounds-maintenance company on a householder's behalf. Bins remain council property. Suspended over Christmas/New Year.</p>
+          </div>
+        </div>
+        <div class="ct-block ct-block--council" data-council="tewkesbury">
+          <div class="ct-authority-card">
+            <h3>Tewkesbury Borough Council</h3>
+            <p>"Garden waste club" — membership year runs 1 April to 31 March, brown wheelie bin, fortnightly. No branded stickers any more; residents write their address on the bin in marker pen so crews can identify it. 14-day cooling-off period; refunds outside that window are at the council's discretion. No collections over the two-week Christmas/New Year period.</p>
+            <p>Processed by open windrow composting at the Enovert site next to Wingmoor Farm HRC near Bishop's Cleeve — about a third of the compost restores old landfill on site, the rest is sold to farmers.</p>
+            <p class="ct-authority-card__meta">Contact: recycling@tewkesbury.gov.uk, 01684 295010.</p>
+          </div>
+        </div>
+        <div class="ct-block ct-block--council ct-block--todo" data-council="cheltenham">
+          <div class="ct-authority-card">
+            <h3>Cheltenham Borough Council</h3>
+            <p class="ct-todo">Cheltenham's garden waste details are being confirmed. In the meantime, please contact Cheltenham Borough Council directly.</p>
+          </div>
+        </div>
+
+      </div><!-- /ct-content -->
 
     </div><!-- /ct-layout -->
   </main>
 
-  <!-- Pre-footer social / newsletter strip -->
   <section class="prefooter" aria-label="Stay connected">
     <div class="container prefooter__inner">
       <div class="prefooter__social">
@@ -242,7 +238,7 @@
   </footer>
 
   <script src="../area-cookie.js"></script>
-  <script src="waste-landing.js"></script>
+  <script src="topic-page.js"></script>
   <script>
     (function () {
       var btn = document.querySelector('.nav-toggle');

--- a/LGR/Consolidated/waste-general-waste.html
+++ b/LGR/Consolidated/waste-general-waste.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Bins and recycling – Newstershire Council</title>
+  <title>General waste – Bins and recycling – Newstershire Council</title>
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="council-tax.css">
 </head>
@@ -11,7 +11,6 @@
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
 
-  <!-- Top utility bar -->
   <div class="utility-bar">
     <div class="container utility-bar__inner">
       <span class="utility-bar__item">
@@ -56,29 +55,29 @@
     </div>
   </header>
 
-  <!-- Breadcrumb -->
   <nav class="breadcrumb" aria-label="Breadcrumb">
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
         <li><a href="#">Residents</a></li>
-        <li aria-current="page">Bins and recycling</li>
+        <li><a href="waste.html">Bins and recycling</a></li>
+        <li aria-current="page">General waste</li>
       </ol>
     </div>
   </nav>
 
-  <!-- Page hero -->
-  <section class="ct-hero" aria-label="Bins and recycling">
+  <section class="ct-hero" aria-label="General waste">
     <div class="container">
-      <h1 class="ct-hero__title">Bins and recycling</h1>
-      <p class="ct-hero__sub">Bin colours, collection days and what goes where are set locally and still differ across the county. Choose your area, then pick a topic below.</p>
+      <h1 class="ct-hero__title">General waste (refuse)</h1>
+      <p class="ct-hero__sub">What goes in your refuse bin, how often it's collected and when you can get extra capacity — select your area for local details.</p>
     </div>
   </section>
 
   <main id="main-content">
     <div class="container ct-layout">
 
-      <!-- Area picker -->
+      <p class="ct-back"><a href="waste.html">&larr; All bins and recycling topics</a></p>
+
       <div class="ct-picker-wrap">
         <div class="ct-picker">
           <label for="ct-area-select" class="ct-picker__label">
@@ -98,68 +97,79 @@
         <p id="ct-area-label" class="ct-area-label" aria-live="polite" hidden></p>
       </div>
 
-      <!-- Topic tiles -->
-      <h2 class="section-title">Choose a topic</h2>
-      <p class="page-intro">Your selected area is remembered as you move between these pages.</p>
-      <div class="service-tiles" aria-label="Bins and recycling topics">
-
-        <a href="waste-general-waste.html" class="service-tile service-tile--link">
-          <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v6M14 11v6"/><path d="M9 6V4h6v2"/></svg>
-          <span class="service-tile__title">General waste</span>
-          <span class="service-tile__desc">What goes in your refuse bin, collection frequency and extra capacity</span>
-          <span class="service-tile__cta" aria-hidden="true">View →</span>
-        </a>
-
-        <a href="waste-recycling.html" class="service-tile service-tile--link">
-          <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><polyline points="7 4 4 7 7 10"/><path d="M4 7h11a4 4 0 013.5 6"/><polyline points="17 20 20 17 17 14"/><path d="M20 17H9a4 4 0 01-3.5-6"/></svg>
-          <span class="service-tile__title">Recycling</span>
-          <span class="service-tile__desc">Boxes, bags and bins, and what each stream accepts in your area</span>
-          <span class="service-tile__cta" aria-hidden="true">View →</span>
-        </a>
-
-        <a href="waste-food-waste.html" class="service-tile service-tile--link">
-          <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M6 2v6a3 3 0 006 0V2"/><path d="M9 2v20"/><path d="M17 2c-1.5 0-3 1.5-3 4v6h3"/><path d="M17 12v10"/></svg>
-          <span class="service-tile__title">Food waste</span>
-          <span class="service-tile__desc">Weekly caddy collection, what's accepted and why it can't go in garden waste</span>
-          <span class="service-tile__cta" aria-hidden="true">View →</span>
-        </a>
-
-        <a href="waste-garden-waste.html" class="service-tile service-tile--link">
-          <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M12 22V11"/><path d="M12 11c0-4 3-7 8-7 0 4-3 7-8 7z"/><path d="M12 14C12 10 9 8 4 8c0 4 3 6 8 6z"/></svg>
-          <span class="service-tile__title">Garden waste</span>
-          <span class="service-tile__desc">The opt-in paid subscription, prices and season in your area</span>
-          <span class="service-tile__cta" aria-hidden="true">View →</span>
-        </a>
-
-        <a href="waste-bulky.html" class="service-tile service-tile--link">
-          <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><rect x="3" y="10" width="18" height="10" rx="1"/><path d="M6 10V7a3 3 0 013-3h6a3 3 0 013 3v3"/><path d="M9 14h6"/></svg>
-          <span class="service-tile__title">Bulky waste &amp; centres</span>
-          <span class="service-tile__desc">Booking a large-item collection and finding your Household Recycling Centre</span>
-          <span class="service-tile__cta" aria-hidden="true">View →</span>
-        </a>
-
+      <div class="ct-block ct-block--common">
+        <p>General waste is for rubbish that can't be recycled or composted. It's collected every two weeks everywhere in Gloucestershire, on the opposite week to recycling.</p>
+        <p>The same things are kept out of general waste everywhere, for the same reasons:</p>
+        <ul>
+          <li>Garden waste and anything recyclable at the kerbside — it belongs in the other bins</li>
+          <li>Liquids like paint and oil — illegal to bin, and costly to clean up if spilled</li>
+          <li>Building or DIY waste, rubble, soil, plasterboard — take these to a Household Recycling Centre (plasterboard specifically can't go to landfill)</li>
+          <li>Trade waste, even if you run a business from home</li>
+          <li>Hot ashes (let them cool first) and sharp objects (double-wrap and use a rigid container)</li>
+        </ul>
+        <p>If a property can't take a wheeled bin — flats, mainly — councils issue refuse sacks instead, usually after an assessment. Extra capacity beyond the standard bin is generally only available for larger households (commonly five or more people) or on medical grounds, assessed case by case.</p>
       </div>
 
-      <!-- No-JS note -->
-      <noscript>
-        <div class="ct-nojs">
-          <h2>Bins and recycling</h2>
-          <p>JavaScript is not available, so your area can't be remembered between pages — each topic page lets you choose your area again. You can also go directly to your council's bins and recycling pages:</p>
-          <ul>
-            <li><a href="https://www.cheltenham.gov.uk/bins-and-recycling">Cheltenham Borough Council — bins and recycling</a></li>
-            <li><a href="https://www.cotswold.gov.uk/bins-and-recycling">Cotswold District Council — bins and recycling</a></li>
-            <li><a href="https://www.fdean.gov.uk/bins-and-recycling">Forest of Dean District Council — bins and recycling</a></li>
-            <li><a href="https://www.gloucester.gov.uk/bins-and-recycling">Gloucester City Council — bins and recycling</a></li>
-            <li><a href="https://www.stroud.gov.uk/bins-and-recycling">Stroud District Council — bins and recycling</a></li>
-            <li><a href="https://www.tewkesbury.gov.uk/bins-and-recycling">Tewkesbury Borough Council — bins and recycling</a></li>
-          </ul>
+      <div id="ct-no-area" class="ct-prompt">
+        <svg aria-hidden="true" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M21 10c0 7-9 13-9 13S3 17 3 10a9 9 0 0118 0z"/><circle cx="12" cy="10" r="3"/></svg>
+        <p>Select your area above to see the general waste arrangements that apply to you.</p>
+      </div>
+
+      <div id="ct-content" class="ct-content" hidden>
+        <div class="ct-block ct-block--council" data-council="gloucester">
+          <div class="ct-authority-card">
+            <h3>Gloucester City Council</h3>
+            <p>Black bin or council-issued domestic sack. Out by <strong>7am</strong> on collection day; remove from the highway by end of day.</p>
+            <ul>
+              <li>Replacement refuse sack £5, small bin £16.50, standard bin £25, large bin (where authorised) £55</li>
+              <li>Flats without communal facilities (typically 6 or fewer) get a 140L bin per flat</li>
+            </ul>
+            <p class="ct-authority-card__meta">Contact: 01452 396 396.</p>
+          </div>
         </div>
-      </noscript>
+        <div class="ct-block ct-block--council" data-council="stroud">
+          <div class="ct-authority-card">
+            <h3>Stroud District Council</h3>
+            <p>Grey wheelie bin or beige bags, collected every two weeks, opposite week to recycling. Present by <strong>6am</strong>.</p>
+            <p>There's no smaller or bigger grey bin option — the council decided that swapping bins as household sizes change isn't sustainable. Not accepted: cling film, bubble wrap, polystyrene, crisp packets, sanitary products, nappies, bagged pet waste, vacuum dust, rubble, garden waste/soil, batteries/vapes (these go weekly with food waste), clinical/hazardous waste, DIY materials, electricals, business waste, car parts, furniture. Residual waste goes to the Javelin Park Waste to Energy facility.</p>
+            <p class="ct-authority-card__meta">Replacement bin: customer.services@stroud.gov.uk or 01453 766321.</p>
+          </div>
+        </div>
+        <div class="ct-block ct-block--council" data-council="cotswold">
+          <div class="ct-authority-card">
+            <h3>Cotswold District Council</h3>
+            <p>Grey wheelie bin, collected every two weeks. Out by <strong>7am</strong> (6am during exceptional hot-weather early starts).</p>
+            <p>Not accepted: stones/gravel/rubble, garden waste/soil, sharp objects, hot ashes, DIY waste, carpet and underlay, trade or building waste. Extra rubbish: beige sacks, 84p each, from council offices. An extra bin or sacks are possible for households of more than five, or with children in nappies.</p>
+          </div>
+        </div>
+        <div class="ct-block ct-block--council" data-council="forest-of-dean">
+          <div class="ct-authority-card">
+            <h3>Forest of Dean District Council</h3>
+            <p>Black wheelie bin, collected every two weeks, out by <strong>7am</strong>, lid closed; rubbish can be loose or bagged inside the bin, but no sacks left beside it.</p>
+            <p>Unusually, general waste here <em>accepts</em> several things not recyclable elsewhere: nappies and sanitary products, polystyrene, crisp/sweet packets, bagged dog/cat waste, foil-lined food pouches and plastic films. Not accepted: garden waste, anything kerbside-recyclable (including food waste), liquids, trade waste, building/DIY waste/rubble/soil/plasterboard, household asbestos (book the Recycling Centre instead), hot ashes.</p>
+            <p>Flats unsuited to a wheelie bin get 80 beige refuse sacks a year, or a communal bin, following assessment. Extra beige sacks £10 a roll. Extra bin: household of 6+, medical reasons, or a large household with children in nappies.</p>
+            <p class="ct-authority-card__meta">Apply via 01594 810000.</p>
+          </div>
+        </div>
+        <div class="ct-block ct-block--council" data-council="tewkesbury">
+          <div class="ct-authority-card">
+            <h3>Tewkesbury Borough Council</h3>
+            <p>Green refuse bin, collected every two weeks, out by <strong>7am</strong>. From mid-September 2025, new and replacement bins are <strong>140 litres</strong> (down from 180L) — part of a "small on waste, big on recycling" policy, after county-wide analysis found roughly a quarter of household waste was food and another 23% recyclable plastic, paper and card.</p>
+            <p>Not accepted: batteries, vapes (supermarkets/HRCs instead), stones/gravel/rubble, garden waste/soil, sharp objects, DIY waste, carpet/underlay, commercial waste, paint/chemicals, clinical waste. Extra 140L bin: chargeable for households of 5+ who've maximised recycling; free on medical grounds. No extra bins for nappy waste — the Gloucestershire Real Nappy Project offers a £30 voucher towards reusable nappies instead.</p>
+            <p>On the narrow-access round (smaller vehicles), general waste goes in a reusable black sack — rubbish must be bagged inside it, not loose, as crews pull it out by hand.</p>
+          </div>
+        </div>
+        <div class="ct-block ct-block--council ct-block--todo" data-council="cheltenham">
+          <div class="ct-authority-card">
+            <h3>Cheltenham Borough Council</h3>
+            <p class="ct-todo">Cheltenham's bin and collection details are being confirmed. In the meantime, please contact Cheltenham Borough Council directly.</p>
+          </div>
+        </div>
+      </div><!-- /ct-content -->
 
     </div><!-- /ct-layout -->
   </main>
 
-  <!-- Pre-footer social / newsletter strip -->
   <section class="prefooter" aria-label="Stay connected">
     <div class="container prefooter__inner">
       <div class="prefooter__social">
@@ -242,7 +252,7 @@
   </footer>
 
   <script src="../area-cookie.js"></script>
-  <script src="waste-landing.js"></script>
+  <script src="topic-page.js"></script>
   <script>
     (function () {
       var btn = document.querySelector('.nav-toggle');

--- a/LGR/Consolidated/waste-landing.js
+++ b/LGR/Consolidated/waste-landing.js
@@ -1,0 +1,47 @@
+/* Bins & recycling landing page — area selector only.
+   Stores the chosen area in the shared cookie so the topic detail pages
+   (waste-*.html, powered by topic-page.js) open pre-filtered. */
+(function () {
+  'use strict';
+
+  var select    = document.getElementById('ct-area-select');
+  var areaLabel = document.getElementById('ct-area-label');
+  if (!select) return;
+
+  var AREA_NAMES = {
+    'cheltenham':    'Cheltenham Borough Council',
+    'cotswold':      'Cotswold District Council',
+    'forest-of-dean':'Forest of Dean District Council',
+    'gloucester':    'Gloucester City Council',
+    'stroud':        'Stroud District Council',
+    'tewkesbury':    'Tewkesbury Borough Council'
+  };
+
+  function showLabel(area) {
+    if (area && AREA_NAMES[area]) {
+      areaLabel.textContent = 'Showing information for: ' + AREA_NAMES[area];
+      areaLabel.hidden = false;
+    } else {
+      areaLabel.hidden = true;
+    }
+  }
+
+  select.addEventListener('change', function () {
+    var area = select.value;
+    if (!area) {
+      if (typeof LGRArea !== 'undefined') LGRArea.clear();
+      showLabel('');
+      return;
+    }
+    if (typeof LGRArea !== 'undefined') LGRArea.set(area);
+    showLabel(area);
+  });
+
+  // Restore from cookie on load
+  var saved = typeof LGRArea !== 'undefined' && LGRArea.get();
+  if (saved && AREA_NAMES[saved]) {
+    select.value = saved;
+    showLabel(saved);
+  }
+
+}());

--- a/LGR/Consolidated/waste-recycling.html
+++ b/LGR/Consolidated/waste-recycling.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Bins and recycling – Newstershire Council</title>
+  <title>Recycling – Bins and recycling – Newstershire Council</title>
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="council-tax.css">
 </head>
@@ -11,7 +11,6 @@
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
 
-  <!-- Top utility bar -->
   <div class="utility-bar">
     <div class="container utility-bar__inner">
       <span class="utility-bar__item">
@@ -56,29 +55,29 @@
     </div>
   </header>
 
-  <!-- Breadcrumb -->
   <nav class="breadcrumb" aria-label="Breadcrumb">
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
         <li><a href="#">Residents</a></li>
-        <li aria-current="page">Bins and recycling</li>
+        <li><a href="waste.html">Bins and recycling</a></li>
+        <li aria-current="page">Recycling</li>
       </ol>
     </div>
   </nav>
 
-  <!-- Page hero -->
-  <section class="ct-hero" aria-label="Bins and recycling">
+  <section class="ct-hero" aria-label="General waste">
     <div class="container">
-      <h1 class="ct-hero__title">Bins and recycling</h1>
-      <p class="ct-hero__sub">Bin colours, collection days and what goes where are set locally and still differ across the county. Choose your area, then pick a topic below.</p>
+      <h1 class="ct-hero__title">Recycling</h1>
+      <p class="ct-hero__sub">Boxes, bags and bins differ by area — select yours to see what each stream accepts and how often it's collected.</p>
     </div>
   </section>
 
   <main id="main-content">
     <div class="container ct-layout">
 
-      <!-- Area picker -->
+      <p class="ct-back"><a href="waste.html">&larr; All bins and recycling topics</a></p>
+
       <div class="ct-picker-wrap">
         <div class="ct-picker">
           <label for="ct-area-select" class="ct-picker__label">
@@ -98,68 +97,71 @@
         <p id="ct-area-label" class="ct-area-label" aria-live="polite" hidden></p>
       </div>
 
-      <!-- Topic tiles -->
-      <h2 class="section-title">Choose a topic</h2>
-      <p class="page-intro">Your selected area is remembered as you move between these pages.</p>
-      <div class="service-tiles" aria-label="Bins and recycling topics">
-
-        <a href="waste-general-waste.html" class="service-tile service-tile--link">
-          <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v6M14 11v6"/><path d="M9 6V4h6v2"/></svg>
-          <span class="service-tile__title">General waste</span>
-          <span class="service-tile__desc">What goes in your refuse bin, collection frequency and extra capacity</span>
-          <span class="service-tile__cta" aria-hidden="true">View →</span>
-        </a>
-
-        <a href="waste-recycling.html" class="service-tile service-tile--link">
-          <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><polyline points="7 4 4 7 7 10"/><path d="M4 7h11a4 4 0 013.5 6"/><polyline points="17 20 20 17 17 14"/><path d="M20 17H9a4 4 0 01-3.5-6"/></svg>
-          <span class="service-tile__title">Recycling</span>
-          <span class="service-tile__desc">Boxes, bags and bins, and what each stream accepts in your area</span>
-          <span class="service-tile__cta" aria-hidden="true">View →</span>
-        </a>
-
-        <a href="waste-food-waste.html" class="service-tile service-tile--link">
-          <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M6 2v6a3 3 0 006 0V2"/><path d="M9 2v20"/><path d="M17 2c-1.5 0-3 1.5-3 4v6h3"/><path d="M17 12v10"/></svg>
-          <span class="service-tile__title">Food waste</span>
-          <span class="service-tile__desc">Weekly caddy collection, what's accepted and why it can't go in garden waste</span>
-          <span class="service-tile__cta" aria-hidden="true">View →</span>
-        </a>
-
-        <a href="waste-garden-waste.html" class="service-tile service-tile--link">
-          <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M12 22V11"/><path d="M12 11c0-4 3-7 8-7 0 4-3 7-8 7z"/><path d="M12 14C12 10 9 8 4 8c0 4 3 6 8 6z"/></svg>
-          <span class="service-tile__title">Garden waste</span>
-          <span class="service-tile__desc">The opt-in paid subscription, prices and season in your area</span>
-          <span class="service-tile__cta" aria-hidden="true">View →</span>
-        </a>
-
-        <a href="waste-bulky.html" class="service-tile service-tile--link">
-          <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><rect x="3" y="10" width="18" height="10" rx="1"/><path d="M6 10V7a3 3 0 013-3h6a3 3 0 013 3v3"/><path d="M9 14h6"/></svg>
-          <span class="service-tile__title">Bulky waste &amp; centres</span>
-          <span class="service-tile__desc">Booking a large-item collection and finding your Household Recycling Centre</span>
-          <span class="service-tile__cta" aria-hidden="true">View →</span>
-        </a>
-
+      <div class="ct-block ct-block--common">
+        <p>Every council separates recycling into glass, paper/card, and plastics/tins/cans/foil at the point of collection — but the container types, colours and exact frequency are set locally, so check your area's section below rather than assuming.</p>
+        <p>A few things hold everywhere:</p>
+        <ul>
+          <li>Recycling generally needs to be loose, not bagged in plastic, when it goes in a box — bagged recycling usually isn't picked up because it can't be sorted</li>
+          <li>Aerosols must be empty before recycling, for fire safety at the sorting facility</li>
+          <li>Small electrical items are increasingly collected at the kerbside (in a bag, separate from the main recycling), but large electricals, light bulbs and fluorescent tubes still need a Household Recycling Centre</li>
+        </ul>
       </div>
 
-      <!-- No-JS note -->
-      <noscript>
-        <div class="ct-nojs">
-          <h2>Bins and recycling</h2>
-          <p>JavaScript is not available, so your area can't be remembered between pages — each topic page lets you choose your area again. You can also go directly to your council's bins and recycling pages:</p>
-          <ul>
-            <li><a href="https://www.cheltenham.gov.uk/bins-and-recycling">Cheltenham Borough Council — bins and recycling</a></li>
-            <li><a href="https://www.cotswold.gov.uk/bins-and-recycling">Cotswold District Council — bins and recycling</a></li>
-            <li><a href="https://www.fdean.gov.uk/bins-and-recycling">Forest of Dean District Council — bins and recycling</a></li>
-            <li><a href="https://www.gloucester.gov.uk/bins-and-recycling">Gloucester City Council — bins and recycling</a></li>
-            <li><a href="https://www.stroud.gov.uk/bins-and-recycling">Stroud District Council — bins and recycling</a></li>
-            <li><a href="https://www.tewkesbury.gov.uk/bins-and-recycling">Tewkesbury Borough Council — bins and recycling</a></li>
-          </ul>
+
+      <div id="ct-no-area" class="ct-prompt">
+        <svg aria-hidden="true" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M21 10c0 7-9 13-9 13S3 17 3 10a9 9 0 0118 0z"/><circle cx="12" cy="10" r="3"/></svg>
+        <p>Select your area above to see the recycling arrangements that apply to you.</p>
+      </div>
+
+      <div id="ct-content" class="ct-content" hidden>
+        <div class="ct-block ct-block--council" data-council="gloucester">
+          <div class="ct-authority-card">
+            <h3>Gloucester City Council</h3>
+            <p>Two green recycling boxes (one for glass only; one for plastic, cans, tins, aerosols, foil and cartons together), plus a blue sack for all paper and card. Collected opposite week to general waste.</p>
+            <p>Since December 2019, glass must be kept separate — broken glass was spoiling otherwise-good bales. Textiles, batteries and anything in a carrier bag are no longer collected at the kerbside (batteries go to supermarkets). Small electricals go loose on the lid of the green box. New and replacement containers are chargeable.</p>
+          </div>
         </div>
-      </noscript>
+        <div class="ct-block ct-block--council" data-council="stroud">
+          <div class="ct-authority-card">
+            <h3>Stroud District Council</h3>
+            <p>Green wheelie bin or green bag for cans, glass bottles/jars, plastic bottles, aerosols, foil and drinks cartons together; a separate green box for paper and card. Collected every two weeks, opposite week to general waste, out by <strong>6am</strong>.</p>
+            <p>Batteries and vapes are now collected weekly alongside food waste, not in the fortnightly recycling. Not accepted: carrier bags/cling film, plastic toys, polystyrene, large plastic items, foil or glittered wrapping paper, kitchen roll, tissue paper, and glass other than bottles and jars (Pyrex, window glass, drinking glasses, light bulbs).</p>
+          </div>
+        </div>
+        <div class="ct-block ct-block--council" data-council="cotswold">
+          <div class="ct-authority-card">
+            <h3>Cotswold District Council</h3>
+            <p>The most subdivided scheme of the five: two black boxes, a white bag and a blue bag. Box one for glass bottles and jars; box two for paper; white bag for plastic bottles, tubs, pots, trays, tins, cans, aerosols, foil and cartons; blue bag for all cardboard. Small electricals, textiles and batteries each go in a separate old carrier bag tucked inside a box.</p>
+            <p>Collected every two weeks, out by <strong>7am</strong> (6am during hot-weather early starts). Not accepted: broken glass, drinking glasses, Pyrex, sheet/toughened glass, light bulbs; crisp packets, pet food pouches, cling film, bubble wrap, plastic film, coat hangers, takeaway coffee cups; car or motorbike batteries.</p>
+          </div>
+        </div>
+        <div class="ct-block ct-block--council" data-council="forest-of-dean">
+          <div class="ct-authority-card">
+            <h3>Forest of Dean District Council</h3>
+            <p>Two green boxes plus a blue bag. Green box one for plastic bottles/pots/tubs/trays/punnets, plant pots (except black), tins, cans, metal lids, empty aerosols and clean foil; green box two for glass bottles and jars (lids go in the tins-and-cans box) plus textiles in a tied carrier bag; blue bag for paper and card, including clean pizza boxes.</p>
+            <p>Collected <strong>weekly</strong> — the only one of the five councils collecting general recycling weekly rather than fortnightly. Out by 7am. Not accepted: hard plastics (toys, hangers, DVD cases), black plastics (the sorting lasers can't detect them), soft plastics/film, pet/baby food pouches, cartons such as Tetra Pak (notably different from Gloucester and Stroud, who do accept cartons), polystyrene.</p>
+          </div>
+        </div>
+        <div class="ct-block ct-block--council" data-council="tewkesbury">
+          <div class="ct-authority-card">
+            <h3>Tewkesbury Borough Council</h3>
+            <p>Blue bin for card/cardboard, cartons, metal packaging (tins, cans, foil, aerosols), glass and mixed paper together, plus plastic containers and packaging (bottles, pots, tubs, trays) in the same collection. Fortnightly, out by <strong>7am</strong>. Accepts black plastic packaging, unlike Forest of Dean.</p>
+            <p>Does not accept plastic bags/film, crisp packets, pre-prepared salad bags, polystyrene trays, or batteries/vapes (supermarkets or HRCs). Small electricals go loose in an untied old carrier bag beside the blue bin — not available on the narrow-access round.</p>
+            <p>On the narrow-access round: four reusable blue sacks, presented loose (not bagged inside another bag) — the opposite convention to the boxed schemes elsewhere.</p>
+          </div>
+        </div>
+        <div class="ct-block ct-block--council ct-block--todo" data-council="cheltenham">
+          <div class="ct-authority-card">
+            <h3>Cheltenham Borough Council</h3>
+            <p class="ct-todo">Cheltenham's recycling details are being confirmed. In the meantime, please contact Cheltenham Borough Council directly.</p>
+          </div>
+        </div>
+
+      </div><!-- /ct-content -->
 
     </div><!-- /ct-layout -->
   </main>
 
-  <!-- Pre-footer social / newsletter strip -->
   <section class="prefooter" aria-label="Stay connected">
     <div class="container prefooter__inner">
       <div class="prefooter__social">
@@ -242,7 +244,7 @@
   </footer>
 
   <script src="../area-cookie.js"></script>
-  <script src="waste-landing.js"></script>
+  <script src="topic-page.js"></script>
   <script>
     (function () {
       var btn = document.querySelector('.nav-toggle');


### PR DESCRIPTION
## Summary

Replaces the single tabbed waste page with a **landing hub + per-topic detail pages**, as requested.

- **`waste.html`** is now a hub: ex-district selector at the top, then a tile grid — General waste, Recycling, Food waste, Garden waste, Bulky waste & centres. Selecting an area stores it in the shared cookie.
- **Five new topic pages** (`waste-general-waste`, `waste-recycling`, `waste-food-waste`, `waste-garden-waste`, `waste-bulky`): each shows common guidance always, plus the selected area's authority card once an area is chosen. They reuse `topic-page.js` (area selector + reveal, no tabs), and the area carries over from the hub via the cookie.
- New `waste-landing.js` (selector persists the area + shows a label on the hub).
- Added `.service-tile--link` / `.service-tile__cta` and `.ct-back` styles.
- Home page bulky/recycling-centre quick-links now deep-link to `waste-bulky.html`.

The council tax page keeps its tabbed layout — only waste moved to the tile model.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJ29uNGieSuureHRDAyPKy)_