### PR TITLE
Home page tidy-up: single service list, repositioned copy, recycling centres under waste

### DIFF
--- a/LGR/Consolidated/county-adult-social-care.html
+++ b/LGR/Consolidated/county-adult-social-care.html
@@ -129,7 +129,6 @@
           <li><a href="county-adult-social-care.html">Adult social care</a></li>
           <li><a href="county-childrens-services.html">Children, young people &amp; families</a></li>
           <li><a href="county-highways.html">Highways &amp; roads</a></li>
-          <li><a href="county-recycling-centres.html">Household Recycling Centres</a></li>
           <li><a href="county-libraries.html">Libraries</a></li>
         </ul>
       </nav>
@@ -190,7 +189,6 @@
             <li><a href="county-adult-social-care.html">Adult social care</a></li>
             <li><a href="county-childrens-services.html">Children &amp; families</a></li>
             <li><a href="county-libraries.html">Libraries</a></li>
-            <li><a href="county-recycling-centres.html">Recycling centres</a></li>
           </ul>
         </div>
         <div class="footer-col">

--- a/LGR/Consolidated/county-adult-social-care.html
+++ b/LGR/Consolidated/county-adult-social-care.html
@@ -59,7 +59,6 @@
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
-        <li><a href="index.html#county-services">County-wide services</a></li>
         <li aria-current="page">Adult social care</li>
       </ol>
     </div>

--- a/LGR/Consolidated/county-childrens-services.html
+++ b/LGR/Consolidated/county-childrens-services.html
@@ -59,7 +59,6 @@
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
-        <li><a href="index.html#county-services">County-wide services</a></li>
         <li aria-current="page">Children &amp; families</li>
       </ol>
     </div>

--- a/LGR/Consolidated/county-childrens-services.html
+++ b/LGR/Consolidated/county-childrens-services.html
@@ -118,7 +118,6 @@
           <li><a href="county-adult-social-care.html">Adult social care</a></li>
           <li><a href="county-childrens-services.html">Children, young people &amp; families</a></li>
           <li><a href="county-highways.html">Highways &amp; roads</a></li>
-          <li><a href="county-recycling-centres.html">Household Recycling Centres</a></li>
           <li><a href="county-libraries.html">Libraries</a></li>
         </ul>
       </nav>
@@ -179,7 +178,6 @@
             <li><a href="county-adult-social-care.html">Adult social care</a></li>
             <li><a href="county-childrens-services.html">Children &amp; families</a></li>
             <li><a href="county-libraries.html">Libraries</a></li>
-            <li><a href="county-recycling-centres.html">Recycling centres</a></li>
           </ul>
         </div>
         <div class="footer-col">

--- a/LGR/Consolidated/county-highways.html
+++ b/LGR/Consolidated/county-highways.html
@@ -113,7 +113,6 @@
           <li><a href="county-adult-social-care.html">Adult social care</a></li>
           <li><a href="county-childrens-services.html">Children, young people &amp; families</a></li>
           <li><a href="county-highways.html">Highways &amp; roads</a></li>
-          <li><a href="county-recycling-centres.html">Household Recycling Centres</a></li>
           <li><a href="county-libraries.html">Libraries</a></li>
         </ul>
       </nav>
@@ -174,7 +173,6 @@
             <li><a href="county-adult-social-care.html">Adult social care</a></li>
             <li><a href="county-childrens-services.html">Children &amp; families</a></li>
             <li><a href="county-libraries.html">Libraries</a></li>
-            <li><a href="county-recycling-centres.html">Recycling centres</a></li>
           </ul>
         </div>
         <div class="footer-col">

--- a/LGR/Consolidated/county-highways.html
+++ b/LGR/Consolidated/county-highways.html
@@ -59,7 +59,6 @@
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
-        <li><a href="index.html#county-services">County-wide services</a></li>
         <li aria-current="page">Highways &amp; roads</li>
       </ol>
     </div>

--- a/LGR/Consolidated/county-libraries.html
+++ b/LGR/Consolidated/county-libraries.html
@@ -114,7 +114,6 @@
           <li><a href="county-adult-social-care.html">Adult social care</a></li>
           <li><a href="county-childrens-services.html">Children, young people &amp; families</a></li>
           <li><a href="county-highways.html">Highways &amp; roads</a></li>
-          <li><a href="county-recycling-centres.html">Household Recycling Centres</a></li>
           <li><a href="county-libraries.html">Libraries</a></li>
         </ul>
       </nav>
@@ -175,7 +174,6 @@
             <li><a href="county-adult-social-care.html">Adult social care</a></li>
             <li><a href="county-childrens-services.html">Children &amp; families</a></li>
             <li><a href="county-libraries.html">Libraries</a></li>
-            <li><a href="county-recycling-centres.html">Recycling centres</a></li>
           </ul>
         </div>
         <div class="footer-col">

--- a/LGR/Consolidated/county-libraries.html
+++ b/LGR/Consolidated/county-libraries.html
@@ -59,7 +59,6 @@
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
-        <li><a href="index.html#county-services">County-wide services</a></li>
         <li aria-current="page">Libraries</li>
       </ol>
     </div>

--- a/LGR/Consolidated/county-recycling-centres.html
+++ b/LGR/Consolidated/county-recycling-centres.html
@@ -59,7 +59,6 @@
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
-        <li><a href="index.html#county-services">County-wide services</a></li>
         <li aria-current="page">Household Recycling Centres</li>
       </ol>
     </div>

--- a/LGR/Consolidated/index.html
+++ b/LGR/Consolidated/index.html
@@ -59,7 +59,7 @@
     <div class="container hero__inner">
       <div class="hero__text">
         <h1 class="hero__title">Welcome to Newstershire Council</h1>
-        <p class="hero__sub">The new single council for the whole of Gloucestershire. Tell us where you live and we'll take you straight to the service you need.</p>
+        <p class="hero__sub"><strong>Newstershire Council is a new unitary authority.</strong> We've replaced Gloucestershire County Council and the six district and borough councils with one council for the whole county. While we bring everything together, some services still live on the former councils' websites.</p>
       </div>
       <div class="hero__stats" aria-label="Key figures">
         <div class="stat-card">
@@ -83,18 +83,6 @@
 
       <!-- Left: router tool -->
       <div class="router-col">
-
-        <!-- New council notice -->
-        <div class="notice-banner" role="note" aria-label="Important: This is a new council">
-          <svg aria-hidden="true" focusable="false" width="20" height="20" viewBox="0 0 20 20" fill="none">
-            <circle cx="10" cy="10" r="9" stroke="#1d4477" stroke-width="2"/>
-            <path d="M10 6v4M10 14v.5" stroke="#1d4477" stroke-width="2" stroke-linecap="round"/>
-          </svg>
-          <p>
-            <strong>Newstershire Council is a new unitary authority.</strong> We've replaced Gloucestershire County Council and the six district and borough councils with one council for the whole county.
-            While we bring everything together, some services still live on the former councils' websites.
-          </p>
-        </div>
 
         <!-- Consolidated services -->
         <h2 class="section-title">Services on this site</h2>
@@ -173,7 +161,7 @@
         </div>
 
         <h2 class="section-title section-title--router">Looking for another service?</h2>
-        <p class="page-intro">We're still moving some services across from the former councils. Tell us where you live and we'll open the right website in a new tab.</p>
+        <p class="page-intro">The new single council for the whole of Gloucestershire. Tell us where you live and we'll take you straight to the service you need — for services still moving across, we'll open the right existing council website in a new tab.</p>
 
         <!-- === STEP 1: area === -->
         <section id="step-area" class="step" aria-labelledby="step-area-heading">

--- a/LGR/Consolidated/index.html
+++ b/LGR/Consolidated/index.html
@@ -84,54 +84,26 @@
       <!-- Left: router tool -->
       <div class="router-col">
 
-        <!-- Consolidated services -->
-        <h2 class="section-title">Services on this site</h2>
+        <!-- Services available here -->
+        <h2 class="section-title">Services available here</h2>
         <p class="page-intro">These services are now handled right here on the new council website — no redirect needed.</p>
-        <div class="service-tiles" aria-label="Consolidated services">
-          <div class="service-tile">
-            <span class="service-tile__badge">Available here</span>
-            <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><rect x="2" y="5" width="20" height="14" rx="2"/><line x1="2" y1="10" x2="22" y2="10"/></svg>
-            <span class="service-tile__title">Council tax</span>
-            <span class="service-tile__desc">Exemptions, discounts, empty homes, second homes and reductions</span>
-            <a href="council-tax.html" class="service-tile__link">View council tax →</a>
-          </div>
-          <div class="service-tile">
-            <span class="service-tile__badge">Available here</span>
-            <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v6M14 11v6"/><path d="M9 6V4h6v2"/></svg>
-            <span class="service-tile__title">Bins &amp; recycling</span>
-            <span class="service-tile__desc">Collection days, what goes in which bin and recycling centres</span>
-            <a href="waste.html" class="service-tile__link">View bins &amp; recycling →</a>
-          </div>
-          <div class="service-tile">
-            <span class="service-tile__badge">Available here</span>
-            <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
-            <span class="service-tile__title">Planning</span>
-            <span class="service-tile__desc">Applying for permission, fees, decisions, appeals and the Local Plan</span>
-            <a href="planning.html" class="service-tile__link">View planning →</a>
-          </div>
-          <div class="service-tile">
-            <span class="service-tile__badge">Available here</span>
-            <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/><path d="M9 22V12h6v10"/></svg>
-            <span class="service-tile__title">Housing</span>
-            <span class="service-tile__desc">Homelessness help, the housing register, affordable and supported housing</span>
-            <a href="housing.html" class="service-tile__link">View housing →</a>
-          </div>
-          <div class="service-tile">
-            <span class="service-tile__badge">Available here</span>
-            <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><rect x="2" y="5" width="20" height="14" rx="2"/><circle cx="12" cy="12" r="3"/></svg>
-            <span class="service-tile__title">Benefits &amp; support</span>
-            <span class="service-tile__desc">Universal Credit, Housing Benefit, crisis payments and cost-of-living help</span>
-            <a href="benefits.html" class="service-tile__link">View benefits &amp; support →</a>
-          </div>
-        </div>
-
-        <h2 id="county-services" class="section-title section-title--router">County-wide services</h2>
-        <p class="page-intro">Services we run once for the whole county (previously Gloucestershire County Council). They work the same wherever you live.</p>
-        <div class="service-tiles" aria-label="County-wide services">
+        <div class="service-tiles" aria-label="Services available here">
           <a href="county-adult-social-care.html" class="service-tile service-tile--link">
             <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z"/></svg>
             <span class="service-tile__title">Adult social care</span>
             <span class="service-tile__desc">Assessments, paying for care, safeguarding and support for carers</span>
+            <span class="service-tile__cta" aria-hidden="true">View →</span>
+          </a>
+          <a href="benefits.html" class="service-tile service-tile--link">
+            <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><rect x="2" y="5" width="20" height="14" rx="2"/><circle cx="12" cy="12" r="3"/></svg>
+            <span class="service-tile__title">Benefits &amp; support</span>
+            <span class="service-tile__desc">Universal Credit, Housing Benefit, crisis payments and cost-of-living help</span>
+            <span class="service-tile__cta" aria-hidden="true">View →</span>
+          </a>
+          <a href="waste.html" class="service-tile service-tile--link">
+            <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v6M14 11v6"/><path d="M9 6V4h6v2"/></svg>
+            <span class="service-tile__title">Bins &amp; recycling</span>
+            <span class="service-tile__desc">Collection days, what goes in which bin and recycling centres</span>
             <span class="service-tile__cta" aria-hidden="true">View →</span>
           </a>
           <a href="county-childrens-services.html" class="service-tile service-tile--link">
@@ -140,22 +112,40 @@
             <span class="service-tile__desc">Safeguarding, reporting a concern and support for children and young people</span>
             <span class="service-tile__cta" aria-hidden="true">View →</span>
           </a>
+          <a href="council-tax.html" class="service-tile service-tile--link">
+            <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><rect x="2" y="5" width="20" height="14" rx="2"/><line x1="2" y1="10" x2="22" y2="10"/></svg>
+            <span class="service-tile__title">Council tax</span>
+            <span class="service-tile__desc">Exemptions, discounts, empty homes, second homes and reductions</span>
+            <span class="service-tile__cta" aria-hidden="true">View →</span>
+          </a>
           <a href="county-highways.html" class="service-tile service-tile--link">
             <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M4 19l4-14M20 19l-4-14M12 5v3M12 12v3M12 19v1"/></svg>
             <span class="service-tile__title">Highways &amp; roads</span>
             <span class="service-tile__desc">Report a pothole or fault, and how road repairs are prioritised</span>
             <span class="service-tile__cta" aria-hidden="true">View →</span>
           </a>
-          <a href="county-recycling-centres.html" class="service-tile service-tile--link">
-            <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M7 19a2 2 0 01-2-2l-1-9h16l-1 9a2 2 0 01-2 2z"/><path d="M9 8V5a3 3 0 016 0v3"/></svg>
-            <span class="service-tile__title">Recycling centres</span>
-            <span class="service-tile__desc">Book a visit to a Household Recycling Centre and what you can bring</span>
+          <a href="housing.html" class="service-tile service-tile--link">
+            <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/><path d="M9 22V12h6v10"/></svg>
+            <span class="service-tile__title">Housing</span>
+            <span class="service-tile__desc">Homelessness help, the housing register, affordable and supported housing</span>
             <span class="service-tile__cta" aria-hidden="true">View →</span>
           </a>
           <a href="county-libraries.html" class="service-tile service-tile--link">
             <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M4 19.5A2.5 2.5 0 016.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 014 19.5v-15A2.5 2.5 0 016.5 2z"/></svg>
             <span class="service-tile__title">Libraries</span>
             <span class="service-tile__desc">Borrowing, events, digital services and the Home Library Service</span>
+            <span class="service-tile__cta" aria-hidden="true">View →</span>
+          </a>
+          <a href="planning.html" class="service-tile service-tile--link">
+            <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <span class="service-tile__title">Planning</span>
+            <span class="service-tile__desc">Applying for permission, fees, decisions, appeals and the Local Plan</span>
+            <span class="service-tile__cta" aria-hidden="true">View →</span>
+          </a>
+          <a href="county-recycling-centres.html" class="service-tile service-tile--link">
+            <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M7 19a2 2 0 01-2-2l-1-9h16l-1 9a2 2 0 01-2 2z"/><path d="M9 8V5a3 3 0 016 0v3"/></svg>
+            <span class="service-tile__title">Recycling centres</span>
+            <span class="service-tile__desc">Book a visit to a Household Recycling Centre and what you can bring</span>
             <span class="service-tile__cta" aria-hidden="true">View →</span>
           </a>
         </div>

--- a/LGR/Consolidated/index.html
+++ b/LGR/Consolidated/index.html
@@ -142,12 +142,6 @@
             <span class="service-tile__desc">Applying for permission, fees, decisions, appeals and the Local Plan</span>
             <span class="service-tile__cta" aria-hidden="true">View →</span>
           </a>
-          <a href="county-recycling-centres.html" class="service-tile service-tile--link">
-            <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M7 19a2 2 0 01-2-2l-1-9h16l-1 9a2 2 0 01-2 2z"/><path d="M9 8V5a3 3 0 016 0v3"/></svg>
-            <span class="service-tile__title">Recycling centres</span>
-            <span class="service-tile__desc">Book a visit to a Household Recycling Centre and what you can bring</span>
-            <span class="service-tile__cta" aria-hidden="true">View →</span>
-          </a>
         </div>
 
         <h2 class="section-title section-title--router">Looking for another service?</h2>

--- a/LGR/Consolidated/waste-bulky.html
+++ b/LGR/Consolidated/waste-bulky.html
@@ -155,14 +155,7 @@
 
         <div class="ct-block ct-block--common">
           <h3>Household Recycling Centres (HRCs)</h3>
-          <p>For anything that doesn't fit a bulky collection — or as a free alternative — Gloucestershire's Household Recycling Centres are run by <strong>Gloucestershire County Council</strong>, not the district or city councils, so the same network serves everyone regardless of who collects their bins:</p>
-          <ul>
-            <li><strong>Hempsted</strong> — serves Gloucester</li>
-            <li><strong>Wingmoor Farm</strong>, near Bishop's Cleeve — serves Tewkesbury; also processes garden waste by open windrow composting</li>
-            <li><strong>Oak Quarry and Hempsted</strong> — Forest of Dean residents are directed to both</li>
-            <li><strong>Pyke Quarry, Horsley, and Hempsted</strong> — Stroud residents</li>
-          </ul>
-          <p>Asbestos in small household quantities can be taken to an HRC but must be booked in advance. Find your nearest site and book where required via gloucestershirerecycles.com.</p>
+          <p>For anything that doesn't fit a bulky collection — or as a free alternative — Gloucestershire's Household Recycling Centres serve everyone across the county, whatever your area. See <a href="waste-recycling-centres.html">recycling centres</a> for the sites, how to book a visit and what you can bring.</p>
         </div>
 
       </div><!-- /ct-content -->

--- a/LGR/Consolidated/waste-recycling-centres.html
+++ b/LGR/Consolidated/waste-recycling-centres.html
@@ -59,7 +59,8 @@
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
-        <li aria-current="page">Household Recycling Centres</li>
+        <li><a href="waste.html">Bins and recycling</a></li>
+        <li aria-current="page">Recycling centres</li>
       </ol>
     </div>
   </nav>
@@ -74,8 +75,10 @@
   <main id="main-content">
     <div class="container ct-layout">
 
+      <p class="ct-back"><a href="waste.html">&larr; All bins and recycling topics</a></p>
+
       <div class="ct-note ct-note--info" style="margin-bottom:1.5rem;">
-        This is a <strong>county-wide service</strong>, run once for the whole of Gloucestershire (previously by Gloucestershire County Council). It works the same wherever you live in the county.
+        Household Recycling Centres are run once for the whole of Gloucestershire, so the sites, booking system and rules are the same wherever you live — separate from the kerbside bin collections, which differ by area.
       </div>
 
       <div class="ct-block ct-block--common">
@@ -101,14 +104,14 @@
 
       </div>
 
-      <nav class="ct-related" aria-label="Other county-wide services">
-        <h2>Other county-wide services</h2>
+      <nav class="ct-related" aria-label="Other bins and recycling topics">
+        <h2>Other bins and recycling topics</h2>
         <ul>
-          <li><a href="county-adult-social-care.html">Adult social care</a></li>
-          <li><a href="county-childrens-services.html">Children, young people &amp; families</a></li>
-          <li><a href="county-highways.html">Highways &amp; roads</a></li>
-          <li><a href="county-recycling-centres.html">Household Recycling Centres</a></li>
-          <li><a href="county-libraries.html">Libraries</a></li>
+          <li><a href="waste-general-waste.html">General waste</a></li>
+          <li><a href="waste-recycling.html">Recycling</a></li>
+          <li><a href="waste-food-waste.html">Food waste</a></li>
+          <li><a href="waste-garden-waste.html">Garden waste</a></li>
+          <li><a href="waste-bulky.html">Bulky waste</a></li>
         </ul>
       </nav>
 
@@ -168,7 +171,7 @@
             <li><a href="county-adult-social-care.html">Adult social care</a></li>
             <li><a href="county-childrens-services.html">Children &amp; families</a></li>
             <li><a href="county-libraries.html">Libraries</a></li>
-            <li><a href="county-recycling-centres.html">Recycling centres</a></li>
+            <li><a href="waste-recycling-centres.html">Recycling centres</a></li>
           </ul>
         </div>
         <div class="footer-col">

--- a/LGR/Consolidated/waste.html
+++ b/LGR/Consolidated/waste.html
@@ -133,8 +133,15 @@
 
         <a href="waste-bulky.html" class="service-tile service-tile--link">
           <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><rect x="3" y="10" width="18" height="10" rx="1"/><path d="M6 10V7a3 3 0 013-3h6a3 3 0 013 3v3"/><path d="M9 14h6"/></svg>
-          <span class="service-tile__title">Bulky waste &amp; centres</span>
-          <span class="service-tile__desc">Booking a large-item collection and finding your Household Recycling Centre</span>
+          <span class="service-tile__title">Bulky waste</span>
+          <span class="service-tile__desc">Booking a chargeable collection for furniture, white goods and large items</span>
+          <span class="service-tile__cta" aria-hidden="true">View →</span>
+        </a>
+
+        <a href="waste-recycling-centres.html" class="service-tile service-tile--link">
+          <svg class="service-tile__icon" aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M7 19a2 2 0 01-2-2l-1-9h16l-1 9a2 2 0 01-2 2z"/><path d="M9 8V5a3 3 0 016 0v3"/></svg>
+          <span class="service-tile__title">Recycling centres</span>
+          <span class="service-tile__desc">Booking a visit to a Household Recycling Centre and what you can bring</span>
           <span class="service-tile__cta" aria-hidden="true">View →</span>
         </a>
 


### PR DESCRIPTION
## Summary

Three home-page/structure refinements:

1. **Repositioned intro copy** — the "new unitary authority" explanation now sits in the hero under "Welcome to Newstershire Council"; the "tell us where you live" line moved down to introduce the area-selector router. Removed the redundant notice banner.
2. **Single services section** — merged the "Services on this site" and "County-wide services" blocks into one "Services available here" section, tiles ordered alphabetically and using a consistent whole-card link style.
3. **Recycling centres moved under bins & recycling** — `county-recycling-centres.html` → `waste-recycling-centres.html`, added as a tile in the waste hub; the bulky page's duplicated HRC block trimmed to a pointer; standalone home tile removed; county pages' references dropped.

All internal links resolve and markup is balanced.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJ29uNGieSuureHRDAyPKy)_