### PR TITLE
Make breadcrumbs consistent across district and county pages

### DIFF
--- a/LGR/Consolidated/county-adult-social-care.html
+++ b/LGR/Consolidated/county-adult-social-care.html
@@ -59,6 +59,7 @@
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
+        <li><a href="#">Residents</a></li>
         <li aria-current="page">Adult social care</li>
       </ol>
     </div>

--- a/LGR/Consolidated/county-blue-badges.html
+++ b/LGR/Consolidated/county-blue-badges.html
@@ -59,7 +59,7 @@
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
-        <li><a href="index.html#county-services">County-wide services</a></li>
+        <li><a href="#">Residents</a></li>
         <li aria-current="page">Blue Badges &amp; travel</li>
       </ol>
     </div>

--- a/LGR/Consolidated/county-childrens-services.html
+++ b/LGR/Consolidated/county-childrens-services.html
@@ -59,6 +59,7 @@
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
+        <li><a href="#">Residents</a></li>
         <li aria-current="page">Children &amp; families</li>
       </ol>
     </div>

--- a/LGR/Consolidated/county-highways.html
+++ b/LGR/Consolidated/county-highways.html
@@ -59,6 +59,7 @@
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
+        <li><a href="#">Residents</a></li>
         <li aria-current="page">Highways &amp; roads</li>
       </ol>
     </div>

--- a/LGR/Consolidated/county-libraries.html
+++ b/LGR/Consolidated/county-libraries.html
@@ -59,6 +59,7 @@
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
+        <li><a href="#">Residents</a></li>
         <li aria-current="page">Libraries</li>
       </ol>
     </div>

--- a/LGR/Consolidated/county-registrars.html
+++ b/LGR/Consolidated/county-registrars.html
@@ -59,7 +59,7 @@
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
-        <li><a href="index.html#county-services">County-wide services</a></li>
+        <li><a href="#">Residents</a></li>
         <li aria-current="page">Registrars</li>
       </ol>
     </div>

--- a/LGR/Consolidated/county-school-admissions.html
+++ b/LGR/Consolidated/county-school-admissions.html
@@ -59,7 +59,7 @@
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
-        <li><a href="index.html#county-services">County-wide services</a></li>
+        <li><a href="#">Residents</a></li>
         <li aria-current="page">School admissions</li>
       </ol>
     </div>

--- a/LGR/Consolidated/waste-recycling-centres.html
+++ b/LGR/Consolidated/waste-recycling-centres.html
@@ -59,6 +59,7 @@
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
+        <li><a href="#">Residents</a></li>
         <li><a href="waste.html">Bins and recycling</a></li>
         <li aria-current="page">Recycling centres</li>
       </ol>


### PR DESCRIPTION
## Summary

Unifies breadcrumbs so district and county services follow the same trail: `Home > Residents > [service]`, and detail pages `Home > Residents > [hub] > [topic]`.

- County single-service pages (adult social care, children, highways, libraries) gained the missing "Residents" level.
- The three newer county pages (registrars, blue badges, school admissions) had a middle crumb pointing at the removed `#county-services` anchor — repointed to Residents.
- `waste-recycling-centres` was missing "Residents" — added.

Verified all 31 service pages now have "Residents" as the second breadcrumb item.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJ29uNGieSuureHRDAyPKy)_