### PR TITLE
Add consolidated housing section (tiled hub + topic pages)

### DIFF
--- a/LGR/Consolidated/council-tax.html
+++ b/LGR/Consolidated/council-tax.html
@@ -535,7 +535,7 @@
             <li><a href="council-tax.html">Council tax</a></li>
             <li><a href="waste.html">Bins and recycling</a></li>
             <li><a href="planning.html">Planning</a></li>
-            <li><a href="#">Housing</a></li>
+            <li><a href="housing.html">Housing</a></li>
             <li><a href="#">Roads and transport</a></li>
           </ul>
         </div>

--- a/LGR/Consolidated/housing-affordable.html
+++ b/LGR/Consolidated/housing-affordable.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>The Local Plan – Planning – Newstershire Council</title>
+  <title>Affordable housing – Housing – Newstershire Council</title>
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="council-tax.css">
 </head>
@@ -60,23 +60,23 @@
       <ol>
         <li><a href="index.html">Home</a></li>
         <li><a href="#">Residents</a></li>
-        <li><a href="planning.html">Planning</a></li>
-        <li aria-current="page">The Local Plan</li>
+        <li><a href="housing.html">Housing</a></li>
+        <li aria-current="page">Affordable housing &amp; home ownership</li>
       </ol>
     </div>
   </nav>
 
   <section class="ct-hero" aria-label="General waste">
     <div class="container">
-      <h1 class="ct-hero__title">The Local Plan</h1>
-      <p class="ct-hero__sub">Every area must plan for housing and development — the process is national, the numbers and policies are local. Select your area.</p>
+      <h1 class="ct-hero__title">Affordable housing and home ownership</h1>
+      <p class="ct-hero__sub">Affordable and social rent, shared ownership and the national First Homes scheme. Which sites offer them is local — select your area.</p>
     </div>
   </section>
 
   <main id="main-content">
     <div class="container ct-layout">
 
-      <p class="ct-back"><a href="planning.html">&larr; All planning topics</a></p>
+      <p class="ct-back"><a href="housing.html">&larr; All housing topics</a></p>
 
       <div class="ct-picker-wrap">
         <div class="ct-picker">
@@ -98,55 +98,58 @@
       </div>
 
       <div class="ct-block ct-block--common">
-        <p>This is the one part of planning content that's genuinely, structurally local — not the same rule with a different number attached.</p>
-        <p>By law, every council must produce a Local Plan covering a minimum 15-year horizon, setting out how development — housing, business, infrastructure — will be delivered in that area. Government sets the national housing delivery targets; the Local Plan is each council's own decision about how its share is best met given local circumstances, land availability and priorities, developed with resident input through public consultation. Without an up-to-date Local Plan, a council has much less ability to resist or shape speculative development — and government can ultimately intervene and write the plan itself if a council fails to keep one current.</p>
-        <p>Because the plan-making process, evidence base (Strategic Housing Market Assessments, housing trajectories, brownfield land registers) and monitoring cycle (Housing Delivery Test, Five Year Housing Land Supply) are broadly standardised in method, this is a case where the <em>process</em> is common but the <em>content and numbers</em> are entirely local.</p>
+        <p>"Affordable housing" covers several distinct products, defined nationally and delivered by registered providers (housing associations) rather than the council directly:</p>
+        <ul>
+          <li><strong>Affordable rent</strong> — up to 80% of local market rent</li>
+          <li><strong>Social rent</strong> — usually the lowest rents available, owned by registered providers</li>
+          <li><strong>Shared ownership</strong> — you take a mortgage on a percentage of the property and pay rent on the remainder, a genuine part-buy/part-rent structure defined the same way nationally</li>
+        </ul>
+        <h3>First Homes</h3>
+        <p>A national scheme (England only) letting eligible first-time buyers purchase a home at 30–50% below market value. To qualify you must be 18 or older, a genuine first-time buyer, able to secure a mortgage for at least half the purchase price, and have a household income no more than £80,000 a year before tax (based on the previous tax year). The home must become your only or main residence, and can be either newly built or bought second-hand from someone who originally bought it through the scheme.</p>
+        <p>All of this is set nationally. What varies locally is which sites and developments actually offer First Homes, shared ownership or affordable rent in a given district, since that depends on what's been built and by whom.</p>
       </div>
 
 
       <div id="ct-no-area" class="ct-prompt">
         <svg aria-hidden="true" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M21 10c0 7-9 13-9 13S3 17 3 10a9 9 0 0118 0z"/><circle cx="12" cy="10" r="3"/></svg>
-        <p>Select your area above to see the Local Plan position for your area.</p>
+        <p>Select your area above to see local affordable housing and development information for your area.</p>
       </div>
 
       <div id="ct-content" class="ct-content" hidden>
-        <div class="ct-block ct-block--council ct-block--todo" data-council="gloucester">
+        <div class="ct-block ct-block--council" data-council="gloucester">
           <div class="ct-authority-card">
             <h3>Gloucester City Council</h3>
-            <p class="ct-todo">Gloucester's current Local Plan status, adopted housing delivery number and plan period are being confirmed. Gloucester works jointly with Cheltenham and Tewkesbury on some strategic housing matters, so numbers may be set through a joint strategic plan rather than a standalone Gloucester document.</p>
+            <p>Partnered with Cheltenham and Tewkesbury Borough councils to deliver new affordable homes physically located in Tewkesbury Borough but open to Gloucester Homeseeker Plus applicants, with equal bidding chances even without a Tewkesbury local connection. Current and upcoming developments: Perrybrook (Brockworth) — providers include Aster, Bromford and Sovereign — plus Innsworth and Pirton Fields still to come.</p>
           </div>
         </div>
         <div class="ct-block ct-block--council ct-block--todo" data-council="stroud">
           <div class="ct-authority-card">
             <h3>Stroud District Council</h3>
-            <p>Publishes annual monitoring reports covering housing land availability, housing land supply and employment land availability, going back to 2012. Tracks a Housing Delivery Test measurement and a rolling Five Year Housing Land Supply position, both updated regularly (most recent captured: January 2025).</p>
-            <p class="ct-todo">Stroud's current adopted housing requirement figure and Local Plan period are being confirmed — the monitoring framework is well evidenced but the headline housing number wasn't captured separately.</p>
+            <p class="ct-todo">Stroud's current affordable housing development pipeline and First Homes availability are being confirmed — not captured in the current source set.</p>
           </div>
         </div>
-        <div class="ct-block ct-block--council ct-block--todo" data-council="cotswold">
+        <div class="ct-block ct-block--council" data-council="cotswold">
           <div class="ct-authority-card">
             <h3>Cotswold District Council</h3>
-            <p>Maintains an extensive housing evidence base, including a district-specific Objectively Assessed Housing Need review (2023) alongside county-wide Strategic Housing Market Assessments shared historically with Stroud and Forest of Dean. Also maintains a Gypsy and Traveller Accommodation Assessment programme, most recently updated October 2023.</p>
-            <p class="ct-todo">Cotswold's current adopted housing requirement figure and Local Plan period are being confirmed.</p>
+            <p>Publishes a dedicated First Homes guidance note for the district. Given genuinely limited social housing supply relative to demand in a rural district, Cotswold's pages actively steer applicants toward the full range of alternatives — private renting, shared ownership, First Homes, discount market homes and supported accommodation — rather than the housing register alone.</p>
           </div>
         </div>
-        <div class="ct-block ct-block--council" data-council="forest-of-dean">
+        <div class="ct-block ct-block--council ct-block--todo" data-council="forest-of-dean">
           <div class="ct-authority-card">
             <h3>Forest of Dean District Council</h3>
-            <p>Required by national government to allow a minimum of <strong>372 new homes per year, totalling 7,440 by 2041</strong>. The council has no discretion over the overall number, but retains influence over type and location.</p>
-            <p>The current Local Plan is structured around six objectives: a stronger local economy; regenerating town centres and bringing unused sites back into use; meeting local housing needs; tackling climate change; improving and protecting the environment; and promoting healthy, active travel. The Allocations Plan (adopted June 2018) sits alongside the Core Strategy, setting settlement boundaries and site allocations; it went through a successfully-defended legal challenge in 2013 relating to the Cinderford Northern Quarter Area Action Plan.</p>
+            <p class="ct-todo">Forest of Dean's current affordable housing pipeline and First Homes-specific guidance are being confirmed — a resident-facing First Homes/shared ownership summary wasn't captured separately in the current source set.</p>
           </div>
         </div>
-        <div class="ct-block ct-block--council ct-block--todo" data-council="tewkesbury">
+        <div class="ct-block ct-block--council" data-council="tewkesbury">
           <div class="ct-authority-card">
             <h3>Tewkesbury Borough Council</h3>
-            <p class="ct-todo">Tewkesbury's current Local Plan status, adopted housing delivery number and plan period are being confirmed. Given its joint delivery arrangement with Gloucester and Cheltenham on specific sites (Perrybrook, Innsworth, Pirton Fields), some delivery may be coordinated through the joint core strategy area rather than a standalone Tewkesbury document.</p>
+            <p>Hosts new-build affordable developments delivered jointly with Gloucester City and Cheltenham councils (see Perrybrook), open to Gloucester Homeseeker Plus applicants on equal bidding terms.</p>
           </div>
         </div>
         <div class="ct-block ct-block--council ct-block--todo" data-council="cheltenham">
           <div class="ct-authority-card">
             <h3>Cheltenham Borough Council</h3>
-            <p class="ct-todo">Cheltenham's Local Plan details are being confirmed. In the meantime, please contact Cheltenham Borough Council directly.</p>
+            <p class="ct-todo">Cheltenham's affordable housing pipeline is being confirmed. The national schemes (First Homes, shared ownership) apply everywhere; in the meantime, please contact Cheltenham Borough Council directly.</p>
           </div>
         </div>
 

--- a/LGR/Consolidated/housing-homelessness.html
+++ b/LGR/Consolidated/housing-homelessness.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>The Local Plan – Planning – Newstershire Council</title>
+  <title>Homelessness – Housing – Newstershire Council</title>
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="council-tax.css">
 </head>
@@ -60,23 +60,23 @@
       <ol>
         <li><a href="index.html">Home</a></li>
         <li><a href="#">Residents</a></li>
-        <li><a href="planning.html">Planning</a></li>
-        <li aria-current="page">The Local Plan</li>
+        <li><a href="housing.html">Housing</a></li>
+        <li aria-current="page">Homelessness</li>
       </ol>
     </div>
   </nav>
 
   <section class="ct-hero" aria-label="General waste">
     <div class="container">
-      <h1 class="ct-hero__title">The Local Plan</h1>
-      <p class="ct-hero__sub">Every area must plan for housing and development — the process is national, the numbers and policies are local. Select your area.</p>
+      <h1 class="ct-hero__title">Homelessness — duties and support</h1>
+      <p class="ct-hero__sub">If you're homeless or at risk within 56 days, your council has legal duties to help — the same everywhere. Select your area for local contacts and services.</p>
     </div>
   </section>
 
   <main id="main-content">
     <div class="container ct-layout">
 
-      <p class="ct-back"><a href="planning.html">&larr; All planning topics</a></p>
+      <p class="ct-back"><a href="housing.html">&larr; All housing topics</a></p>
 
       <div class="ct-picker-wrap">
         <div class="ct-picker">
@@ -98,55 +98,88 @@
       </div>
 
       <div class="ct-block ct-block--common">
-        <p>This is the one part of planning content that's genuinely, structurally local — not the same rule with a different number attached.</p>
-        <p>By law, every council must produce a Local Plan covering a minimum 15-year horizon, setting out how development — housing, business, infrastructure — will be delivered in that area. Government sets the national housing delivery targets; the Local Plan is each council's own decision about how its share is best met given local circumstances, land availability and priorities, developed with resident input through public consultation. Without an up-to-date Local Plan, a council has much less ability to resist or shape speculative development — and government can ultimately intervene and write the plan itself if a council fails to keep one current.</p>
-        <p>Because the plan-making process, evidence base (Strategic Housing Market Assessments, housing trajectories, brownfield land registers) and monitoring cycle (Housing Delivery Test, Five Year Housing Land Supply) are broadly standardised in method, this is a case where the <em>process</em> is common but the <em>content and numbers</em> are entirely local.</p>
+        <p>If you're homeless, or going to become homeless within 56 days, your council has legal duties to help you — the same duties everywhere, because they come from national legislation, not local policy.</p>
+
+        <h3>The two duties</h3>
+        <p><strong>Duty to prevent homelessness.</strong> If you're threatened with losing your home within 56 days, the council must take reasonable steps to help you stay there or find somewhere else before you become homeless.</p>
+        <p><strong>Duty to relieve homelessness.</strong> If you're already homeless, the council must take reasonable steps to help you secure suitable accommodation — regardless of whether you have "priority need" or are judged "intentionally homeless." Everyone eligible gets some help.</p>
+        <p>If neither step resolves things and you remain homeless, only applicants with priority need move on to further, more substantial duties (like an offer of temporary or settled accommodation). Applicants without priority need aren't entitled to further housing duty, though advice continues.</p>
+
+        <h3>Priority need</h3>
+        <p>Set out in law, identical everywhere:</p>
+        <ul>
+          <li>pregnant, or living with someone who's pregnant</li>
+          <li>dependent children living with you (or who it would be reasonable to expect to live with you)</li>
+          <li>homeless due to an emergency like fire or flood</li>
+          <li>vulnerable because of old age, illness, mental illness, physical disability, or another special reason</li>
+          <li>vulnerable due to an institutional background — council care, the armed forces, or custody</li>
+          <li>vulnerable because you're homeless due to violence</li>
+        </ul>
+
+        <h3>Intentionally homeless</h3>
+        <p>You're not treated as intentionally homeless if the accommodation you left wasn't reasonable to occupy, if you were at risk of violence there, or if you acted in good faith without knowing a relevant fact. If your homelessness genuinely did result from your own actions, the council's duty to provide temporary accommodation is limited to a short period.</p>
+
+        <h3>Local connection</h3>
+        <p>You have a local connection to a district if you normally live there, work there, have immediate family who've lived there at least five years, or have another particularly strong reason connecting you to the area. If you don't have a local connection to the council you've applied to but do have one elsewhere, they'll normally refer you to that other authority — unless you'd be at risk of violence there.</p>
+
+        <h3>Eligibility</h3>
+        <p>Help depends on immigration status as well as housing need. If you're not entitled to certain benefits because of your immigration status, the council can generally only advise, not accommodate.</p>
+
+        <h3>Duty to Refer</h3>
+        <p>Since 1 October 2018, the Homelessness Reduction Act 2017 places a legal duty on specified public bodies (hospitals, prisons, Jobcentre Plus and others) to refer anyone who may be homeless or threatened with homelessness to a local housing authority, with the person's consent.</p>
+
+        <h3>Rough sleeping and severe weather</h3>
+        <p>Report a rough sleeper via StreetLink. All five councils feed into the same Gloucestershire Assertive Outreach Team, delivered by Julian House on behalf of all six Gloucestershire local authorities. During a Severe Weather Emergency Protocol (SWEP) — triggered county-wide when the forecast hits 0°C or below for three or more consecutive nights, or -3°C for a single night — emergency shelter and a bed are provided regardless of which council area you're in.</p>
+
+        <h3>If you disagree with a decision</h3>
+        <p>You can request a review of most homelessness decisions within 21 days. The council isn't obliged to keep accommodating you while a review is being decided.</p>
       </div>
 
 
       <div id="ct-no-area" class="ct-prompt">
         <svg aria-hidden="true" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M21 10c0 7-9 13-9 13S3 17 3 10a9 9 0 0118 0z"/><circle cx="12" cy="10" r="3"/></svg>
-        <p>Select your area above to see the Local Plan position for your area.</p>
+        <p>Select your area above to see local homelessness contacts and services for your area.</p>
       </div>
 
       <div id="ct-content" class="ct-content" hidden>
         <div class="ct-block ct-block--council ct-block--todo" data-council="gloucester">
           <div class="ct-authority-card">
             <h3>Gloucester City Council</h3>
-            <p class="ct-todo">Gloucester's current Local Plan status, adopted housing delivery number and plan period are being confirmed. Gloucester works jointly with Cheltenham and Tewkesbury on some strategic housing matters, so numbers may be set through a joint strategic plan rather than a standalone Gloucester document.</p>
+            <p class="ct-todo">Gloucester's specific homelessness contact route, out-of-hours number and current Preventing Homelessness Strategy date are being confirmed — this page wasn't as fully captured as Forest of Dean's. Gloucester's Move-on priority banding for care leavers and people in supported accommodation is covered on the housing register page.</p>
           </div>
         </div>
-        <div class="ct-block ct-block--council ct-block--todo" data-council="stroud">
+        <div class="ct-block ct-block--council" data-council="stroud">
           <div class="ct-authority-card">
             <h3>Stroud District Council</h3>
-            <p>Publishes annual monitoring reports covering housing land availability, housing land supply and employment land availability, going back to 2012. Tracks a Housing Delivery Test measurement and a rolling Five Year Housing Land Supply position, both updated regularly (most recent captured: January 2025).</p>
-            <p class="ct-todo">Stroud's current adopted housing requirement figure and Local Plan period are being confirmed — the monitoring framework is well evidenced but the headline housing number wasn't captured separately.</p>
+            <p>Register via the Housing Assistance Referral Portal if you're homeless now or threatened within 56 days. Housing Team: 01453 766321, option 3 for detailed advice.</p>
+            <p>Age-banded routes: 16–17s are referred to Children's Social Care for a Child in Need assessment (via Youth Support, 01453 763993); 18–21s may be eligible for supported accommodation (Season House, Ark House, Open House); 21–35s without local supported accommodation may be referred to Gloucester and reconnected later; over-35s may claim Housing Benefit toward a B&B room while a tenancy is arranged. All applicants over 18 can apply to the homelessness prevention fund. The team also offers free relationship counselling, can refer to Citizens Advice for money advice, and issues foodbank vouchers in person.</p>
           </div>
         </div>
-        <div class="ct-block ct-block--council ct-block--todo" data-council="cotswold">
+        <div class="ct-block ct-block--council" data-council="cotswold">
           <div class="ct-authority-card">
             <h3>Cotswold District Council</h3>
-            <p>Maintains an extensive housing evidence base, including a district-specific Objectively Assessed Housing Need review (2023) alongside county-wide Strategic Housing Market Assessments shared historically with Stroud and Forest of Dean. Also maintains a Gypsy and Traveller Accommodation Assessment programme, most recently updated October 2023.</p>
-            <p class="ct-todo">Cotswold's current adopted housing requirement figure and Local Plan period are being confirmed.</p>
+            <p>Out-of-hours emergency line: 01285 623000. Duty to Refer enquiries: dutytorefer@cotswold.gov.uk.</p>
+            <p>Adopted a Preventing Homelessness Strategy for 2025–2030 built around four priorities: preventing homelessness; effective partnerships; supporting rough sleepers; increasing accommodation options — worded almost identically to Forest of Dean's, suggesting joint development.</p>
           </div>
         </div>
         <div class="ct-block ct-block--council" data-council="forest-of-dean">
           <div class="ct-authority-card">
             <h3>Forest of Dean District Council</h3>
-            <p>Required by national government to allow a minimum of <strong>372 new homes per year, totalling 7,440 by 2041</strong>. The council has no discretion over the overall number, but retains influence over type and location.</p>
-            <p>The current Local Plan is structured around six objectives: a stronger local economy; regenerating town centres and bringing unused sites back into use; meeting local housing needs; tackling climate change; improving and protecting the environment; and promoting healthy, active travel. The Allocations Plan (adopted June 2018) sits alongside the Core Strategy, setting settlement boundaries and site allocations; it went through a successfully-defended legal challenge in 2013 relating to the Cinderford Northern Quarter Area Action Plan.</p>
+            <p>Out-of-hours emergency line: 01594 810000 (also the daytime Housing Options Team number). Contact the Housing Team via the council's "Ask us for Help with Homelessness" route.</p>
+            <p>Adopted a Preventing Homelessness Strategy for 2025–2030 with the same four-priority structure as Cotswold's.</p>
           </div>
         </div>
-        <div class="ct-block ct-block--council ct-block--todo" data-council="tewkesbury">
+        <div class="ct-block ct-block--council" data-council="tewkesbury">
           <div class="ct-authority-card">
             <h3>Tewkesbury Borough Council</h3>
-            <p class="ct-todo">Tewkesbury's current Local Plan status, adopted housing delivery number and plan period are being confirmed. Given its joint delivery arrangement with Gloucester and Cheltenham on specific sites (Perrybrook, Innsworth, Pirton Fields), some delivery may be coordinated through the joint core strategy area rather than a standalone Tewkesbury document.</p>
+            <p>Contact: housingadvice@tewkesbury.gov.uk, 01684 295010. Support for vulnerable customers who can't sustain an independent tenancy includes access to supported and sheltered accommodation across the county.</p>
+            <p>Any council assistance toward a private rented property is capped at the Local Housing Allowance (LHA) rate for the property's area and household size, whether or not you're claiming Housing Benefit — properties larger than the household needs won't have their full rent covered.</p>
           </div>
         </div>
         <div class="ct-block ct-block--council ct-block--todo" data-council="cheltenham">
           <div class="ct-authority-card">
             <h3>Cheltenham Borough Council</h3>
-            <p class="ct-todo">Cheltenham's Local Plan details are being confirmed. In the meantime, please contact Cheltenham Borough Council directly.</p>
+            <p class="ct-todo">Cheltenham's homelessness contacts are being confirmed. The national duties above apply everywhere; in the meantime, please contact Cheltenham Borough Council directly.</p>
           </div>
         </div>
 

--- a/LGR/Consolidated/housing-register.html
+++ b/LGR/Consolidated/housing-register.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>The Local Plan – Planning – Newstershire Council</title>
+  <title>Housing register – Housing – Newstershire Council</title>
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="council-tax.css">
 </head>
@@ -60,23 +60,23 @@
       <ol>
         <li><a href="index.html">Home</a></li>
         <li><a href="#">Residents</a></li>
-        <li><a href="planning.html">Planning</a></li>
-        <li aria-current="page">The Local Plan</li>
+        <li><a href="housing.html">Housing</a></li>
+        <li aria-current="page">Housing register</li>
       </ol>
     </div>
   </nav>
 
   <section class="ct-hero" aria-label="General waste">
     <div class="container">
-      <h1 class="ct-hero__title">The Local Plan</h1>
-      <p class="ct-hero__sub">Every area must plan for housing and development — the process is national, the numbers and policies are local. Select your area.</p>
+      <h1 class="ct-hero__title">Housing register and Homeseeker Plus</h1>
+      <p class="ct-hero__sub">All social housing in Gloucestershire is let through one shared scheme, Homeseeker Plus. Select your area for local contacts.</p>
     </div>
   </section>
 
   <main id="main-content">
     <div class="container ct-layout">
 
-      <p class="ct-back"><a href="planning.html">&larr; All planning topics</a></p>
+      <p class="ct-back"><a href="housing.html">&larr; All housing topics</a></p>
 
       <div class="ct-picker-wrap">
         <div class="ct-picker">
@@ -98,55 +98,74 @@
       </div>
 
       <div class="ct-block ct-block--common">
-        <p>This is the one part of planning content that's genuinely, structurally local — not the same rule with a different number attached.</p>
-        <p>By law, every council must produce a Local Plan covering a minimum 15-year horizon, setting out how development — housing, business, infrastructure — will be delivered in that area. Government sets the national housing delivery targets; the Local Plan is each council's own decision about how its share is best met given local circumstances, land availability and priorities, developed with resident input through public consultation. Without an up-to-date Local Plan, a council has much less ability to resist or shape speculative development — and government can ultimately intervene and write the plan itself if a council fails to keep one current.</p>
-        <p>Because the plan-making process, evidence base (Strategic Housing Market Assessments, housing trajectories, brownfield land registers) and monitoring cycle (Housing Delivery Test, Five Year Housing Land Supply) are broadly standardised in method, this is a case where the <em>process</em> is common but the <em>content and numbers</em> are entirely local.</p>
+        <p>All social housing in Gloucestershire and West Oxfordshire is let through one shared scheme: <strong>Homeseeker Plus</strong>. This isn't five similar local schemes — it's one partnership between all six Gloucestershire councils, other participating authorities, and housing associations. Whichever council's website you're on, the underlying scheme, priority bands and bidding rules are the same.</p>
+
+        <h3>How it works</h3>
+        <p>A choice-based lettings system: rather than the council allocating you a property, you register, get assessed and banded, then actively bid on properties advertised on the Homeseeker Plus website that match your circumstances.</p>
+        <ol>
+          <li>Register with Homeseeker Plus and complete the application form (roughly 30 minutes)</li>
+          <li>Get assessed — takes 4 to 6 weeks; you may be asked for supporting information</li>
+          <li>Receive your banding decision by email or letter, including your bedroom need and confirmed local connections</li>
+          <li>Browse adverts — new properties can be posted any weekday and normally stay live for 7 days</li>
+          <li>Bid — up to 3 live bids at a time; there's no money involved, you're just expressing interest</li>
+        </ol>
+
+        <h3>Priority bands</h3>
+        <p>Four bands, in order of priority: <strong>Emergency</strong>, <strong>Gold</strong>, <strong>Silver</strong>, <strong>Bronze</strong>. Full eligibility criteria for each band are set out in the Homeseeker Plus policy, common to all participating authorities.</p>
+
+        <h3>How shortlisting works</h3>
+        <p>After bidding closes, the shortlist is reviewed and the property allocated based on eligibility for that specific property, banding, and the date the banding was awarded (priority date) — never the time you placed your bid within the window. Some adverts specify a Parish Local Connection requirement. If your bid is successful, the housing association assesses you against their own tenancy criteria before offering a viewing. You can refuse an offer, but refusing three or more may see your application suspended.</p>
+
+        <h3>Eligibility, savings and income</h3>
+        <p>There's no fixed savings or income limit. Instead, if an assessment concludes you have enough savings or household income to meet your housing needs on the open market, you may be judged ineligible for the register (the FAQ references figures around £60,000/year as a discussion point). Existing homeowners aren't normally eligible, though exceptions exist — severe negative equity or an unmeetable medical need are examples.</p>
+
+        <h3>Transfers and swaps</h3>
+        <p>Existing social tenants in Gloucestershire wanting to move can apply for a transfer through Homeseeker Plus, or search for a mutual exchange via HomeSwapper — free for most Gloucestershire tenants through county membership of the scheme.</p>
       </div>
 
 
       <div id="ct-no-area" class="ct-prompt">
         <svg aria-hidden="true" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M21 10c0 7-9 13-9 13S3 17 3 10a9 9 0 0118 0z"/><circle cx="12" cy="10" r="3"/></svg>
-        <p>Select your area above to see the Local Plan position for your area.</p>
+        <p>Select your area above to see local Homeseeker Plus contacts for your area.</p>
       </div>
 
       <div id="ct-content" class="ct-content" hidden>
-        <div class="ct-block ct-block--council ct-block--todo" data-council="gloucester">
+        <div class="ct-block ct-block--council" data-council="gloucester">
           <div class="ct-authority-card">
             <h3>Gloucester City Council</h3>
-            <p class="ct-todo">Gloucester's current Local Plan status, adopted housing delivery number and plan period are being confirmed. Gloucester works jointly with Cheltenham and Tewkesbury on some strategic housing matters, so numbers may be set through a joint strategic plan rather than a standalone Gloucester document.</p>
+            <p>Contact: Homeseeker@gloucester.gov.uk. Gloucester runs a specific <strong>Move-on priority banding</strong> route for people leaving supported/sheltered accommodation with care, support or supervision, and for care leavers — assessed once the provider confirms readiness for independent living and Gloucester accepts it's the appropriate authority to rehouse.</p>
+            <p>Gloucester applicants can also bid on new-build affordable homes in Tewkesbury Borough — delivered jointly with Cheltenham and Tewkesbury (currently Perrybrook in Brockworth, with Innsworth and Pirton Fields to follow) — with an equal chance on those properties even without a Tewkesbury local connection.</p>
           </div>
         </div>
-        <div class="ct-block ct-block--council ct-block--todo" data-council="stroud">
+        <div class="ct-block ct-block--council" data-council="stroud">
           <div class="ct-authority-card">
             <h3>Stroud District Council</h3>
-            <p>Publishes annual monitoring reports covering housing land availability, housing land supply and employment land availability, going back to 2012. Tracks a Housing Delivery Test measurement and a rolling Five Year Housing Land Supply position, both updated regularly (most recent captured: January 2025).</p>
-            <p class="ct-todo">Stroud's current adopted housing requirement figure and Local Plan period are being confirmed — the monitoring framework is well evidenced but the headline housing number wasn't captured separately.</p>
+            <p>Contact: housing.advice@stroud.gov.uk or 01453 766321 (Mon–Thu 8:45am–5pm, Fri 8:45am–4:30pm). Postal: Housing Advice Team, Stroud District Council, Ebley Mill, Ebley Wharf, Stroud, GL5 4UB.</p>
           </div>
         </div>
         <div class="ct-block ct-block--council ct-block--todo" data-council="cotswold">
           <div class="ct-authority-card">
             <h3>Cotswold District Council</h3>
-            <p>Maintains an extensive housing evidence base, including a district-specific Objectively Assessed Housing Need review (2023) alongside county-wide Strategic Housing Market Assessments shared historically with Stroud and Forest of Dean. Also maintains a Gypsy and Traveller Accommodation Assessment programme, most recently updated October 2023.</p>
-            <p class="ct-todo">Cotswold's current adopted housing requirement figure and Local Plan period are being confirmed.</p>
+            <p>Given limited social housing supply relative to demand, Cotswold points applicants toward private renting, shared ownership, First Homes and supported accommodation as alternatives to the register alone.</p>
+            <p class="ct-todo">A dedicated Homeseeker Plus contact email/number for Cotswold is being confirmed — not captured separately in the current source set.</p>
           </div>
         </div>
         <div class="ct-block ct-block--council" data-council="forest-of-dean">
           <div class="ct-authority-card">
             <h3>Forest of Dean District Council</h3>
-            <p>Required by national government to allow a minimum of <strong>372 new homes per year, totalling 7,440 by 2041</strong>. The council has no discretion over the overall number, but retains influence over type and location.</p>
-            <p>The current Local Plan is structured around six objectives: a stronger local economy; regenerating town centres and bringing unused sites back into use; meeting local housing needs; tackling climate change; improving and protecting the environment; and promoting healthy, active travel. The Allocations Plan (adopted June 2018) sits alongside the Core Strategy, setting settlement boundaries and site allocations; it went through a successfully-defended legal challenge in 2013 relating to the Cinderford Northern Quarter Area Action Plan.</p>
+            <p>Publishes the most detailed FAQ of the five councils — covering bidding closure timing (11:59pm on the advert's closing day, though system-placed autobids may be processed after this and can appear above manually placed bids), shortlist behaviour (positions can shift right up until allocation), and the four priority bands by name.</p>
           </div>
         </div>
-        <div class="ct-block ct-block--council ct-block--todo" data-council="tewkesbury">
+        <div class="ct-block ct-block--council" data-council="tewkesbury">
           <div class="ct-authority-card">
             <h3>Tewkesbury Borough Council</h3>
-            <p class="ct-todo">Tewkesbury's current Local Plan status, adopted housing delivery number and plan period are being confirmed. Given its joint delivery arrangement with Gloucester and Cheltenham on specific sites (Perrybrook, Innsworth, Pirton Fields), some delivery may be coordinated through the joint core strategy area rather than a standalone Tewkesbury document.</p>
+            <p>Contact: housingadvice@tewkesbury.gov.uk, 01684 295010. Useful documents include a dedicated Homeseeker Plus leaflet.</p>
           </div>
         </div>
         <div class="ct-block ct-block--council ct-block--todo" data-council="cheltenham">
           <div class="ct-authority-card">
             <h3>Cheltenham Borough Council</h3>
-            <p class="ct-todo">Cheltenham's Local Plan details are being confirmed. In the meantime, please contact Cheltenham Borough Council directly.</p>
+            <p class="ct-todo">Cheltenham's Homeseeker Plus contact route is being confirmed. The scheme itself is shared county-wide; in the meantime, please contact Cheltenham Borough Council directly.</p>
           </div>
         </div>
 

--- a/LGR/Consolidated/housing-supported.html
+++ b/LGR/Consolidated/housing-supported.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>The Local Plan – Planning – Newstershire Council</title>
+  <title>Supported &amp; sheltered housing – Housing – Newstershire Council</title>
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="council-tax.css">
 </head>
@@ -60,23 +60,23 @@
       <ol>
         <li><a href="index.html">Home</a></li>
         <li><a href="#">Residents</a></li>
-        <li><a href="planning.html">Planning</a></li>
-        <li aria-current="page">The Local Plan</li>
+        <li><a href="housing.html">Housing</a></li>
+        <li aria-current="page">Supported &amp; sheltered housing</li>
       </ol>
     </div>
   </nav>
 
   <section class="ct-hero" aria-label="General waste">
     <div class="container">
-      <h1 class="ct-hero__title">The Local Plan</h1>
-      <p class="ct-hero__sub">Every area must plan for housing and development — the process is national, the numbers and policies are local. Select your area.</p>
+      <h1 class="ct-hero__title">Supported and sheltered housing</h1>
+      <p class="ct-hero__sub">Retirement and extra-care housing depends on which providers operate locally. Select your area to see what's available.</p>
     </div>
   </section>
 
   <main id="main-content">
     <div class="container ct-layout">
 
-      <p class="ct-back"><a href="planning.html">&larr; All planning topics</a></p>
+      <p class="ct-back"><a href="housing.html">&larr; All housing topics</a></p>
 
       <div class="ct-picker-wrap">
         <div class="ct-picker">
@@ -98,55 +98,55 @@
       </div>
 
       <div class="ct-block ct-block--common">
-        <p>This is the one part of planning content that's genuinely, structurally local — not the same rule with a different number attached.</p>
-        <p>By law, every council must produce a Local Plan covering a minimum 15-year horizon, setting out how development — housing, business, infrastructure — will be delivered in that area. Government sets the national housing delivery targets; the Local Plan is each council's own decision about how its share is best met given local circumstances, land availability and priorities, developed with resident input through public consultation. Without an up-to-date Local Plan, a council has much less ability to resist or shape speculative development — and government can ultimately intervene and write the plan itself if a council fails to keep one current.</p>
-        <p>Because the plan-making process, evidence base (Strategic Housing Market Assessments, housing trajectories, brownfield land registers) and monitoring cycle (Housing Delivery Test, Five Year Housing Land Supply) are broadly standardised in method, this is a case where the <em>process</em> is common but the <em>content and numbers</em> are entirely local.</p>
+        <p>This is the area of housing with the least in common across the county, because provision depends entirely on which registered providers actually operate schemes in a district — it isn't a shared scheme like Homeseeker Plus, and it isn't set by national law like homelessness duties. What's shared is the access route and the underlying concepts, not the provision itself.</p>
+        <p>Sheltered/retirement housing is specially designed accommodation, typically for people aged 60 or over, generally including a communal lounge, a dedicated scheme manager, laundry facilities, guest rooms and 24-hour emergency call assistance. Extra care schemes go further, adding on-site facilities and support for people with higher care needs.</p>
+        <p>Access to any scheme run by a housing association normally requires registration on Homeseeker Plus, even where the provider also keeps its own separate waiting list.</p>
+        <p>There's a partnership-level agreement across the Homeseeker Plus authorities: when someone is in supported accommodation outside their home or "lead" authority area, they're reconnected back to their home area once ready to move on — this is what sits behind Gloucester's Move-on priority banding.</p>
       </div>
 
 
       <div id="ct-no-area" class="ct-prompt">
         <svg aria-hidden="true" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M21 10c0 7-9 13-9 13S3 17 3 10a9 9 0 0118 0z"/><circle cx="12" cy="10" r="3"/></svg>
-        <p>Select your area above to see the Local Plan position for your area.</p>
+        <p>Select your area above to see supported and sheltered housing options for your area.</p>
       </div>
 
       <div id="ct-content" class="ct-content" hidden>
         <div class="ct-block ct-block--council ct-block--todo" data-council="gloucester">
           <div class="ct-authority-card">
             <h3>Gloucester City Council</h3>
-            <p class="ct-todo">Gloucester's current Local Plan status, adopted housing delivery number and plan period are being confirmed. Gloucester works jointly with Cheltenham and Tewkesbury on some strategic housing matters, so numbers may be set through a joint strategic plan rather than a standalone Gloucester document.</p>
+            <p>Move-on priority banding is the primary documented route into independent social housing for people leaving supported accommodation or care — see the housing register page for the process.</p>
+            <p class="ct-todo">Which supported/sheltered providers currently operate stock within Gloucester City is being confirmed — not separately captured in the current source set.</p>
           </div>
         </div>
-        <div class="ct-block ct-block--council ct-block--todo" data-council="stroud">
+        <div class="ct-block ct-block--council" data-council="stroud">
           <div class="ct-authority-card">
             <h3>Stroud District Council</h3>
-            <p>Publishes annual monitoring reports covering housing land availability, housing land supply and employment land availability, going back to 2012. Tracks a Housing Delivery Test measurement and a rolling Five Year Housing Land Supply position, both updated regularly (most recent captured: January 2025).</p>
-            <p class="ct-todo">Stroud's current adopted housing requirement figure and Local Plan period are being confirmed — the monitoring framework is well evidenced but the headline housing number wasn't captured separately.</p>
+            <p>Named supported accommodation providers for 18–21 year olds: Season House, Ark House and Open House. No dedicated supported accommodation for the 21–35 bracket within the district — applicants are referred to projects in Gloucester and reconnected to Stroud once assessed as ready to move on (Gloucester waiting lists are usually high). Nightstop provides emergency host-family placements for single people up to age 25, subject to eligibility.</p>
           </div>
         </div>
         <div class="ct-block ct-block--council ct-block--todo" data-council="cotswold">
           <div class="ct-authority-card">
             <h3>Cotswold District Council</h3>
-            <p>Maintains an extensive housing evidence base, including a district-specific Objectively Assessed Housing Need review (2023) alongside county-wide Strategic Housing Market Assessments shared historically with Stroud and Forest of Dean. Also maintains a Gypsy and Traveller Accommodation Assessment programme, most recently updated October 2023.</p>
-            <p class="ct-todo">Cotswold's current adopted housing requirement figure and Local Plan period are being confirmed.</p>
+            <p class="ct-todo">Cotswold's specific supported and sheltered housing providers and schemes are being confirmed — supported accommodation is referenced as an alternative to the register, but named schemes weren't captured in the current source set.</p>
           </div>
         </div>
-        <div class="ct-block ct-block--council" data-council="forest-of-dean">
+        <div class="ct-block ct-block--council ct-block--todo" data-council="forest-of-dean">
           <div class="ct-authority-card">
             <h3>Forest of Dean District Council</h3>
-            <p>Required by national government to allow a minimum of <strong>372 new homes per year, totalling 7,440 by 2041</strong>. The council has no discretion over the overall number, but retains influence over type and location.</p>
-            <p>The current Local Plan is structured around six objectives: a stronger local economy; regenerating town centres and bringing unused sites back into use; meeting local housing needs; tackling climate change; improving and protecting the environment; and promoting healthy, active travel. The Allocations Plan (adopted June 2018) sits alongside the Core Strategy, setting settlement boundaries and site allocations; it went through a successfully-defended legal challenge in 2013 relating to the Cinderford Northern Quarter Area Action Plan.</p>
+            <p class="ct-todo">Forest of Dean's specific supported and sheltered housing providers and schemes are being confirmed — not captured in the current source set.</p>
           </div>
         </div>
-        <div class="ct-block ct-block--council ct-block--todo" data-council="tewkesbury">
+        <div class="ct-block ct-block--council" data-council="tewkesbury">
           <div class="ct-authority-card">
             <h3>Tewkesbury Borough Council</h3>
-            <p class="ct-todo">Tewkesbury's current Local Plan status, adopted housing delivery number and plan period are being confirmed. Given its joint delivery arrangement with Gloucester and Cheltenham on specific sites (Perrybrook, Innsworth, Pirton Fields), some delivery may be coordinated through the joint core strategy area rather than a standalone Tewkesbury document.</p>
+            <p>The most detailed provider list of the five councils. <strong>Anchor Housing</strong> runs several schemes in Tewkesbury town, including Hanover Court (riverside, near a supermarket, post office, dental practice and surgery, with a bus service to Cheltenham) and Marina Court (an extra care scheme with shared gardens, residents' lounge, hair salon and guest room). <strong>Housing 21</strong> runs Clee House, a social enterprise for older people near Tewkesbury Abbey. <strong>Bromford Housing</strong> runs 12 retirement schemes across the borough (over 400 units), including Atherton Close (Shurdington), Barton Court, Graham Court, Lanes Court, Langley Close (Winchcombe) and Parklands.</p>
+            <p>All schemes require Homeseeker Plus registration, though some providers (Anchor specifically) also accept direct registration onto their own waiting list.</p>
           </div>
         </div>
         <div class="ct-block ct-block--council ct-block--todo" data-council="cheltenham">
           <div class="ct-authority-card">
             <h3>Cheltenham Borough Council</h3>
-            <p class="ct-todo">Cheltenham's Local Plan details are being confirmed. In the meantime, please contact Cheltenham Borough Council directly.</p>
+            <p class="ct-todo">Cheltenham's supported and sheltered housing providers are being confirmed. In the meantime, please contact Cheltenham Borough Council directly.</p>
           </div>
         </div>
 

--- a/LGR/Consolidated/housing.html
+++ b/LGR/Consolidated/housing.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>The Local Plan – Planning – Newstershire Council</title>
+  <title>Housing – Newstershire Council</title>
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="council-tax.css">
 </head>
@@ -11,6 +11,7 @@
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
 
+  <!-- Top utility bar -->
   <div class="utility-bar">
     <div class="container utility-bar__inner">
       <span class="utility-bar__item">
@@ -55,29 +56,29 @@
     </div>
   </header>
 
+  <!-- Breadcrumb -->
   <nav class="breadcrumb" aria-label="Breadcrumb">
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
         <li><a href="#">Residents</a></li>
-        <li><a href="planning.html">Planning</a></li>
-        <li aria-current="page">The Local Plan</li>
+        <li aria-current="page">Housing</li>
       </ol>
     </div>
   </nav>
 
-  <section class="ct-hero" aria-label="General waste">
+  <!-- Page hero -->
+  <section class="ct-hero" aria-label="Housing">
     <div class="container">
-      <h1 class="ct-hero__title">The Local Plan</h1>
-      <p class="ct-hero__sub">Every area must plan for housing and development — the process is national, the numbers and policies are local. Select your area.</p>
+      <h1 class="ct-hero__title">Housing</h1>
+      <p class="ct-hero__sub">Homelessness help, the Homeseeker Plus housing register, affordable housing and supported housing. Some of this is the same across the county, some is local — choose your area, then pick a topic.</p>
     </div>
   </section>
 
   <main id="main-content">
     <div class="container ct-layout">
 
-      <p class="ct-back"><a href="planning.html">&larr; All planning topics</a></p>
-
+      <!-- Area picker -->
       <div class="ct-picker-wrap">
         <div class="ct-picker">
           <label for="ct-area-select" class="ct-picker__label">
@@ -97,64 +98,63 @@
         <p id="ct-area-label" class="ct-area-label" aria-live="polite" hidden></p>
       </div>
 
-      <div class="ct-block ct-block--common">
-        <p>This is the one part of planning content that's genuinely, structurally local — not the same rule with a different number attached.</p>
-        <p>By law, every council must produce a Local Plan covering a minimum 15-year horizon, setting out how development — housing, business, infrastructure — will be delivered in that area. Government sets the national housing delivery targets; the Local Plan is each council's own decision about how its share is best met given local circumstances, land availability and priorities, developed with resident input through public consultation. Without an up-to-date Local Plan, a council has much less ability to resist or shape speculative development — and government can ultimately intervene and write the plan itself if a council fails to keep one current.</p>
-        <p>Because the plan-making process, evidence base (Strategic Housing Market Assessments, housing trajectories, brownfield land registers) and monitoring cycle (Housing Delivery Test, Five Year Housing Land Supply) are broadly standardised in method, this is a case where the <em>process</em> is common but the <em>content and numbers</em> are entirely local.</p>
+      <!-- Topic tiles -->
+      <h2 class="section-title">Choose a topic</h2>
+      <p class="page-intro">Your selected area is remembered as you move between these pages.</p>
+            <div class="service-tiles" aria-label="Housing topics">
+
+        <a href="housing-homelessness.html" class="service-tile service-tile--link">
+          <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/><path d="M9 22V12h6v10"/></svg>
+          <span class="service-tile__title">Homelessness</span>
+          <span class="service-tile__desc">Your council's legal duties if you're homeless or at risk, and local contacts</span>
+          <span class="service-tile__cta" aria-hidden="true">View →</span>
+        </a>
+
+        <a href="housing-register.html" class="service-tile service-tile--link">
+          <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="8" y1="13" x2="16" y2="13"/><line x1="8" y1="17" x2="16" y2="17"/></svg>
+          <span class="service-tile__title">Housing register</span>
+          <span class="service-tile__desc">Homeseeker Plus — how to register, priority bands and bidding</span>
+          <span class="service-tile__cta" aria-hidden="true">View →</span>
+        </a>
+
+        <a href="housing-affordable.html" class="service-tile service-tile--link">
+          <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M3 21h18"/><path d="M5 21V7l7-4 7 4v14"/><path d="M9 21v-6h6v6"/></svg>
+          <span class="service-tile__title">Affordable housing &amp; home ownership</span>
+          <span class="service-tile__desc">Affordable and social rent, shared ownership and the First Homes scheme</span>
+          <span class="service-tile__cta" aria-hidden="true">View →</span>
+        </a>
+
+        <a href="housing-supported.html" class="service-tile service-tile--link">
+          <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+          <span class="service-tile__title">Supported &amp; sheltered housing</span>
+          <span class="service-tile__desc">Retirement and extra-care schemes and the providers operating locally</span>
+          <span class="service-tile__cta" aria-hidden="true">View →</span>
+        </a>
+
       </div>
 
 
-      <div id="ct-no-area" class="ct-prompt">
-        <svg aria-hidden="true" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M21 10c0 7-9 13-9 13S3 17 3 10a9 9 0 0118 0z"/><circle cx="12" cy="10" r="3"/></svg>
-        <p>Select your area above to see the Local Plan position for your area.</p>
-      </div>
+      <!-- No-JS note -->
+      <noscript>
+        <div class="ct-nojs">
+          <h2>Housing</h2>
+          <p>JavaScript is not available, so your area can't be remembered between pages — each topic page lets you choose your area again. You can also go directly to your council's housing pages:</p>
+          <ul>
+            <li><a href="https://www.cheltenham.gov.uk/housing">Cheltenham Borough Council — housing</a></li>
+            <li><a href="https://www.cotswold.gov.uk/housing">Cotswold District Council — housing</a></li>
+            <li><a href="https://www.fdean.gov.uk/housing">Forest of Dean District Council — housing</a></li>
+            <li><a href="https://www.gloucester.gov.uk/housing">Gloucester City Council — housing</a></li>
+            <li><a href="https://www.stroud.gov.uk/housing">Stroud District Council — housing</a></li>
+            <li><a href="https://www.tewkesbury.gov.uk/housing">Tewkesbury Borough Council — housing</a></li>
+          </ul>
+        </div>
+      </noscript>
 
-      <div id="ct-content" class="ct-content" hidden>
-        <div class="ct-block ct-block--council ct-block--todo" data-council="gloucester">
-          <div class="ct-authority-card">
-            <h3>Gloucester City Council</h3>
-            <p class="ct-todo">Gloucester's current Local Plan status, adopted housing delivery number and plan period are being confirmed. Gloucester works jointly with Cheltenham and Tewkesbury on some strategic housing matters, so numbers may be set through a joint strategic plan rather than a standalone Gloucester document.</p>
-          </div>
-        </div>
-        <div class="ct-block ct-block--council ct-block--todo" data-council="stroud">
-          <div class="ct-authority-card">
-            <h3>Stroud District Council</h3>
-            <p>Publishes annual monitoring reports covering housing land availability, housing land supply and employment land availability, going back to 2012. Tracks a Housing Delivery Test measurement and a rolling Five Year Housing Land Supply position, both updated regularly (most recent captured: January 2025).</p>
-            <p class="ct-todo">Stroud's current adopted housing requirement figure and Local Plan period are being confirmed — the monitoring framework is well evidenced but the headline housing number wasn't captured separately.</p>
-          </div>
-        </div>
-        <div class="ct-block ct-block--council ct-block--todo" data-council="cotswold">
-          <div class="ct-authority-card">
-            <h3>Cotswold District Council</h3>
-            <p>Maintains an extensive housing evidence base, including a district-specific Objectively Assessed Housing Need review (2023) alongside county-wide Strategic Housing Market Assessments shared historically with Stroud and Forest of Dean. Also maintains a Gypsy and Traveller Accommodation Assessment programme, most recently updated October 2023.</p>
-            <p class="ct-todo">Cotswold's current adopted housing requirement figure and Local Plan period are being confirmed.</p>
-          </div>
-        </div>
-        <div class="ct-block ct-block--council" data-council="forest-of-dean">
-          <div class="ct-authority-card">
-            <h3>Forest of Dean District Council</h3>
-            <p>Required by national government to allow a minimum of <strong>372 new homes per year, totalling 7,440 by 2041</strong>. The council has no discretion over the overall number, but retains influence over type and location.</p>
-            <p>The current Local Plan is structured around six objectives: a stronger local economy; regenerating town centres and bringing unused sites back into use; meeting local housing needs; tackling climate change; improving and protecting the environment; and promoting healthy, active travel. The Allocations Plan (adopted June 2018) sits alongside the Core Strategy, setting settlement boundaries and site allocations; it went through a successfully-defended legal challenge in 2013 relating to the Cinderford Northern Quarter Area Action Plan.</p>
-          </div>
-        </div>
-        <div class="ct-block ct-block--council ct-block--todo" data-council="tewkesbury">
-          <div class="ct-authority-card">
-            <h3>Tewkesbury Borough Council</h3>
-            <p class="ct-todo">Tewkesbury's current Local Plan status, adopted housing delivery number and plan period are being confirmed. Given its joint delivery arrangement with Gloucester and Cheltenham on specific sites (Perrybrook, Innsworth, Pirton Fields), some delivery may be coordinated through the joint core strategy area rather than a standalone Tewkesbury document.</p>
-          </div>
-        </div>
-        <div class="ct-block ct-block--council ct-block--todo" data-council="cheltenham">
-          <div class="ct-authority-card">
-            <h3>Cheltenham Borough Council</h3>
-            <p class="ct-todo">Cheltenham's Local Plan details are being confirmed. In the meantime, please contact Cheltenham Borough Council directly.</p>
-          </div>
-        </div>
-
-      </div><!-- /ct-content -->
 
     </div><!-- /ct-layout -->
   </main>
 
+  <!-- Pre-footer social / newsletter strip -->
   <section class="prefooter" aria-label="Stay connected">
     <div class="container prefooter__inner">
       <div class="prefooter__social">
@@ -237,7 +237,7 @@
   </footer>
 
   <script src="../area-cookie.js"></script>
-  <script src="topic-page.js"></script>
+  <script src="hub-landing.js"></script>
   <script>
     (function () {
       var btn = document.querySelector('.nav-toggle');

--- a/LGR/Consolidated/index.html
+++ b/LGR/Consolidated/index.html
@@ -121,6 +121,13 @@
             <span class="service-tile__desc">Applying for permission, fees, decisions, appeals and the Local Plan</span>
             <a href="planning.html" class="service-tile__link">View planning →</a>
           </div>
+          <div class="service-tile">
+            <span class="service-tile__badge">Available here</span>
+            <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/><path d="M9 22V12h6v10"/></svg>
+            <span class="service-tile__title">Housing</span>
+            <span class="service-tile__desc">Homelessness help, the housing register, affordable and supported housing</span>
+            <a href="housing.html" class="service-tile__link">View housing →</a>
+          </div>
         </div>
 
         <h2 class="section-title section-title--router">Looking for another service?</h2>
@@ -388,7 +395,7 @@
             <li><a href="#">Council tax</a></li>
             <li><a href="#">Bins and recycling</a></li>
             <li><a href="planning.html">Planning</a></li>
-            <li><a href="#">Housing</a></li>
+            <li><a href="housing.html">Housing</a></li>
             <li><a href="#">Roads and transport</a></li>
           </ul>
         </div>

--- a/LGR/Consolidated/planning-appeals.html
+++ b/LGR/Consolidated/planning-appeals.html
@@ -208,7 +208,7 @@
             <li><a href="council-tax.html">Council tax</a></li>
             <li><a href="waste.html">Bins and recycling</a></li>
             <li><a href="planning.html">Planning</a></li>
-            <li><a href="#">Housing</a></li>
+            <li><a href="housing.html">Housing</a></li>
             <li><a href="#">Roads and transport</a></li>
           </ul>
         </div>

--- a/LGR/Consolidated/planning-decision.html
+++ b/LGR/Consolidated/planning-decision.html
@@ -216,7 +216,7 @@
             <li><a href="council-tax.html">Council tax</a></li>
             <li><a href="waste.html">Bins and recycling</a></li>
             <li><a href="planning.html">Planning</a></li>
-            <li><a href="#">Housing</a></li>
+            <li><a href="housing.html">Housing</a></li>
             <li><a href="#">Roads and transport</a></li>
           </ul>
         </div>

--- a/LGR/Consolidated/planning-fees.html
+++ b/LGR/Consolidated/planning-fees.html
@@ -209,7 +209,7 @@
             <li><a href="council-tax.html">Council tax</a></li>
             <li><a href="waste.html">Bins and recycling</a></li>
             <li><a href="planning.html">Planning</a></li>
-            <li><a href="#">Housing</a></li>
+            <li><a href="housing.html">Housing</a></li>
             <li><a href="#">Roads and transport</a></li>
           </ul>
         </div>

--- a/LGR/Consolidated/planning-how-to-apply.html
+++ b/LGR/Consolidated/planning-how-to-apply.html
@@ -221,7 +221,7 @@
             <li><a href="council-tax.html">Council tax</a></li>
             <li><a href="waste.html">Bins and recycling</a></li>
             <li><a href="planning.html">Planning</a></li>
-            <li><a href="#">Housing</a></li>
+            <li><a href="housing.html">Housing</a></li>
             <li><a href="#">Roads and transport</a></li>
           </ul>
         </div>

--- a/LGR/Consolidated/planning.html
+++ b/LGR/Consolidated/planning.html
@@ -210,7 +210,7 @@
             <li><a href="council-tax.html">Council tax</a></li>
             <li><a href="waste.html">Bins and recycling</a></li>
             <li><a href="planning.html">Planning</a></li>
-            <li><a href="#">Housing</a></li>
+            <li><a href="housing.html">Housing</a></li>
             <li><a href="#">Roads and transport</a></li>
           </ul>
         </div>

--- a/LGR/Consolidated/waste-bulky.html
+++ b/LGR/Consolidated/waste-bulky.html
@@ -220,7 +220,7 @@
             <li><a href="council-tax.html">Council tax</a></li>
             <li><a href="waste.html">Bins and recycling</a></li>
             <li><a href="planning.html">Planning</a></li>
-            <li><a href="#">Housing</a></li>
+            <li><a href="housing.html">Housing</a></li>
             <li><a href="#">Roads and transport</a></li>
           </ul>
         </div>

--- a/LGR/Consolidated/waste-food-waste.html
+++ b/LGR/Consolidated/waste-food-waste.html
@@ -207,7 +207,7 @@
             <li><a href="council-tax.html">Council tax</a></li>
             <li><a href="waste.html">Bins and recycling</a></li>
             <li><a href="planning.html">Planning</a></li>
-            <li><a href="#">Housing</a></li>
+            <li><a href="housing.html">Housing</a></li>
             <li><a href="#">Roads and transport</a></li>
           </ul>
         </div>

--- a/LGR/Consolidated/waste-garden-waste.html
+++ b/LGR/Consolidated/waste-garden-waste.html
@@ -206,7 +206,7 @@
             <li><a href="council-tax.html">Council tax</a></li>
             <li><a href="waste.html">Bins and recycling</a></li>
             <li><a href="planning.html">Planning</a></li>
-            <li><a href="#">Housing</a></li>
+            <li><a href="housing.html">Housing</a></li>
             <li><a href="#">Roads and transport</a></li>
           </ul>
         </div>

--- a/LGR/Consolidated/waste-general-waste.html
+++ b/LGR/Consolidated/waste-general-waste.html
@@ -220,7 +220,7 @@
             <li><a href="council-tax.html">Council tax</a></li>
             <li><a href="waste.html">Bins and recycling</a></li>
             <li><a href="planning.html">Planning</a></li>
-            <li><a href="#">Housing</a></li>
+            <li><a href="housing.html">Housing</a></li>
             <li><a href="#">Roads and transport</a></li>
           </ul>
         </div>

--- a/LGR/Consolidated/waste-recycling.html
+++ b/LGR/Consolidated/waste-recycling.html
@@ -212,7 +212,7 @@
             <li><a href="council-tax.html">Council tax</a></li>
             <li><a href="waste.html">Bins and recycling</a></li>
             <li><a href="planning.html">Planning</a></li>
-            <li><a href="#">Housing</a></li>
+            <li><a href="housing.html">Housing</a></li>
             <li><a href="#">Roads and transport</a></li>
           </ul>
         </div>

--- a/LGR/Consolidated/waste.html
+++ b/LGR/Consolidated/waste.html
@@ -210,7 +210,7 @@
             <li><a href="council-tax.html">Council tax</a></li>
             <li><a href="waste.html">Bins and recycling</a></li>
             <li><a href="planning.html">Planning</a></li>
-            <li><a href="#">Housing</a></li>
+            <li><a href="housing.html">Housing</a></li>
             <li><a href="#">Roads and transport</a></li>
           </ul>
         </div>


### PR DESCRIPTION
## Summary

New housing section for the Consolidated site, built from `MD/Housing`, mirroring the bins & recycling / planning hub model.

- **`housing.html`**: tiled landing with the ex-district selector at the top and four topic tiles — homelessness, housing register (Homeseeker Plus), affordable housing & home ownership, and supported & sheltered housing. Selecting an area stores it in the shared cookie.
- **Four detail pages** (`housing-homelessness`, `housing-register`, `housing-affordable`, `housing-supported`): each shows the shared content always, plus the selected area's authority card once an area is chosen. Reuse `topic-page.js`.
- Content reflects the source's structure note: homelessness duties (Housing Act 1996 Part 7) and the county-wide Homeseeker Plus scheme are genuinely shared ("same service, different front door"), while temporary accommodation, contacts and supported/sheltered provision are local. Source TODO gaps shown as amber callouts; Cheltenham flagged as being confirmed.
- Home page: added a live Housing tile (now four consolidated services); Housing linked in the footer Residents list across all pages.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJ29uNGieSuureHRDAyPKy)_