### PR TITLE
Add county-wide service pages from MD/County

### DIFF
--- a/LGR/Consolidated/council-tax.css
+++ b/LGR/Consolidated/council-tax.css
@@ -302,6 +302,37 @@
   color: var(--text);
 }
 
+/* ---- Related services (county pages) ---- */
+.ct-related {
+  margin-top: 2.5rem;
+  padding-top: 1.5rem;
+  border-top: 2px solid var(--border);
+}
+.ct-related h2 {
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: var(--blue-dark);
+  margin-bottom: 0.875rem;
+}
+.ct-related ul {
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 0.5rem;
+}
+.ct-related a {
+  display: block;
+  padding: 0.6rem 0.875rem;
+  background: var(--white);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--blue-mid);
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 0.9375rem;
+}
+.ct-related a:hover { border-color: var(--blue-mid); background: var(--blue-xlight); color: var(--blue-dark); }
+
 /* ---- No-JS fallback ---- */
 .ct-nojs {
   background: var(--white);

--- a/LGR/Consolidated/county-adult-social-care.html
+++ b/LGR/Consolidated/county-adult-social-care.html
@@ -1,0 +1,228 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Adult social care – Newstershire Council</title>
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="council-tax.css">
+</head>
+<body>
+
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <div class="utility-bar">
+    <div class="container utility-bar__inner">
+      <span class="utility-bar__item">
+        <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 16.92v3a2 2 0 01-2.18 2 19.79 19.79 0 01-8.63-3.07A19.5 19.5 0 013.07 9.8 19.79 19.79 0 01.22 1.18 2 2 0 012.22 0h3a2 2 0 012 1.72c.13 1 .37 1.97.72 2.9a2 2 0 01-.45 2.11L6.09 7.91a16 16 0 006 6l1.18-1.18a2 2 0 012.11-.45c.93.35 1.9.59 2.9.72A2 2 0 0122 14.92v2z"/></svg>
+        0800 123 4567
+      </span>
+      <span class="utility-bar__item">
+        <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
+        info@newstershire.gov.uk
+      </span>
+      <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
+    </div>
+  </div>
+
+  <header class="site-header">
+    <div class="container site-header__inner">
+      <div class="logo-lockup">
+        <a href="index.html" style="text-decoration:none;display:flex;align-items:center;gap:0.75rem;">
+          <svg class="logo-icon" aria-hidden="true" focusable="false" width="52" height="52" viewBox="0 0 52 52">
+            <circle cx="26" cy="26" r="26" fill="#1d4477"/>
+            <path d="M10 36 Q18 18 26 22 Q34 18 42 36 Z" fill="#c8a951" opacity="0.9"/>
+            <path d="M18 36 Q22 26 26 28 Q30 26 34 36 Z" fill="#ffffff" opacity="0.85"/>
+            <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
+          </svg>
+          <div>
+            <span class="org-name">Newstershire Council</span>
+            <span class="org-tagline">Serving Gloucestershire together</span>
+          </div>
+        </a>
+      </div>
+      <button class="nav-toggle" aria-expanded="false" aria-controls="header-nav" aria-label="Open menu">
+        <svg aria-hidden="true" focusable="false" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+      </button>
+      <nav id="header-nav" class="header-nav" aria-label="Site navigation">
+        <ul>
+          <li><a href="index.html" class="nav-link">Home</a></li>
+          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="#" class="nav-link">About us</a></li>
+          <li><a href="#" class="nav-link">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <div class="container">
+      <ol>
+        <li><a href="index.html">Home</a></li>
+        <li><a href="index.html#county-services">County-wide services</a></li>
+        <li aria-current="page">Adult social care</li>
+      </ol>
+    </div>
+  </nav>
+
+  <section class="ct-hero" aria-label="Adult social care">
+    <div class="container">
+      <h1 class="ct-hero__title">Adult social care</h1>
+      <p class="ct-hero__sub">Help for adults aged 18 and over to stay independent, safe and well — assessments, paying for care, safeguarding and support for carers.</p>
+    </div>
+  </section>
+
+  <main id="main-content">
+    <div class="container ct-layout">
+
+      <div class="ct-note ct-note--info" style="margin-bottom:1.5rem;">
+        This is a <strong>county-wide service</strong>, run once for the whole of Gloucestershire (previously by Gloucestershire County Council). It works the same wherever you live in the county.
+      </div>
+
+      <div class="ct-block ct-block--common">
+        <p>Adult Social Care helps adults aged 18 and over stay independent, safe and well — whatever's behind the need, whether that's a learning disability, physical disability, mental health condition, dementia, autism, or another long-term condition. Support for carers, including young carers, is part of the same service.</p>
+        <p>Some people only need help for a short period — recovering after a hospital stay, for example. Others need care that builds up gradually, or support for life. The starting point is the same either way: talk to the council, and they'll work with you to understand what you actually need.</p>
+
+        <h3>What support looks like</h3>
+        <ul>
+          <li>Information, advice and guidance, including for unpaid carers</li>
+          <li>Help staying connected — friends, family, social activities</li>
+          <li>Equipment, gadgets and home adaptations</li>
+          <li>Personal care: washing, dressing, household tasks</li>
+          <li>Supported living or a care home placement, where that's the right fit</li>
+        </ul>
+
+        <h3>Getting an assessment</h3>
+        <p>If you think you, or someone you care for, might need extra help, you can ask for a Care and Support Assessment. Gloucestershire calls this an "Adult Social Care Assessment" internally — the same process, just a different name to the one used in some national guidance.</p>
+
+        <h3>Paying for care</h3>
+        <p>Social care for adults is hardly ever free. Almost all care and support arranged or provided by the council is means-tested, and a financial assessment works out what you'll pay. From there:</p>
+        <ul>
+          <li><strong>Self-funding</strong> — if you don't qualify for council support, you pay for your own care</li>
+          <li><strong>Deferred payments</strong> — a way to delay paying certain care home costs, usually secured against your property</li>
+          <li><strong>Direct payments</strong> — money paid to you so you can arrange your own care</li>
+          <li><strong>Personal budgets</strong> — an agreed amount to spend on your care and support</li>
+          <li><strong>Property disregards</strong> — situations where your home isn't counted in the assessment, for example if a spouse or certain relatives still live there</li>
+        </ul>
+        <p>A full "Paying for Adult Social Care" booklet is available, including easy read and large print versions.</p>
+
+        <h3>Keeping people safe</h3>
+        <p>If you're worried a vulnerable adult is at risk of abuse or neglect, contact the Adult Social Care Helpdesk, or the police on 101 — 999 if it's an emergency. Professionals who suspect abuse or risk complete a safeguarding referral through the Adult Social Care portal. Where someone's freedom needs to be restricted for their own safety, usually in a care setting, that's handled through the Deprivation of Liberty Safeguards (DoLS) process.</p>
+
+        <h3>Getting in touch</h3>
+        <ul>
+          <li><strong>Adult Social Care Helpdesk:</strong> 01452 426868, Monday–Friday, 8am–5pm</li>
+          <li><strong>Email:</strong> socialcare.enq@gloucestershire.gov.uk</li>
+          <li><strong>Emergency Duty Team</strong> (out of hours, for serious social care emergencies including suspected abuse): via the council's emergency contacts page</li>
+          <li><strong>Referrals and enquiries:</strong> through the Helpdesk enquiry form, or the online Adult Social Care Portal</li>
+        </ul>
+        <p>Therapy referrals — community nursing, occupational therapy, physiotherapy, reablement — go through Integrated Community Teams, who can also carry out a carer's assessment for anyone supporting someone with support needs.</p>
+
+        <div class="ct-note ct-note--info">
+          <strong>The legal framework:</strong> adult social care operates under the Care Act 2014 and is regulated by the Care Quality Commission. The Your Circle directory signposts local voluntary and community care options — being listed isn't an endorsement, so check an organisation's own qualifications and inspection reports directly.
+        </div>
+
+      </div>
+
+      <nav class="ct-related" aria-label="Other county-wide services">
+        <h2>Other county-wide services</h2>
+        <ul>
+          <li><a href="county-adult-social-care.html">Adult social care</a></li>
+          <li><a href="county-childrens-services.html">Children, young people &amp; families</a></li>
+          <li><a href="county-highways.html">Highways &amp; roads</a></li>
+          <li><a href="county-recycling-centres.html">Household Recycling Centres</a></li>
+          <li><a href="county-libraries.html">Libraries</a></li>
+        </ul>
+      </nav>
+
+    </div>
+  </main>
+
+  <section class="prefooter" aria-label="Stay connected">
+    <div class="container prefooter__inner">
+      <div class="prefooter__social">
+        <h2 class="prefooter__heading">Follow us</h2>
+        <div class="social-links">
+          <a href="#" class="social-link" aria-label="Newstershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
+          <a href="#" class="social-link" aria-label="Newstershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
+          <a href="#" class="social-link" aria-label="Newstershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
+          <a href="#" class="social-link" aria-label="Newstershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
+        </div>
+      </div>
+      <div class="prefooter__newsletter">
+        <h2 class="prefooter__heading">Stay informed</h2>
+        <p>Get council news and service updates straight to your inbox.</p>
+        <form class="newsletter-form" action="#" method="post" aria-label="Newsletter sign-up">
+          <label for="newsletter-email" class="sr-only">Email address</label>
+          <input type="email" id="newsletter-email" name="email" placeholder="Your email address" autocomplete="email">
+          <button type="submit">Sign up</button>
+        </form>
+      </div>
+    </div>
+  </section>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="footer-grid">
+        <div class="footer-col">
+          <h3 class="footer-col__title">About Newstershire</h3>
+          <ul>
+            <li><a href="#">About the council</a></li>
+            <li><a href="#">Councillors and committees</a></li>
+            <li><a href="#">Council meetings</a></li>
+            <li><a href="#">Budget and spending</a></li>
+            <li><a href="#">LGR transition</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <h3 class="footer-col__title">Residents</h3>
+          <ul>
+            <li><a href="council-tax.html">Council tax</a></li>
+            <li><a href="waste.html">Bins and recycling</a></li>
+            <li><a href="planning.html">Planning</a></li>
+            <li><a href="housing.html">Housing</a></li>
+            <li><a href="benefits.html">Benefits and support</a></li>
+            <li><a href="county-highways.html">Roads and transport</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <h3 class="footer-col__title">County services</h3>
+          <ul>
+            <li><a href="county-adult-social-care.html">Adult social care</a></li>
+            <li><a href="county-childrens-services.html">Children &amp; families</a></li>
+            <li><a href="county-libraries.html">Libraries</a></li>
+            <li><a href="county-recycling-centres.html">Recycling centres</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <h3 class="footer-col__title">Help &amp; legal</h3>
+          <ul>
+            <li><a href="#">Accessibility statement</a></li>
+            <li><a href="#">Privacy policy</a></li>
+            <li><a href="#">Cookies</a></li>
+            <li><a href="#">Freedom of information</a></li>
+            <li><a href="#">Contact us</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    (function () {
+      var btn = document.querySelector('.nav-toggle');
+      var nav = document.getElementById('header-nav');
+      if (!btn || !nav) return;
+      btn.addEventListener('click', function () {
+        var open = nav.classList.toggle('header-nav--open');
+        btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+        btn.setAttribute('aria-label', open ? 'Close menu' : 'Open menu');
+      });
+    }());
+  </script>
+</body>
+</html>

--- a/LGR/Consolidated/county-childrens-services.html
+++ b/LGR/Consolidated/county-childrens-services.html
@@ -1,0 +1,217 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Children, young people and families – Newstershire Council</title>
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="council-tax.css">
+</head>
+<body>
+
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <div class="utility-bar">
+    <div class="container utility-bar__inner">
+      <span class="utility-bar__item">
+        <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 16.92v3a2 2 0 01-2.18 2 19.79 19.79 0 01-8.63-3.07A19.5 19.5 0 013.07 9.8 19.79 19.79 0 01.22 1.18 2 2 0 012.22 0h3a2 2 0 012 1.72c.13 1 .37 1.97.72 2.9a2 2 0 01-.45 2.11L6.09 7.91a16 16 0 006 6l1.18-1.18a2 2 0 012.11-.45c.93.35 1.9.59 2.9.72A2 2 0 0122 14.92v2z"/></svg>
+        0800 123 4567
+      </span>
+      <span class="utility-bar__item">
+        <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
+        info@newstershire.gov.uk
+      </span>
+      <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
+    </div>
+  </div>
+
+  <header class="site-header">
+    <div class="container site-header__inner">
+      <div class="logo-lockup">
+        <a href="index.html" style="text-decoration:none;display:flex;align-items:center;gap:0.75rem;">
+          <svg class="logo-icon" aria-hidden="true" focusable="false" width="52" height="52" viewBox="0 0 52 52">
+            <circle cx="26" cy="26" r="26" fill="#1d4477"/>
+            <path d="M10 36 Q18 18 26 22 Q34 18 42 36 Z" fill="#c8a951" opacity="0.9"/>
+            <path d="M18 36 Q22 26 26 28 Q30 26 34 36 Z" fill="#ffffff" opacity="0.85"/>
+            <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
+          </svg>
+          <div>
+            <span class="org-name">Newstershire Council</span>
+            <span class="org-tagline">Serving Gloucestershire together</span>
+          </div>
+        </a>
+      </div>
+      <button class="nav-toggle" aria-expanded="false" aria-controls="header-nav" aria-label="Open menu">
+        <svg aria-hidden="true" focusable="false" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+      </button>
+      <nav id="header-nav" class="header-nav" aria-label="Site navigation">
+        <ul>
+          <li><a href="index.html" class="nav-link">Home</a></li>
+          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="#" class="nav-link">About us</a></li>
+          <li><a href="#" class="nav-link">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <div class="container">
+      <ol>
+        <li><a href="index.html">Home</a></li>
+        <li><a href="index.html#county-services">County-wide services</a></li>
+        <li aria-current="page">Children &amp; families</li>
+      </ol>
+    </div>
+  </nav>
+
+  <section class="ct-hero" aria-label="Children &amp; families">
+    <div class="container">
+      <h1 class="ct-hero__title">Children, young people and families</h1>
+      <p class="ct-hero__sub">Safeguarding, social care and family support — how to report a concern, and the help available for children and young people.</p>
+    </div>
+  </section>
+
+  <main id="main-content">
+    <div class="container ct-layout">
+
+      <div class="ct-note ct-note--info" style="margin-bottom:1.5rem;">
+        This is a <strong>county-wide service</strong>, run once for the whole of Gloucestershire (previously by Gloucestershire County Council). It works the same wherever you live in the county.
+      </div>
+
+      <div class="ct-block ct-block--common">
+        <p>Newstershire Council is the statutory children's services authority for the county — responsible for safeguarding, social care, and support for children, young people and families. Ofsted currently rates the service 'Good' with 'Outstanding' elements.</p>
+
+        <h3>If you're worried about a child</h3>
+        <p><strong>Children and Families Front Door Service:</strong> 01452 426565, select option 2. Monday–Friday, 9am–5pm. This is the main route for reporting a welfare concern, or checking whether a child or family might be eligible for support.</p>
+        <p><strong>Outside office hours</strong>, if it can't safely wait until the next working day, contact the Emergency Duty Team.</p>
+        <div class="ct-todo">
+          <strong>Emergency Duty Team number needs confirming.</strong> The council's own published material gives this as both <strong>01452 614758</strong> (contact page) and <strong>01452 614194</strong> (safeguarding leaflet). This is a genuine inconsistency in the source material — the correct number must be verified before this page goes live. Both numbers reach an answering machine; leave a message and a number and someone calls back. You don't have to give your name.
+        </div>
+        <p><strong>Childline:</strong> 0800 1111 — free, confidential, for children and young people to contact directly. If you've been hurt by anyone, or an adult or another young person has made you feel upset or scared, telling someone is the way to get support and protection.</p>
+
+        <h3>For professionals</h3>
+        <p>Referrals go through a Multi-Agency Referral Form (MARF) on the Liquid Logic portal — a one-time registration, no training needed. Where a child is at immediate risk of significant harm, contact the Front Door directly on 01452 426565 rather than relying on the portal alone.</p>
+        <p>A dedicated advice line (Monday–Friday, 8:30am–4:30pm) covers Early Help and Social Care thresholds, talking through concerns to work out whether a MARF is needed, and support with MyPlans, the family support planning framework. This line replaced several separate advice lines (Community Social Worker, ECHO, and the Family Information Service advice line), which have since closed. Concerns about a professional working with children go through a separate allegations management process, not the standard referral route.</p>
+
+        <h3>What's covered</h3>
+        <ul>
+          <li><strong>Early help and targeted support</strong>, delivered through Family Hubs and Youth Hubs under the Families First Partnership Programme</li>
+          <li><strong>Family Information Service (FIS)</strong> — signposting for families and young people aged 0–19, up to 25 for those with SEND, via the Glosfamilies Directory</li>
+          <li><strong>Fostering and adoption</strong></li>
+          <li><strong>Care leavers</strong> support</li>
+          <li><strong>Participation Team and Voice Gloucestershire</strong> — the Children in Care Council, giving looked-after children a say in how services are run</li>
+          <li><strong>Youth Justice Service</strong></li>
+          <li><strong>Early Years Service</strong></li>
+        </ul>
+        <p>Two documents set the strategic direction: the One Plan for children and young people in Gloucestershire (2024–2030), and the Home@theHeart Sufficiency Strategy (2025–2028), which sets out how enough local placements are provided for children who can't live with their birth families.</p>
+
+        <h3>How information is shared</h3>
+        <p>The council works with a range of partner organisations to coordinate support for children and families, and shares information where that's needed. It will nearly always explain what's being shared and why before doing so — set out in full in the general privacy notice.</p>
+
+        <p class="ct-authority-card__meta">Children's Services, Shire Hall, Westgate Street, Gloucester GL1 2TG.</p>
+
+      </div>
+
+      <nav class="ct-related" aria-label="Other county-wide services">
+        <h2>Other county-wide services</h2>
+        <ul>
+          <li><a href="county-adult-social-care.html">Adult social care</a></li>
+          <li><a href="county-childrens-services.html">Children, young people &amp; families</a></li>
+          <li><a href="county-highways.html">Highways &amp; roads</a></li>
+          <li><a href="county-recycling-centres.html">Household Recycling Centres</a></li>
+          <li><a href="county-libraries.html">Libraries</a></li>
+        </ul>
+      </nav>
+
+    </div>
+  </main>
+
+  <section class="prefooter" aria-label="Stay connected">
+    <div class="container prefooter__inner">
+      <div class="prefooter__social">
+        <h2 class="prefooter__heading">Follow us</h2>
+        <div class="social-links">
+          <a href="#" class="social-link" aria-label="Newstershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
+          <a href="#" class="social-link" aria-label="Newstershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
+          <a href="#" class="social-link" aria-label="Newstershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
+          <a href="#" class="social-link" aria-label="Newstershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
+        </div>
+      </div>
+      <div class="prefooter__newsletter">
+        <h2 class="prefooter__heading">Stay informed</h2>
+        <p>Get council news and service updates straight to your inbox.</p>
+        <form class="newsletter-form" action="#" method="post" aria-label="Newsletter sign-up">
+          <label for="newsletter-email" class="sr-only">Email address</label>
+          <input type="email" id="newsletter-email" name="email" placeholder="Your email address" autocomplete="email">
+          <button type="submit">Sign up</button>
+        </form>
+      </div>
+    </div>
+  </section>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="footer-grid">
+        <div class="footer-col">
+          <h3 class="footer-col__title">About Newstershire</h3>
+          <ul>
+            <li><a href="#">About the council</a></li>
+            <li><a href="#">Councillors and committees</a></li>
+            <li><a href="#">Council meetings</a></li>
+            <li><a href="#">Budget and spending</a></li>
+            <li><a href="#">LGR transition</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <h3 class="footer-col__title">Residents</h3>
+          <ul>
+            <li><a href="council-tax.html">Council tax</a></li>
+            <li><a href="waste.html">Bins and recycling</a></li>
+            <li><a href="planning.html">Planning</a></li>
+            <li><a href="housing.html">Housing</a></li>
+            <li><a href="benefits.html">Benefits and support</a></li>
+            <li><a href="county-highways.html">Roads and transport</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <h3 class="footer-col__title">County services</h3>
+          <ul>
+            <li><a href="county-adult-social-care.html">Adult social care</a></li>
+            <li><a href="county-childrens-services.html">Children &amp; families</a></li>
+            <li><a href="county-libraries.html">Libraries</a></li>
+            <li><a href="county-recycling-centres.html">Recycling centres</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <h3 class="footer-col__title">Help &amp; legal</h3>
+          <ul>
+            <li><a href="#">Accessibility statement</a></li>
+            <li><a href="#">Privacy policy</a></li>
+            <li><a href="#">Cookies</a></li>
+            <li><a href="#">Freedom of information</a></li>
+            <li><a href="#">Contact us</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    (function () {
+      var btn = document.querySelector('.nav-toggle');
+      var nav = document.getElementById('header-nav');
+      if (!btn || !nav) return;
+      btn.addEventListener('click', function () {
+        var open = nav.classList.toggle('header-nav--open');
+        btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+        btn.setAttribute('aria-label', open ? 'Close menu' : 'Open menu');
+      });
+    }());
+  </script>
+</body>
+</html>

--- a/LGR/Consolidated/county-highways.html
+++ b/LGR/Consolidated/county-highways.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Highways and roads – Newstershire Council</title>
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="council-tax.css">
+</head>
+<body>
+
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <div class="utility-bar">
+    <div class="container utility-bar__inner">
+      <span class="utility-bar__item">
+        <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 16.92v3a2 2 0 01-2.18 2 19.79 19.79 0 01-8.63-3.07A19.5 19.5 0 013.07 9.8 19.79 19.79 0 01.22 1.18 2 2 0 012.22 0h3a2 2 0 012 1.72c.13 1 .37 1.97.72 2.9a2 2 0 01-.45 2.11L6.09 7.91a16 16 0 006 6l1.18-1.18a2 2 0 012.11-.45c.93.35 1.9.59 2.9.72A2 2 0 0122 14.92v2z"/></svg>
+        0800 123 4567
+      </span>
+      <span class="utility-bar__item">
+        <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
+        info@newstershire.gov.uk
+      </span>
+      <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
+    </div>
+  </div>
+
+  <header class="site-header">
+    <div class="container site-header__inner">
+      <div class="logo-lockup">
+        <a href="index.html" style="text-decoration:none;display:flex;align-items:center;gap:0.75rem;">
+          <svg class="logo-icon" aria-hidden="true" focusable="false" width="52" height="52" viewBox="0 0 52 52">
+            <circle cx="26" cy="26" r="26" fill="#1d4477"/>
+            <path d="M10 36 Q18 18 26 22 Q34 18 42 36 Z" fill="#c8a951" opacity="0.9"/>
+            <path d="M18 36 Q22 26 26 28 Q30 26 34 36 Z" fill="#ffffff" opacity="0.85"/>
+            <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
+          </svg>
+          <div>
+            <span class="org-name">Newstershire Council</span>
+            <span class="org-tagline">Serving Gloucestershire together</span>
+          </div>
+        </a>
+      </div>
+      <button class="nav-toggle" aria-expanded="false" aria-controls="header-nav" aria-label="Open menu">
+        <svg aria-hidden="true" focusable="false" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+      </button>
+      <nav id="header-nav" class="header-nav" aria-label="Site navigation">
+        <ul>
+          <li><a href="index.html" class="nav-link">Home</a></li>
+          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="#" class="nav-link">About us</a></li>
+          <li><a href="#" class="nav-link">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <div class="container">
+      <ol>
+        <li><a href="index.html">Home</a></li>
+        <li><a href="index.html#county-services">County-wide services</a></li>
+        <li aria-current="page">Highways &amp; roads</li>
+      </ol>
+    </div>
+  </nav>
+
+  <section class="ct-hero" aria-label="Highways &amp; roads">
+    <div class="container">
+      <h1 class="ct-hero__title">Highways and road maintenance</h1>
+      <p class="ct-hero__sub">Reporting potholes and faults, how repairs are prioritised, and the county's wider road maintenance work.</p>
+    </div>
+  </section>
+
+  <main id="main-content">
+    <div class="container ct-layout">
+
+      <div class="ct-note ct-note--info" style="margin-bottom:1.5rem;">
+        This is a <strong>county-wide service</strong>, run once for the whole of Gloucestershire (previously by Gloucestershire County Council). It works the same wherever you live in the county.
+      </div>
+
+      <div class="ct-block ct-block--common">
+        <p>Newstershire Council is the highway authority for the whole county — one service covering all the former district and city areas the same way. Day-to-day maintenance is delivered by contractor Ringway, under a Term Maintenance Contract that began in April 2019 for an initial seven years and has since been extended for up to a further four, subject to performance targets. Average annual spend on highways maintenance runs at around £27 million; the extended contract is expected to be worth over £100 million in total.</p>
+
+        <h3>Reporting a problem</h3>
+        <p><strong>Fix My Street</strong> is the single route for reporting potholes, damaged paving, faulty street lights, blocked drains and similar issues. It's taken over 35,000 reports since launch. You can sign up for email updates on the progress of your specific report.</p>
+
+        <h3>How pothole repairs get prioritised</h3>
+        <p>The most dangerous potholes are fixed first. Inspectors carry out a risk assessment — traffic flow, pothole size, and other factors — and classify each defect as either urgent or added to a planned programme of works, following Department for Transport guidance (more detail sits in the Highways Safety Inspection Manual).</p>
+        <p>Confirmed defects get marked with paint on the road to show the exact repair area. On some busy, fast roads, the safety team may not mark the defect for their own safety, but it's still logged for repair. Marks that weren't painted by the safety team don't count — if it isn't logged in the system, it won't trigger work. Where they can, crews fix smaller potholes in the same work area as a scheduled priority repair.</p>
+
+        <h3>Other core work</h3>
+        <ul>
+          <li><strong>Grass cutting</strong> at junctions and bends, scheduled for visibility and safety — published area by area</li>
+          <li><strong>Drainage</strong> — over 130,000 gullies cleared each year across the county; clear a blocked one yourself if it's safe to, or report it via Fix My Street</li>
+          <li><strong>Resurfacing</strong> — an ongoing programme, run in all seasons</li>
+          <li><strong>Tree inspections</strong> and Ash Dieback management</li>
+          <li><strong>Winter service</strong> — road closure information published during winter weather</li>
+          <li><strong>Safer Roads and Community 20s</strong> — reducing speed limits in the highest-risk areas, for both safety and public health</li>
+        </ul>
+        <p class="ct-authority-card__meta">Some figures (pothole and resurfacing totals) were published without a clear reporting-period date and should be treated as indicative pending a freshness check.</p>
+
+        <h3>Related services</h3>
+        <p>Parking, Public Rights of Way, Traffic Regulation Orders, road safety education, and a Highways Skills Academy offering apprenticeships and career routes into highways work.</p>
+
+        <h3>Getting in touch</h3>
+        <p>General contact is through the highways contact page. Highways runs its own social media accounts — Facebook and X/Twitter under "Glosroads" — separate from the main corporate channels. A subscription email bulletin covers seasonal roadworks news, vacancies and road safety tips.</p>
+
+      </div>
+
+      <nav class="ct-related" aria-label="Other county-wide services">
+        <h2>Other county-wide services</h2>
+        <ul>
+          <li><a href="county-adult-social-care.html">Adult social care</a></li>
+          <li><a href="county-childrens-services.html">Children, young people &amp; families</a></li>
+          <li><a href="county-highways.html">Highways &amp; roads</a></li>
+          <li><a href="county-recycling-centres.html">Household Recycling Centres</a></li>
+          <li><a href="county-libraries.html">Libraries</a></li>
+        </ul>
+      </nav>
+
+    </div>
+  </main>
+
+  <section class="prefooter" aria-label="Stay connected">
+    <div class="container prefooter__inner">
+      <div class="prefooter__social">
+        <h2 class="prefooter__heading">Follow us</h2>
+        <div class="social-links">
+          <a href="#" class="social-link" aria-label="Newstershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
+          <a href="#" class="social-link" aria-label="Newstershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
+          <a href="#" class="social-link" aria-label="Newstershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
+          <a href="#" class="social-link" aria-label="Newstershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
+        </div>
+      </div>
+      <div class="prefooter__newsletter">
+        <h2 class="prefooter__heading">Stay informed</h2>
+        <p>Get council news and service updates straight to your inbox.</p>
+        <form class="newsletter-form" action="#" method="post" aria-label="Newsletter sign-up">
+          <label for="newsletter-email" class="sr-only">Email address</label>
+          <input type="email" id="newsletter-email" name="email" placeholder="Your email address" autocomplete="email">
+          <button type="submit">Sign up</button>
+        </form>
+      </div>
+    </div>
+  </section>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="footer-grid">
+        <div class="footer-col">
+          <h3 class="footer-col__title">About Newstershire</h3>
+          <ul>
+            <li><a href="#">About the council</a></li>
+            <li><a href="#">Councillors and committees</a></li>
+            <li><a href="#">Council meetings</a></li>
+            <li><a href="#">Budget and spending</a></li>
+            <li><a href="#">LGR transition</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <h3 class="footer-col__title">Residents</h3>
+          <ul>
+            <li><a href="council-tax.html">Council tax</a></li>
+            <li><a href="waste.html">Bins and recycling</a></li>
+            <li><a href="planning.html">Planning</a></li>
+            <li><a href="housing.html">Housing</a></li>
+            <li><a href="benefits.html">Benefits and support</a></li>
+            <li><a href="county-highways.html">Roads and transport</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <h3 class="footer-col__title">County services</h3>
+          <ul>
+            <li><a href="county-adult-social-care.html">Adult social care</a></li>
+            <li><a href="county-childrens-services.html">Children &amp; families</a></li>
+            <li><a href="county-libraries.html">Libraries</a></li>
+            <li><a href="county-recycling-centres.html">Recycling centres</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <h3 class="footer-col__title">Help &amp; legal</h3>
+          <ul>
+            <li><a href="#">Accessibility statement</a></li>
+            <li><a href="#">Privacy policy</a></li>
+            <li><a href="#">Cookies</a></li>
+            <li><a href="#">Freedom of information</a></li>
+            <li><a href="#">Contact us</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    (function () {
+      var btn = document.querySelector('.nav-toggle');
+      var nav = document.getElementById('header-nav');
+      if (!btn || !nav) return;
+      btn.addEventListener('click', function () {
+        var open = nav.classList.toggle('header-nav--open');
+        btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+        btn.setAttribute('aria-label', open ? 'Close menu' : 'Open menu');
+      });
+    }());
+  </script>
+</body>
+</html>

--- a/LGR/Consolidated/county-libraries.html
+++ b/LGR/Consolidated/county-libraries.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Libraries – Newstershire Council</title>
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="council-tax.css">
+</head>
+<body>
+
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <div class="utility-bar">
+    <div class="container utility-bar__inner">
+      <span class="utility-bar__item">
+        <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 16.92v3a2 2 0 01-2.18 2 19.79 19.79 0 01-8.63-3.07A19.5 19.5 0 013.07 9.8 19.79 19.79 0 01.22 1.18 2 2 0 012.22 0h3a2 2 0 012 1.72c.13 1 .37 1.97.72 2.9a2 2 0 01-.45 2.11L6.09 7.91a16 16 0 006 6l1.18-1.18a2 2 0 012.11-.45c.93.35 1.9.59 2.9.72A2 2 0 0122 14.92v2z"/></svg>
+        0800 123 4567
+      </span>
+      <span class="utility-bar__item">
+        <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
+        info@newstershire.gov.uk
+      </span>
+      <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
+    </div>
+  </div>
+
+  <header class="site-header">
+    <div class="container site-header__inner">
+      <div class="logo-lockup">
+        <a href="index.html" style="text-decoration:none;display:flex;align-items:center;gap:0.75rem;">
+          <svg class="logo-icon" aria-hidden="true" focusable="false" width="52" height="52" viewBox="0 0 52 52">
+            <circle cx="26" cy="26" r="26" fill="#1d4477"/>
+            <path d="M10 36 Q18 18 26 22 Q34 18 42 36 Z" fill="#c8a951" opacity="0.9"/>
+            <path d="M18 36 Q22 26 26 28 Q30 26 34 36 Z" fill="#ffffff" opacity="0.85"/>
+            <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
+          </svg>
+          <div>
+            <span class="org-name">Newstershire Council</span>
+            <span class="org-tagline">Serving Gloucestershire together</span>
+          </div>
+        </a>
+      </div>
+      <button class="nav-toggle" aria-expanded="false" aria-controls="header-nav" aria-label="Open menu">
+        <svg aria-hidden="true" focusable="false" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+      </button>
+      <nav id="header-nav" class="header-nav" aria-label="Site navigation">
+        <ul>
+          <li><a href="index.html" class="nav-link">Home</a></li>
+          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="#" class="nav-link">About us</a></li>
+          <li><a href="#" class="nav-link">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <div class="container">
+      <ol>
+        <li><a href="index.html">Home</a></li>
+        <li><a href="index.html#county-services">County-wide services</a></li>
+        <li aria-current="page">Libraries</li>
+      </ol>
+    </div>
+  </nav>
+
+  <section class="ct-hero" aria-label="Libraries">
+    <div class="container">
+      <h1 class="ct-hero__title">Gloucestershire Libraries</h1>
+      <p class="ct-hero__sub">31 libraries plus community and digital services — borrowing, events, the Home Library Service and free membership.</p>
+    </div>
+  </section>
+
+  <main id="main-content">
+    <div class="container ct-layout">
+
+      <div class="ct-note ct-note--info" style="margin-bottom:1.5rem;">
+        This is a <strong>county-wide service</strong>, run once for the whole of Gloucestershire (previously by Gloucestershire County Council). It works the same wherever you live in the county.
+      </div>
+
+      <div class="ct-block ct-block--common">
+        <p>Newstershire Council runs 31 council libraries and a Digital Immersive Storytelling Centre, and supports a further eight volunteer-run community libraries — 32 buildings in total. In 2023/24, the service recorded around 1.5 million visits and around 1.5 million items borrowed, in person and online combined.</p>
+
+        <h3>More than books</h3>
+        <p>Libraries are treated as community spaces first, book-lending points second: accessible, safe, and offering activities, maker spaces and free digital equipment alongside the usual borrowing. Six libraries house "The Lab," high-tech spaces for digital innovation work with the public. Two libraries have recently moved into wider mixed-use developments — Stroud's is now inside the Five Valleys Shopping Centre, and Gloucester's is part of the University City Campus.</p>
+
+        <h3>What you can access</h3>
+        <ul>
+          <li><strong>Borrowing</strong> — physical books, plus eBooks, eAudiobooks and eMagazines via BorrowBox, free with membership</li>
+          <li><strong>Library of Things</strong> — tools and equipment for loan, reservable online, collected at Charlton Kings Library</li>
+          <li><strong>Eazy Pedal</strong> — an e-bike loan scheme</li>
+          <li><strong>Events</strong> — author talks, children's activities, local history workshops, all bookable online</li>
+          <li><strong>Digital Services</strong> — computer stations, bookable online</li>
+          <li><strong>Ask us</strong> — a reference, enquiry and business support service</li>
+          <li><strong>Local &amp; Family History</strong> research support</li>
+          <li><strong>Music and Performing Arts</strong> service</li>
+        </ul>
+
+        <h3>Home Library Service</h3>
+        <p>If you're confined to your home, for any reason, and nobody's able to visit a library on your behalf, this service delivers to you. Speak to your local library, who arrange a volunteer visit. The volunteer carries proof of identity — check it before you let them in — and asks about your reading preferences to help choose books. Visits are usually every four weeks, fortnightly in some cases, at a day and time that suits you. Large print, audiobooks on CD, and digital audiobooks are all available, and specific book or subject requests are fulfilled free of charge.</p>
+
+        <h3>Joining</h3>
+        <p>Membership is free — sign up online or in person at any library.</p>
+
+        <div class="ct-note ct-note--info">
+          A five-year Library Strategy (2023–2028) is built around five themes — Core, Community, Connect, Climate and Creativity — and a Greener Together Strategy (2025) sets the service's environmental ambitions. The service holds National Portfolio Organisation status with Arts Council England. Formal charges (fines, replacement costs, borrowing limits) are published on the council's policy pages.
+        </div>
+
+      </div>
+
+      <nav class="ct-related" aria-label="Other county-wide services">
+        <h2>Other county-wide services</h2>
+        <ul>
+          <li><a href="county-adult-social-care.html">Adult social care</a></li>
+          <li><a href="county-childrens-services.html">Children, young people &amp; families</a></li>
+          <li><a href="county-highways.html">Highways &amp; roads</a></li>
+          <li><a href="county-recycling-centres.html">Household Recycling Centres</a></li>
+          <li><a href="county-libraries.html">Libraries</a></li>
+        </ul>
+      </nav>
+
+    </div>
+  </main>
+
+  <section class="prefooter" aria-label="Stay connected">
+    <div class="container prefooter__inner">
+      <div class="prefooter__social">
+        <h2 class="prefooter__heading">Follow us</h2>
+        <div class="social-links">
+          <a href="#" class="social-link" aria-label="Newstershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
+          <a href="#" class="social-link" aria-label="Newstershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
+          <a href="#" class="social-link" aria-label="Newstershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
+          <a href="#" class="social-link" aria-label="Newstershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
+        </div>
+      </div>
+      <div class="prefooter__newsletter">
+        <h2 class="prefooter__heading">Stay informed</h2>
+        <p>Get council news and service updates straight to your inbox.</p>
+        <form class="newsletter-form" action="#" method="post" aria-label="Newsletter sign-up">
+          <label for="newsletter-email" class="sr-only">Email address</label>
+          <input type="email" id="newsletter-email" name="email" placeholder="Your email address" autocomplete="email">
+          <button type="submit">Sign up</button>
+        </form>
+      </div>
+    </div>
+  </section>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="footer-grid">
+        <div class="footer-col">
+          <h3 class="footer-col__title">About Newstershire</h3>
+          <ul>
+            <li><a href="#">About the council</a></li>
+            <li><a href="#">Councillors and committees</a></li>
+            <li><a href="#">Council meetings</a></li>
+            <li><a href="#">Budget and spending</a></li>
+            <li><a href="#">LGR transition</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <h3 class="footer-col__title">Residents</h3>
+          <ul>
+            <li><a href="council-tax.html">Council tax</a></li>
+            <li><a href="waste.html">Bins and recycling</a></li>
+            <li><a href="planning.html">Planning</a></li>
+            <li><a href="housing.html">Housing</a></li>
+            <li><a href="benefits.html">Benefits and support</a></li>
+            <li><a href="county-highways.html">Roads and transport</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <h3 class="footer-col__title">County services</h3>
+          <ul>
+            <li><a href="county-adult-social-care.html">Adult social care</a></li>
+            <li><a href="county-childrens-services.html">Children &amp; families</a></li>
+            <li><a href="county-libraries.html">Libraries</a></li>
+            <li><a href="county-recycling-centres.html">Recycling centres</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <h3 class="footer-col__title">Help &amp; legal</h3>
+          <ul>
+            <li><a href="#">Accessibility statement</a></li>
+            <li><a href="#">Privacy policy</a></li>
+            <li><a href="#">Cookies</a></li>
+            <li><a href="#">Freedom of information</a></li>
+            <li><a href="#">Contact us</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    (function () {
+      var btn = document.querySelector('.nav-toggle');
+      var nav = document.getElementById('header-nav');
+      if (!btn || !nav) return;
+      btn.addEventListener('click', function () {
+        var open = nav.classList.toggle('header-nav--open');
+        btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+        btn.setAttribute('aria-label', open ? 'Close menu' : 'Open menu');
+      });
+    }());
+  </script>
+</body>
+</html>

--- a/LGR/Consolidated/county-recycling-centres.html
+++ b/LGR/Consolidated/county-recycling-centres.html
@@ -1,0 +1,206 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Household Recycling Centres – Newstershire Council</title>
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="council-tax.css">
+</head>
+<body>
+
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <div class="utility-bar">
+    <div class="container utility-bar__inner">
+      <span class="utility-bar__item">
+        <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 16.92v3a2 2 0 01-2.18 2 19.79 19.79 0 01-8.63-3.07A19.5 19.5 0 013.07 9.8 19.79 19.79 0 01.22 1.18 2 2 0 012.22 0h3a2 2 0 012 1.72c.13 1 .37 1.97.72 2.9a2 2 0 01-.45 2.11L6.09 7.91a16 16 0 006 6l1.18-1.18a2 2 0 012.11-.45c.93.35 1.9.59 2.9.72A2 2 0 0122 14.92v2z"/></svg>
+        0800 123 4567
+      </span>
+      <span class="utility-bar__item">
+        <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
+        info@newstershire.gov.uk
+      </span>
+      <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
+    </div>
+  </div>
+
+  <header class="site-header">
+    <div class="container site-header__inner">
+      <div class="logo-lockup">
+        <a href="index.html" style="text-decoration:none;display:flex;align-items:center;gap:0.75rem;">
+          <svg class="logo-icon" aria-hidden="true" focusable="false" width="52" height="52" viewBox="0 0 52 52">
+            <circle cx="26" cy="26" r="26" fill="#1d4477"/>
+            <path d="M10 36 Q18 18 26 22 Q34 18 42 36 Z" fill="#c8a951" opacity="0.9"/>
+            <path d="M18 36 Q22 26 26 28 Q30 26 34 36 Z" fill="#ffffff" opacity="0.85"/>
+            <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
+          </svg>
+          <div>
+            <span class="org-name">Newstershire Council</span>
+            <span class="org-tagline">Serving Gloucestershire together</span>
+          </div>
+        </a>
+      </div>
+      <button class="nav-toggle" aria-expanded="false" aria-controls="header-nav" aria-label="Open menu">
+        <svg aria-hidden="true" focusable="false" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+      </button>
+      <nav id="header-nav" class="header-nav" aria-label="Site navigation">
+        <ul>
+          <li><a href="index.html" class="nav-link">Home</a></li>
+          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="#" class="nav-link">About us</a></li>
+          <li><a href="#" class="nav-link">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <div class="container">
+      <ol>
+        <li><a href="index.html">Home</a></li>
+        <li><a href="index.html#county-services">County-wide services</a></li>
+        <li aria-current="page">Household Recycling Centres</li>
+      </ol>
+    </div>
+  </nav>
+
+  <section class="ct-hero" aria-label="Household Recycling Centres">
+    <div class="container">
+      <h1 class="ct-hero__title">Household Recycling Centres</h1>
+      <p class="ct-hero__sub">The county's recycling centres (Gloucestershire Recycles) — how to book a visit, what you can bring, and where the sites are.</p>
+    </div>
+  </section>
+
+  <main id="main-content">
+    <div class="container ct-layout">
+
+      <div class="ct-note ct-note--info" style="margin-bottom:1.5rem;">
+        This is a <strong>county-wide service</strong>, run once for the whole of Gloucestershire (previously by Gloucestershire County Council). It works the same wherever you live in the county.
+      </div>
+
+      <div class="ct-block ct-block--common">
+        <p>Newstershire Council is the Waste Disposal Authority for the county — a different role to kerbside bin collection, which is covered on the <a href="waste.html">bins and recycling</a> pages. It runs the county's Household Recycling Centres, branded Gloucestershire Recycles.</p>
+
+        <h3>Book before you go</h3>
+        <p>Every visit — car or van — needs a booking made in advance online. This isn't a suggestion; you can be turned away without one. It keeps queues and congestion down and makes the sites safer. With over 10,000 bookings a week across the five sites, there isn't capacity to take bookings by phone as standard. If you genuinely can't book online, and nobody can book on your behalf, there's a phone line: 01452 596 626, weekdays 9am–5pm.</p>
+        <p>Bookings run in fixed 30-minute slots — arrive within yours or you may be turned away and asked to rebook. You'll need to give your name, email, postcode, vehicle make and model, registration, and what waste you're bringing. Bring your booking reference — printed or on your phone — to get in. Need to change your vehicle or slot? There are separate amendment forms for cars and for vans, pick-ups and large trailers.</p>
+
+        <h3>What counts as a car visit</h3>
+        <p>Passenger cars, optionally with a small trailer (under 6ft × 4ft internally). Anything bigger — a van, pick-up, or larger trailer — needs a separate van/large-vehicle booking. HRCs are for household waste only; bringing commercial or trade waste is a criminal offence, and vehicle types are checked against council policy.</p>
+
+        <h3>What you can't bring</h3>
+        <p>Fly-tipped waste isn't accepted — the sites aren't licensed for it. Waste fly-tipped on private land needs a private licensed disposal route instead. Bring only what genuinely can't go through kerbside collection or another route.</p>
+
+        <h3>Sites</h3>
+        <p>Five council-run sites across the county, plus one separate site at Swindon Road in Cheltenham, run independently by Cheltenham Borough Council and currently closed pending review. Known sites: <strong>Hempsted</strong> (Gloucester) — due to close during 2026 for essential repairs and improvements, exact dates to be confirmed — <strong>Pyke Quarry</strong> (near Horsley, Stroud), and <strong>Wingmoor Farm</strong> (Bishop's Cleeve).</p>
+        <p>Each site closes one weekday a week, staggered across the county so there's always a reasonable alternative open — deliberately keeping sites open on Bank Holiday Mondays and Good Friday, historically the busiest days. All sites close on Christmas Day, Boxing Day and New Year's Day. If you need help lifting your waste, ask the staff member at the entrance.</p>
+
+        <div class="ct-note ct-note--info">
+          A zero-tolerance policy applies to violence, aggression, threats or harassment toward staff or other visitors — anyone responsible loses access to the service. General enquiries: waste@gloucestershire.gov.uk.
+        </div>
+
+      </div>
+
+      <nav class="ct-related" aria-label="Other county-wide services">
+        <h2>Other county-wide services</h2>
+        <ul>
+          <li><a href="county-adult-social-care.html">Adult social care</a></li>
+          <li><a href="county-childrens-services.html">Children, young people &amp; families</a></li>
+          <li><a href="county-highways.html">Highways &amp; roads</a></li>
+          <li><a href="county-recycling-centres.html">Household Recycling Centres</a></li>
+          <li><a href="county-libraries.html">Libraries</a></li>
+        </ul>
+      </nav>
+
+    </div>
+  </main>
+
+  <section class="prefooter" aria-label="Stay connected">
+    <div class="container prefooter__inner">
+      <div class="prefooter__social">
+        <h2 class="prefooter__heading">Follow us</h2>
+        <div class="social-links">
+          <a href="#" class="social-link" aria-label="Newstershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
+          <a href="#" class="social-link" aria-label="Newstershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
+          <a href="#" class="social-link" aria-label="Newstershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
+          <a href="#" class="social-link" aria-label="Newstershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
+        </div>
+      </div>
+      <div class="prefooter__newsletter">
+        <h2 class="prefooter__heading">Stay informed</h2>
+        <p>Get council news and service updates straight to your inbox.</p>
+        <form class="newsletter-form" action="#" method="post" aria-label="Newsletter sign-up">
+          <label for="newsletter-email" class="sr-only">Email address</label>
+          <input type="email" id="newsletter-email" name="email" placeholder="Your email address" autocomplete="email">
+          <button type="submit">Sign up</button>
+        </form>
+      </div>
+    </div>
+  </section>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="footer-grid">
+        <div class="footer-col">
+          <h3 class="footer-col__title">About Newstershire</h3>
+          <ul>
+            <li><a href="#">About the council</a></li>
+            <li><a href="#">Councillors and committees</a></li>
+            <li><a href="#">Council meetings</a></li>
+            <li><a href="#">Budget and spending</a></li>
+            <li><a href="#">LGR transition</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <h3 class="footer-col__title">Residents</h3>
+          <ul>
+            <li><a href="council-tax.html">Council tax</a></li>
+            <li><a href="waste.html">Bins and recycling</a></li>
+            <li><a href="planning.html">Planning</a></li>
+            <li><a href="housing.html">Housing</a></li>
+            <li><a href="benefits.html">Benefits and support</a></li>
+            <li><a href="county-highways.html">Roads and transport</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <h3 class="footer-col__title">County services</h3>
+          <ul>
+            <li><a href="county-adult-social-care.html">Adult social care</a></li>
+            <li><a href="county-childrens-services.html">Children &amp; families</a></li>
+            <li><a href="county-libraries.html">Libraries</a></li>
+            <li><a href="county-recycling-centres.html">Recycling centres</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <h3 class="footer-col__title">Help &amp; legal</h3>
+          <ul>
+            <li><a href="#">Accessibility statement</a></li>
+            <li><a href="#">Privacy policy</a></li>
+            <li><a href="#">Cookies</a></li>
+            <li><a href="#">Freedom of information</a></li>
+            <li><a href="#">Contact us</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    (function () {
+      var btn = document.querySelector('.nav-toggle');
+      var nav = document.getElementById('header-nav');
+      if (!btn || !nav) return;
+      btn.addEventListener('click', function () {
+        var open = nav.classList.toggle('header-nav--open');
+        btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+        btn.setAttribute('aria-label', open ? 'Close menu' : 'Open menu');
+      });
+    }());
+  </script>
+</body>
+</html>

--- a/LGR/Consolidated/index.html
+++ b/LGR/Consolidated/index.html
@@ -137,6 +137,41 @@
           </div>
         </div>
 
+        <h2 id="county-services" class="section-title section-title--router">County-wide services</h2>
+        <p class="page-intro">Services we run once for the whole county (previously Gloucestershire County Council). They work the same wherever you live.</p>
+        <div class="service-tiles" aria-label="County-wide services">
+          <a href="county-adult-social-care.html" class="service-tile service-tile--link">
+            <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z"/></svg>
+            <span class="service-tile__title">Adult social care</span>
+            <span class="service-tile__desc">Assessments, paying for care, safeguarding and support for carers</span>
+            <span class="service-tile__cta" aria-hidden="true">View →</span>
+          </a>
+          <a href="county-childrens-services.html" class="service-tile service-tile--link">
+            <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M9 11a3 3 0 100-6 3 3 0 000 6z"/><path d="M17 11a3 3 0 100-6 3 3 0 000 6z"/><path d="M2 21v-1a5 5 0 015-5h4a5 5 0 015 5v1"/><path d="M16 15h1a5 5 0 015 5v1"/></svg>
+            <span class="service-tile__title">Children &amp; families</span>
+            <span class="service-tile__desc">Safeguarding, reporting a concern and support for children and young people</span>
+            <span class="service-tile__cta" aria-hidden="true">View →</span>
+          </a>
+          <a href="county-highways.html" class="service-tile service-tile--link">
+            <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M4 19l4-14M20 19l-4-14M12 5v3M12 12v3M12 19v1"/></svg>
+            <span class="service-tile__title">Highways &amp; roads</span>
+            <span class="service-tile__desc">Report a pothole or fault, and how road repairs are prioritised</span>
+            <span class="service-tile__cta" aria-hidden="true">View →</span>
+          </a>
+          <a href="county-recycling-centres.html" class="service-tile service-tile--link">
+            <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M7 19a2 2 0 01-2-2l-1-9h16l-1 9a2 2 0 01-2 2z"/><path d="M9 8V5a3 3 0 016 0v3"/></svg>
+            <span class="service-tile__title">Recycling centres</span>
+            <span class="service-tile__desc">Book a visit to a Household Recycling Centre and what you can bring</span>
+            <span class="service-tile__cta" aria-hidden="true">View →</span>
+          </a>
+          <a href="county-libraries.html" class="service-tile service-tile--link">
+            <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M4 19.5A2.5 2.5 0 016.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 014 19.5v-15A2.5 2.5 0 016.5 2z"/></svg>
+            <span class="service-tile__title">Libraries</span>
+            <span class="service-tile__desc">Borrowing, events, digital services and the Home Library Service</span>
+            <span class="service-tile__cta" aria-hidden="true">View →</span>
+          </a>
+        </div>
+
         <h2 class="section-title section-title--router">Looking for another service?</h2>
         <p class="page-intro">We're still moving some services across from the former councils. Tell us where you live and we'll open the right website in a new tab.</p>
 


### PR DESCRIPTION
## Summary

County services are run by a single authority (previously Gloucestershire County Council) with no per-district variation, so these are plain content pages — no area selector or tabs, unlike the district topic hubs.

- **Five service pages**: `county-adult-social-care`, `county-childrens-services`, `county-highways`, `county-recycling-centres`, `county-libraries`. Each carries a note that it's a county-wide service, the full content, and a cross-link list of the other county services.
- **Home page**: new "County-wide services" section (`id=county-services`) with a tile for each of the five, below the consolidated district services.
- **Preserved the source's two flagged discrepancies inline** rather than resolving them: the Children's Emergency Duty Team number appears as both `01452 614758` and `01452 614194` in GCC's material (shown as an amber caution to verify before go-live), and undated highways figures are marked indicative pending a freshness check.
- County pages link "Roads and transport" and a County services footer column.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJ29uNGieSuureHRDAyPKy)_