### PR TITLE
Add About the council and Contact us pages to both LGR sites

### DIFF
--- a/LGR/Consolidated/about.html
+++ b/LGR/Consolidated/about.html
@@ -1,0 +1,265 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>About the council – Newstershire Council</title>
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="council-tax.css">
+</head>
+<body>
+
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <div class="utility-bar">
+    <div class="container utility-bar__inner">
+      <span class="utility-bar__item">
+        <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 16.92v3a2 2 0 01-2.18 2 19.79 19.79 0 01-8.63-3.07A19.5 19.5 0 013.07 9.8 19.79 19.79 0 01.22 1.18 2 2 0 012.22 0h3a2 2 0 012 1.72c.13 1 .37 1.97.72 2.9a2 2 0 01-.45 2.11L6.09 7.91a16 16 0 006 6l1.18-1.18a2 2 0 012.11-.45c.93.35 1.9.59 2.9.72A2 2 0 0122 14.92v2z"/></svg>
+        0800 123 4567
+      </span>
+      <span class="utility-bar__item">
+        <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
+        info@newstershire.gov.uk
+      </span>
+      <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
+    </div>
+  </div>
+
+  <header class="site-header">
+    <div class="container site-header__inner">
+      <div class="logo-lockup">
+        <a href="index.html" style="text-decoration:none;display:flex;align-items:center;gap:0.75rem;">
+          <svg class="logo-icon" aria-hidden="true" focusable="false" width="52" height="52" viewBox="0 0 52 52">
+            <circle cx="26" cy="26" r="26" fill="#1d4477"/>
+            <path d="M10 36 Q18 18 26 22 Q34 18 42 36 Z" fill="#c8a951" opacity="0.9"/>
+            <path d="M18 36 Q22 26 26 28 Q30 26 34 36 Z" fill="#ffffff" opacity="0.85"/>
+            <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
+          </svg>
+          <div>
+            <span class="org-name">Newstershire Council</span>
+            <span class="org-tagline">Serving Gloucestershire together</span>
+          </div>
+        </a>
+      </div>
+      <button class="nav-toggle" aria-expanded="false" aria-controls="header-nav" aria-label="Open menu">
+        <svg aria-hidden="true" focusable="false" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+      </button>
+      <nav id="header-nav" class="header-nav" aria-label="Site navigation">
+        <ul>
+          <li><a href="index.html" class="nav-link">Home</a></li>
+          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="about.html" class="nav-link nav-link--active">About us</a></li>
+          <li><a href="contact.html" class="nav-link">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <div class="container">
+      <ol>
+        <li><a href="index.html">Home</a></li>
+        <li><a href="#">About us</a></li>
+        <li aria-current="page">About the council</li>
+      </ol>
+    </div>
+  </nav>
+
+  <section class="page-hero" aria-label="About the council">
+    <div class="container">
+      <h1 class="page-hero__title">About the council</h1>
+      <p class="page-hero__sub">Who we are, the area we serve, how we're run, and the story of how Gloucestershire's councils came together as one.</p>
+    </div>
+  </section>
+
+  <main id="main-content">
+    <div class="container page-body">
+
+      <p class="lead">Newstershire Council is the new unitary authority for Gloucestershire. On 1 April 2027 we replaced Gloucestershire County Council and the six district and borough councils with a single council responsible for every local government service across the county — from adult social care and roads to bins, planning and council tax.</p>
+      <p>One council means one place to find services, one phone number to call, and one organisation accountable for getting things right — while keeping decisions as close as possible to the communities they affect.</p>
+
+      <section class="section-block" aria-labelledby="why-heading">
+        <h2 id="why-heading">Why local government reorganised</h2>
+        <p>For decades, Gloucestershire ran a two-tier system: a county council for services like education, social care and highways, and six district and borough councils for services like bins, housing and planning. It worked, but it also meant residents often weren't sure who to contact, and effort was duplicated across seven organisations.</p>
+        <p>Reorganisation brings those services together under one unitary council. The aim is simpler access for residents, lower running costs, and clearer accountability — with the savings reinvested in frontline services.</p>
+      </section>
+
+      <section class="section-block" aria-labelledby="area-heading">
+        <h2 id="area-heading">The area we serve</h2>
+        <p>We serve around 650,000 residents across the whole of Gloucestershire — the six former district and borough areas, now one council:</p>
+        <div class="area-grid">
+          <div class="area-item"><strong>Cheltenham</strong><span>approx. 117,000 residents</span></div>
+          <div class="area-item"><strong>Cotswold</strong><span>approx. 91,000 residents</span></div>
+          <div class="area-item"><strong>Forest of Dean</strong><span>approx. 87,000 residents</span></div>
+          <div class="area-item"><strong>Gloucester</strong><span>approx. 132,000 residents</span></div>
+          <div class="area-item"><strong>Stroud</strong><span>approx. 121,000 residents</span></div>
+          <div class="area-item"><strong>Tewkesbury</strong><span>approx. 96,000 residents</span></div>
+        </div>
+      </section>
+
+      <section class="section-block" aria-labelledby="how-heading">
+        <h2 id="how-heading">How the council works</h2>
+        <p>Newstershire Council is made up of elected councillors, supported by council officers. Councillors set the policies and budget; officers deliver the day-to-day services.</p>
+        <div class="info-grid">
+          <div class="info-card">
+            <h3>Full Council</h3>
+            <p>All elected councillors meet to agree the budget, the council's major plans, and the overall policy framework.</p>
+          </div>
+          <div class="info-card">
+            <h3>Leader &amp; Cabinet</h3>
+            <p>The Leader and a small Cabinet take most day-to-day decisions, each Cabinet member holding a specific portfolio.</p>
+          </div>
+          <div class="info-card">
+            <h3>Scrutiny committees</h3>
+            <p>Cross-party committees hold the Cabinet to account, review decisions, and examine how services are performing.</p>
+          </div>
+          <div class="info-card">
+            <h3>Regulatory committees</h3>
+            <p>Planning, licensing and audit committees take specific statutory decisions independently of political priorities.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section-block" aria-labelledby="cabinet-heading">
+        <h2 id="cabinet-heading">Our leadership</h2>
+        <p>The Cabinet is responsible for the council's key services and decisions.</p>
+        <div class="people-grid">
+          <div class="person-card"><div class="person-avatar" aria-hidden="true">ME</div><h3>Cllr Margaret Ellwood</h3><p class="person-role">Leader of the Council</p></div>
+          <div class="person-card"><div class="person-avatar" aria-hidden="true">DN</div><h3>Cllr David Nkomo</h3><p class="person-role">Deputy Leader &amp; Finance</p></div>
+          <div class="person-card"><div class="person-avatar" aria-hidden="true">PS</div><h3>Cllr Priya Shah</h3><p class="person-role">Adult Social Care &amp; Health</p></div>
+          <div class="person-card"><div class="person-avatar" aria-hidden="true">TB</div><h3>Cllr Tom Beckett</h3><p class="person-role">Children &amp; Education</p></div>
+          <div class="person-card"><div class="person-avatar" aria-hidden="true">RA</div><h3>Cllr Rachel Attwood</h3><p class="person-role">Environment &amp; Waste</p></div>
+          <div class="person-card"><div class="person-avatar" aria-hidden="true">JO</div><h3>Cllr James Okafor</h3><p class="person-role">Housing &amp; Planning</p></div>
+          <div class="person-card"><div class="person-avatar" aria-hidden="true">SP</div><h3>Cllr Susan Pretchard</h3><p class="person-role">Highways &amp; Transport</p></div>
+          <div class="person-card"><div class="person-avatar" aria-hidden="true">FM</div><h3>Fiona Marsh</h3><p class="person-role">Chief Executive (officer)</p></div>
+        </div>
+      </section>
+
+      <section class="section-block" aria-labelledby="priorities-heading">
+        <h2 id="priorities-heading">Our priorities</h2>
+        <p>Our Council Plan sets out what we're focused on for residents:</p>
+        <ul class="tick">
+          <li>One council that's easier to deal with — services in one place, closer to communities</li>
+          <li>Value for money, with reorganisation savings reinvested in frontline services</li>
+          <li>A thriving local economy and vibrant town centres</li>
+          <li>Tackling climate change and protecting Gloucestershire's environment</li>
+          <li>Strong, healthy and connected communities</li>
+        </ul>
+      </section>
+
+      <section class="section-block" aria-labelledby="timeline-heading">
+        <h2 id="timeline-heading">The road to one council</h2>
+        <ol class="timeline">
+          <li class="is-done"><span class="t-date">2024</span><p class="t-body">Government invites Gloucestershire's councils to propose a single unitary authority.</p></li>
+          <li class="is-done"><span class="t-date">February 2026</span><p class="t-body">Newstershire Council is established in shadow form to plan the transition.</p></li>
+          <li class="is-done"><span class="t-date">June 2026</span><p class="t-body">Residents are invited to have their say on services, priorities and the new council's name.</p></li>
+          <li><span class="t-date">1 April 2027</span><p class="t-body">Newstershire Council goes live. The county council and the six district and borough councils are abolished.</p></li>
+          <li><span class="t-date">2027–2028</span><p class="t-body">Services are progressively brought onto one website, one phone line and one set of systems.</p></li>
+        </ol>
+      </section>
+
+      <section class="section-block" aria-labelledby="budget-heading">
+        <h2 id="budget-heading">Budget and spending</h2>
+        <p>Our budget is agreed each year by Full Council and funded through council tax, business rates, government grants and fees and charges. We publish our spending, contracts over £5,000, senior salaries and performance data as part of our commitment to transparency.</p>
+        <p>Reorganisation is expected to reduce running costs by removing duplication across the former seven councils — for example, one set of senior management, one payroll, and shared back-office systems.</p>
+      </section>
+
+      <div class="cta-band">
+        <div class="cta-band__text">
+          <h2>Get in touch</h2>
+          <p>Questions about the council, or need to reach a service? We're here to help.</p>
+        </div>
+        <a href="contact.html" class="btn">Contact us</a>
+      </div>
+
+    </div>
+  </main>
+
+  <section class="prefooter" aria-label="Stay connected">
+    <div class="container prefooter__inner">
+      <div class="prefooter__social">
+        <h2 class="prefooter__heading">Follow us</h2>
+        <div class="social-links">
+          <a href="#" class="social-link" aria-label="Newstershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
+          <a href="#" class="social-link" aria-label="Newstershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
+          <a href="#" class="social-link" aria-label="Newstershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
+          <a href="#" class="social-link" aria-label="Newstershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
+        </div>
+      </div>
+      <div class="prefooter__newsletter">
+        <h2 class="prefooter__heading">Stay informed</h2>
+        <p>Get council news and service updates straight to your inbox.</p>
+        <form class="newsletter-form" action="#" method="post" aria-label="Newsletter sign-up">
+          <label for="newsletter-email" class="sr-only">Email address</label>
+          <input type="email" id="newsletter-email" name="email" placeholder="Your email address" autocomplete="email">
+          <button type="submit">Sign up</button>
+        </form>
+      </div>
+    </div>
+  </section>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="footer-grid">
+        <div class="footer-col">
+          <h3 class="footer-col__title">About Newstershire</h3>
+          <ul>
+            <li><a href="about.html">About the council</a></li>
+            <li><a href="about.html#cabinet-heading">Councillors and committees</a></li>
+            <li><a href="about.html#how-heading">Council meetings</a></li>
+            <li><a href="about.html#budget-heading">Budget and spending</a></li>
+            <li><a href="about.html#timeline-heading">LGR transition</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <h3 class="footer-col__title">Residents</h3>
+          <ul>
+            <li><a href="council-tax.html">Council tax</a></li>
+            <li><a href="waste.html">Bins and recycling</a></li>
+            <li><a href="planning.html">Planning</a></li>
+            <li><a href="housing.html">Housing</a></li>
+            <li><a href="benefits.html">Benefits and support</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <h3 class="footer-col__title">Business</h3>
+          <ul>
+            <li><a href="#">Business rates</a></li>
+            <li><a href="#">Licences and permits</a></li>
+            <li><a href="#">Trading standards</a></li>
+            <li><a href="#">Economic development</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <h3 class="footer-col__title">Help &amp; legal</h3>
+          <ul>
+            <li><a href="#">Accessibility statement</a></li>
+            <li><a href="#">Privacy policy</a></li>
+            <li><a href="#">Cookies</a></li>
+            <li><a href="#">Freedom of information</a></li>
+            <li><a href="contact.html">Contact us</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. Councillor names, figures and dates on this page are illustrative.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../area-cookie.js"></script>
+  <script>
+    (function () {
+      var btn = document.querySelector('.nav-toggle');
+      var nav = document.getElementById('header-nav');
+      if (!btn || !nav) return;
+      btn.addEventListener('click', function () {
+        var open = nav.classList.toggle('header-nav--open');
+        btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+        btn.setAttribute('aria-label', open ? 'Close menu' : 'Open menu');
+      });
+    }());
+  </script>
+</body>
+</html>

--- a/LGR/Consolidated/benefits-cost-of-living.html
+++ b/LGR/Consolidated/benefits-cost-of-living.html
@@ -48,8 +48,8 @@
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
           <li><a href="#" class="nav-link">News</a></li>
-          <li><a href="#" class="nav-link">About us</a></li>
-          <li><a href="#" class="nav-link">Contact</a></li>
+          <li><a href="about.html" class="nav-link">About us</a></li>
+          <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
     </div>
@@ -205,7 +205,7 @@
         <div class="footer-col">
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
-            <li><a href="#">About the council</a></li>
+            <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
             <li><a href="#">Council meetings</a></li>
             <li><a href="#">Budget and spending</a></li>
@@ -238,7 +238,7 @@
             <li><a href="#">Privacy policy</a></li>
             <li><a href="#">Cookies</a></li>
             <li><a href="#">Freedom of information</a></li>
-            <li><a href="#">Contact us</a></li>
+            <li><a href="contact.html">Contact us</a></li>
           </ul>
         </div>
       </div>

--- a/LGR/Consolidated/benefits-housing-payments.html
+++ b/LGR/Consolidated/benefits-housing-payments.html
@@ -48,8 +48,8 @@
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
           <li><a href="#" class="nav-link">News</a></li>
-          <li><a href="#" class="nav-link">About us</a></li>
-          <li><a href="#" class="nav-link">Contact</a></li>
+          <li><a href="about.html" class="nav-link">About us</a></li>
+          <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
     </div>
@@ -198,7 +198,7 @@
         <div class="footer-col">
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
-            <li><a href="#">About the council</a></li>
+            <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
             <li><a href="#">Council meetings</a></li>
             <li><a href="#">Budget and spending</a></li>
@@ -231,7 +231,7 @@
             <li><a href="#">Privacy policy</a></li>
             <li><a href="#">Cookies</a></li>
             <li><a href="#">Freedom of information</a></li>
-            <li><a href="#">Contact us</a></li>
+            <li><a href="contact.html">Contact us</a></li>
           </ul>
         </div>
       </div>

--- a/LGR/Consolidated/benefits-universal-credit.html
+++ b/LGR/Consolidated/benefits-universal-credit.html
@@ -48,8 +48,8 @@
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
           <li><a href="#" class="nav-link">News</a></li>
-          <li><a href="#" class="nav-link">About us</a></li>
-          <li><a href="#" class="nav-link">Contact</a></li>
+          <li><a href="about.html" class="nav-link">About us</a></li>
+          <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
     </div>
@@ -199,7 +199,7 @@
         <div class="footer-col">
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
-            <li><a href="#">About the council</a></li>
+            <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
             <li><a href="#">Council meetings</a></li>
             <li><a href="#">Budget and spending</a></li>
@@ -232,7 +232,7 @@
             <li><a href="#">Privacy policy</a></li>
             <li><a href="#">Cookies</a></li>
             <li><a href="#">Freedom of information</a></li>
-            <li><a href="#">Contact us</a></li>
+            <li><a href="contact.html">Contact us</a></li>
           </ul>
         </div>
       </div>

--- a/LGR/Consolidated/benefits.html
+++ b/LGR/Consolidated/benefits.html
@@ -49,8 +49,8 @@
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
           <li><a href="#" class="nav-link">News</a></li>
-          <li><a href="#" class="nav-link">About us</a></li>
-          <li><a href="#" class="nav-link">Contact</a></li>
+          <li><a href="about.html" class="nav-link">About us</a></li>
+          <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
     </div>
@@ -186,7 +186,7 @@
         <div class="footer-col">
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
-            <li><a href="#">About the council</a></li>
+            <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
             <li><a href="#">Council meetings</a></li>
             <li><a href="#">Budget and spending</a></li>
@@ -220,7 +220,7 @@
             <li><a href="#">Privacy policy</a></li>
             <li><a href="#">Cookies</a></li>
             <li><a href="#">Freedom of information</a></li>
-            <li><a href="#">Contact us</a></li>
+            <li><a href="contact.html">Contact us</a></li>
           </ul>
         </div>
       </div>

--- a/LGR/Consolidated/contact.html
+++ b/LGR/Consolidated/contact.html
@@ -1,0 +1,325 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Contact us – Newstershire Council</title>
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="council-tax.css">
+</head>
+<body>
+
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <div class="utility-bar">
+    <div class="container utility-bar__inner">
+      <span class="utility-bar__item">
+        <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 16.92v3a2 2 0 01-2.18 2 19.79 19.79 0 01-8.63-3.07A19.5 19.5 0 013.07 9.8 19.79 19.79 0 01.22 1.18 2 2 0 012.22 0h3a2 2 0 012 1.72c.13 1 .37 1.97.72 2.9a2 2 0 01-.45 2.11L6.09 7.91a16 16 0 006 6l1.18-1.18a2 2 0 012.11-.45c.93.35 1.9.59 2.9.72A2 2 0 0122 14.92v2z"/></svg>
+        0800 123 4567
+      </span>
+      <span class="utility-bar__item">
+        <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
+        info@newstershire.gov.uk
+      </span>
+      <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
+    </div>
+  </div>
+
+  <header class="site-header">
+    <div class="container site-header__inner">
+      <div class="logo-lockup">
+        <a href="index.html" style="text-decoration:none;display:flex;align-items:center;gap:0.75rem;">
+          <svg class="logo-icon" aria-hidden="true" focusable="false" width="52" height="52" viewBox="0 0 52 52">
+            <circle cx="26" cy="26" r="26" fill="#1d4477"/>
+            <path d="M10 36 Q18 18 26 22 Q34 18 42 36 Z" fill="#c8a951" opacity="0.9"/>
+            <path d="M18 36 Q22 26 26 28 Q30 26 34 36 Z" fill="#ffffff" opacity="0.85"/>
+            <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
+          </svg>
+          <div>
+            <span class="org-name">Newstershire Council</span>
+            <span class="org-tagline">Serving Gloucestershire together</span>
+          </div>
+        </a>
+      </div>
+      <button class="nav-toggle" aria-expanded="false" aria-controls="header-nav" aria-label="Open menu">
+        <svg aria-hidden="true" focusable="false" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+      </button>
+      <nav id="header-nav" class="header-nav" aria-label="Site navigation">
+        <ul>
+          <li><a href="index.html" class="nav-link">Home</a></li>
+          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="about.html" class="nav-link">About us</a></li>
+          <li><a href="contact.html" class="nav-link nav-link--active">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <div class="container">
+      <ol>
+        <li><a href="index.html">Home</a></li>
+        <li aria-current="page">Contact us</li>
+      </ol>
+    </div>
+  </nav>
+
+  <section class="page-hero" aria-label="Contact us">
+    <div class="container">
+      <h1 class="page-hero__title">Contact us</h1>
+      <p class="page-hero__sub">Reach the right team quickly. Many things can be done online any time — but if you'd rather talk to us, here's how.</p>
+    </div>
+  </section>
+
+  <main id="main-content">
+    <div class="container page-body">
+
+      <p class="lead">The quickest way to get help is usually online — most services on this site can be started or completed 24/7. If you can't do it online, or your query is urgent, use the contacts below.</p>
+
+      <section class="section-block" aria-labelledby="general-heading">
+        <h2 id="general-heading">General enquiries</h2>
+        <div class="contact-grid">
+          <div class="contact-card">
+            <h3>Phone</h3>
+            <p><strong>0800 123 4567</strong></p>
+            <p>Monday to Friday, 8:30am–5pm</p>
+            <p>Closed weekends and bank holidays</p>
+          </div>
+          <div class="contact-card">
+            <h3>Email</h3>
+            <p><a href="mailto:info@newstershire.gov.uk">info@newstershire.gov.uk</a></p>
+            <p>We aim to reply within 5 working days</p>
+          </div>
+          <div class="contact-card">
+            <h3>Out of hours emergencies</h3>
+            <p><strong>0800 123 9999</strong></p>
+            <p>For genuine emergencies that can't wait — dangerous roads, homelessness tonight, and adult or child safeguarding.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section-block" aria-labelledby="service-heading">
+        <h2 id="service-heading">Contact a service directly</h2>
+        <p>You'll usually get a faster answer by going straight to the service you need:</p>
+        <div class="contact-grid">
+          <div class="contact-card">
+            <h3>Council tax &amp; benefits</h3>
+            <p>0800 123 4501</p>
+            <p><a href="council-tax.html">Council tax</a> · <a href="benefits.html">Benefits &amp; support</a></p>
+          </div>
+          <div class="contact-card">
+            <h3>Bins &amp; recycling</h3>
+            <p>0800 123 4502</p>
+            <p><a href="waste.html">Report a missed bin or find your day</a></p>
+          </div>
+          <div class="contact-card">
+            <h3>Planning</h3>
+            <p>0800 123 4503</p>
+            <p><a href="planning.html">Planning applications and advice</a></p>
+          </div>
+          <div class="contact-card">
+            <h3>Housing</h3>
+            <p>0800 123 4504</p>
+            <p><a href="housing.html">Homelessness and the housing register</a></p>
+          </div>
+          <div class="contact-card">
+            <h3>Adult social care</h3>
+            <p>01452 426868</p>
+            <p><a href="county-adult-social-care.html">Assessments and support</a></p>
+          </div>
+          <div class="contact-card">
+            <h3>Children &amp; families</h3>
+            <p>01452 426565</p>
+            <p><a href="county-childrens-services.html">Report a concern about a child</a></p>
+          </div>
+          <div class="contact-card">
+            <h3>Highways &amp; roads</h3>
+            <p>Report online via Fix My Street</p>
+            <p><a href="county-highways.html">Potholes, street lights and drains</a></p>
+          </div>
+          <div class="contact-card">
+            <h3>Registrars</h3>
+            <p>01452 425060</p>
+            <p><a href="county-registrars.html">Births, deaths, marriages</a></p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section-block" aria-labelledby="offices-heading">
+        <h2 id="offices-heading">Visit us</h2>
+        <p>Our main offices are open by appointment. Please book before travelling — many enquiries can be resolved by phone or online without a visit.</p>
+        <div class="contact-grid">
+          <div class="contact-card">
+            <h3>Newstershire House (main office)</h3>
+            <p>1 Shire Way, Gloucester, GL1 1AA</p>
+            <p>Mon–Fri, 9am–4:30pm, by appointment</p>
+          </div>
+          <div class="contact-card">
+            <h3>Cheltenham hub</h3>
+            <p>Municipal Offices, Promenade, Cheltenham, GL50 1PP</p>
+            <p>Mon–Fri, 9am–4pm</p>
+          </div>
+          <div class="contact-card">
+            <h3>Stroud hub</h3>
+            <p>Ebley Mill, Ebley Wharf, Stroud, GL5 4UB</p>
+            <p>Mon–Thu, 9am–4:30pm; Fri, 9am–4pm</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section-block" aria-labelledby="form-heading">
+        <h2 id="form-heading">Send us a message</h2>
+        <p>Use this form for general enquiries. For anything urgent, please phone. Fields marked with an asterisk (*) are required.</p>
+        <form class="contact-form" action="#" method="post" aria-labelledby="form-heading">
+          <div class="form-row">
+            <label for="cf-name">Your name *</label>
+            <input type="text" id="cf-name" name="name" autocomplete="name" required>
+          </div>
+          <div class="form-row">
+            <label for="cf-email">Email address *</label>
+            <input type="email" id="cf-email" name="email" autocomplete="email" required>
+          </div>
+          <div class="form-row">
+            <label for="cf-topic">What's your enquiry about? *</label>
+            <select id="cf-topic" name="topic" required>
+              <option value="">Please choose…</option>
+              <option>Council tax or benefits</option>
+              <option>Bins and recycling</option>
+              <option>Planning</option>
+              <option>Housing</option>
+              <option>Adult social care</option>
+              <option>Children and families</option>
+              <option>Highways and roads</option>
+              <option>Something else</option>
+            </select>
+          </div>
+          <div class="form-row">
+            <label for="cf-message">Your message *</label>
+            <textarea id="cf-message" name="message" rows="6" required></textarea>
+          </div>
+          <div class="form-actions">
+            <button type="submit">Send message</button>
+          </div>
+        </form>
+      </section>
+
+      <section class="section-block" aria-labelledby="access-heading">
+        <h2 id="access-heading">Accessibility and other formats</h2>
+        <p>We want everyone to be able to reach us. We can provide information in large print, easy read, braille or audio, and arrange interpretation, including British Sign Language (BSL), on request.</p>
+        <ul class="tick">
+          <li>Text relay: dial <strong>18001</strong> then our number</li>
+          <li>Ask about a face-to-face or video BSL interpreter when you contact us</li>
+          <li>Tell us if you need documents in a different format and we'll arrange it</li>
+        </ul>
+      </section>
+
+      <section class="section-block" aria-labelledby="complaints-heading">
+        <h2 id="complaints-heading">Complaints, feedback and information requests</h2>
+        <p>If something's gone wrong, tell us — we use complaints to put things right and improve. You can also make a Freedom of Information request or ask what personal data we hold about you.</p>
+        <div class="contact-grid">
+          <div class="contact-card">
+            <h3>Complaints &amp; feedback</h3>
+            <p><a href="mailto:feedback@newstershire.gov.uk">feedback@newstershire.gov.uk</a></p>
+          </div>
+          <div class="contact-card">
+            <h3>Freedom of Information</h3>
+            <p><a href="mailto:foi@newstershire.gov.uk">foi@newstershire.gov.uk</a></p>
+          </div>
+          <div class="contact-card">
+            <h3>Data protection</h3>
+            <p><a href="mailto:dpo@newstershire.gov.uk">dpo@newstershire.gov.uk</a></p>
+          </div>
+        </div>
+      </section>
+
+    </div>
+  </main>
+
+  <section class="prefooter" aria-label="Stay connected">
+    <div class="container prefooter__inner">
+      <div class="prefooter__social">
+        <h2 class="prefooter__heading">Follow us</h2>
+        <div class="social-links">
+          <a href="#" class="social-link" aria-label="Newstershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
+          <a href="#" class="social-link" aria-label="Newstershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
+          <a href="#" class="social-link" aria-label="Newstershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
+          <a href="#" class="social-link" aria-label="Newstershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
+        </div>
+      </div>
+      <div class="prefooter__newsletter">
+        <h2 class="prefooter__heading">Stay informed</h2>
+        <p>Get council news and service updates straight to your inbox.</p>
+        <form class="newsletter-form" action="#" method="post" aria-label="Newsletter sign-up">
+          <label for="newsletter-email" class="sr-only">Email address</label>
+          <input type="email" id="newsletter-email" name="email" placeholder="Your email address" autocomplete="email">
+          <button type="submit">Sign up</button>
+        </form>
+      </div>
+    </div>
+  </section>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="footer-grid">
+        <div class="footer-col">
+          <h3 class="footer-col__title">About Newstershire</h3>
+          <ul>
+            <li><a href="about.html">About the council</a></li>
+            <li><a href="about.html#cabinet-heading">Councillors and committees</a></li>
+            <li><a href="about.html#how-heading">Council meetings</a></li>
+            <li><a href="about.html#budget-heading">Budget and spending</a></li>
+            <li><a href="about.html#timeline-heading">LGR transition</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <h3 class="footer-col__title">Residents</h3>
+          <ul>
+            <li><a href="council-tax.html">Council tax</a></li>
+            <li><a href="waste.html">Bins and recycling</a></li>
+            <li><a href="planning.html">Planning</a></li>
+            <li><a href="housing.html">Housing</a></li>
+            <li><a href="benefits.html">Benefits and support</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <h3 class="footer-col__title">Business</h3>
+          <ul>
+            <li><a href="#">Business rates</a></li>
+            <li><a href="#">Licences and permits</a></li>
+            <li><a href="#">Trading standards</a></li>
+            <li><a href="#">Economic development</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <h3 class="footer-col__title">Help &amp; legal</h3>
+          <ul>
+            <li><a href="#">Accessibility statement</a></li>
+            <li><a href="#">Privacy policy</a></li>
+            <li><a href="#">Cookies</a></li>
+            <li><a href="#">Freedom of information</a></li>
+            <li><a href="contact.html">Contact us</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. Contact details on this page are illustrative.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../area-cookie.js"></script>
+  <script>
+    (function () {
+      var btn = document.querySelector('.nav-toggle');
+      var nav = document.getElementById('header-nav');
+      if (!btn || !nav) return;
+      btn.addEventListener('click', function () {
+        var open = nav.classList.toggle('header-nav--open');
+        btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+        btn.setAttribute('aria-label', open ? 'Close menu' : 'Open menu');
+      });
+    }());
+  </script>
+</body>
+</html>

--- a/LGR/Consolidated/council-tax.html
+++ b/LGR/Consolidated/council-tax.html
@@ -49,8 +49,8 @@
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
           <li><a href="#" class="nav-link">News</a></li>
-          <li><a href="#" class="nav-link">About us</a></li>
-          <li><a href="#" class="nav-link">Contact</a></li>
+          <li><a href="about.html" class="nav-link">About us</a></li>
+          <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
     </div>
@@ -522,7 +522,7 @@
         <div class="footer-col">
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
-            <li><a href="#">About the council</a></li>
+            <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
             <li><a href="#">Council meetings</a></li>
             <li><a href="#">Budget and spending</a></li>
@@ -556,7 +556,7 @@
             <li><a href="#">Privacy policy</a></li>
             <li><a href="#">Cookies</a></li>
             <li><a href="#">Freedom of information</a></li>
-            <li><a href="#">Contact us</a></li>
+            <li><a href="contact.html">Contact us</a></li>
           </ul>
         </div>
       </div>

--- a/LGR/Consolidated/county-adult-social-care.html
+++ b/LGR/Consolidated/county-adult-social-care.html
@@ -59,6 +59,7 @@
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
+        <li><a href="#">Residents</a></li>
         <li aria-current="page">Adult social care</li>
       </ol>
     </div>

--- a/LGR/Consolidated/county-blue-badges.html
+++ b/LGR/Consolidated/county-blue-badges.html
@@ -48,8 +48,8 @@
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
           <li><a href="#" class="nav-link">News</a></li>
-          <li><a href="#" class="nav-link">About us</a></li>
-          <li><a href="#" class="nav-link">Contact</a></li>
+          <li><a href="about.html" class="nav-link">About us</a></li>
+          <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
     </div>
@@ -145,7 +145,7 @@
         <div class="footer-col">
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
-            <li><a href="#">About the council</a></li>
+            <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
             <li><a href="#">Council meetings</a></li>
             <li><a href="#">Budget and spending</a></li>
@@ -183,7 +183,7 @@
             <li><a href="#">Privacy policy</a></li>
             <li><a href="#">Cookies</a></li>
             <li><a href="#">Freedom of information</a></li>
-            <li><a href="#">Contact us</a></li>
+            <li><a href="contact.html">Contact us</a></li>
           </ul>
         </div>
       </div>

--- a/LGR/Consolidated/county-blue-badges.html
+++ b/LGR/Consolidated/county-blue-badges.html
@@ -59,7 +59,7 @@
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
-        <li><a href="index.html#county-services">County-wide services</a></li>
+        <li><a href="#">Residents</a></li>
         <li aria-current="page">Blue Badges &amp; travel</li>
       </ol>
     </div>

--- a/LGR/Consolidated/county-childrens-services.html
+++ b/LGR/Consolidated/county-childrens-services.html
@@ -48,8 +48,8 @@
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
           <li><a href="#" class="nav-link">News</a></li>
-          <li><a href="#" class="nav-link">About us</a></li>
-          <li><a href="#" class="nav-link">Contact</a></li>
+          <li><a href="about.html" class="nav-link">About us</a></li>
+          <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
     </div>
@@ -159,7 +159,7 @@
         <div class="footer-col">
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
-            <li><a href="#">About the council</a></li>
+            <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
             <li><a href="#">Council meetings</a></li>
             <li><a href="#">Budget and spending</a></li>
@@ -197,7 +197,7 @@
             <li><a href="#">Privacy policy</a></li>
             <li><a href="#">Cookies</a></li>
             <li><a href="#">Freedom of information</a></li>
-            <li><a href="#">Contact us</a></li>
+            <li><a href="contact.html">Contact us</a></li>
           </ul>
         </div>
       </div>

--- a/LGR/Consolidated/county-childrens-services.html
+++ b/LGR/Consolidated/county-childrens-services.html
@@ -59,6 +59,7 @@
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
+        <li><a href="#">Residents</a></li>
         <li aria-current="page">Children &amp; families</li>
       </ol>
     </div>

--- a/LGR/Consolidated/county-highways.html
+++ b/LGR/Consolidated/county-highways.html
@@ -48,8 +48,8 @@
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
           <li><a href="#" class="nav-link">News</a></li>
-          <li><a href="#" class="nav-link">About us</a></li>
-          <li><a href="#" class="nav-link">Contact</a></li>
+          <li><a href="about.html" class="nav-link">About us</a></li>
+          <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
     </div>
@@ -154,7 +154,7 @@
         <div class="footer-col">
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
-            <li><a href="#">About the council</a></li>
+            <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
             <li><a href="#">Council meetings</a></li>
             <li><a href="#">Budget and spending</a></li>
@@ -192,7 +192,7 @@
             <li><a href="#">Privacy policy</a></li>
             <li><a href="#">Cookies</a></li>
             <li><a href="#">Freedom of information</a></li>
-            <li><a href="#">Contact us</a></li>
+            <li><a href="contact.html">Contact us</a></li>
           </ul>
         </div>
       </div>

--- a/LGR/Consolidated/county-highways.html
+++ b/LGR/Consolidated/county-highways.html
@@ -59,6 +59,7 @@
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
+        <li><a href="#">Residents</a></li>
         <li aria-current="page">Highways &amp; roads</li>
       </ol>
     </div>

--- a/LGR/Consolidated/county-libraries.html
+++ b/LGR/Consolidated/county-libraries.html
@@ -48,8 +48,8 @@
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
           <li><a href="#" class="nav-link">News</a></li>
-          <li><a href="#" class="nav-link">About us</a></li>
-          <li><a href="#" class="nav-link">Contact</a></li>
+          <li><a href="about.html" class="nav-link">About us</a></li>
+          <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
     </div>
@@ -155,7 +155,7 @@
         <div class="footer-col">
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
-            <li><a href="#">About the council</a></li>
+            <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
             <li><a href="#">Council meetings</a></li>
             <li><a href="#">Budget and spending</a></li>
@@ -193,7 +193,7 @@
             <li><a href="#">Privacy policy</a></li>
             <li><a href="#">Cookies</a></li>
             <li><a href="#">Freedom of information</a></li>
-            <li><a href="#">Contact us</a></li>
+            <li><a href="contact.html">Contact us</a></li>
           </ul>
         </div>
       </div>

--- a/LGR/Consolidated/county-libraries.html
+++ b/LGR/Consolidated/county-libraries.html
@@ -59,6 +59,7 @@
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
+        <li><a href="#">Residents</a></li>
         <li aria-current="page">Libraries</li>
       </ol>
     </div>

--- a/LGR/Consolidated/county-registrars.html
+++ b/LGR/Consolidated/county-registrars.html
@@ -59,7 +59,7 @@
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
-        <li><a href="index.html#county-services">County-wide services</a></li>
+        <li><a href="#">Residents</a></li>
         <li aria-current="page">Registrars</li>
       </ol>
     </div>

--- a/LGR/Consolidated/county-registrars.html
+++ b/LGR/Consolidated/county-registrars.html
@@ -48,8 +48,8 @@
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
           <li><a href="#" class="nav-link">News</a></li>
-          <li><a href="#" class="nav-link">About us</a></li>
-          <li><a href="#" class="nav-link">Contact</a></li>
+          <li><a href="about.html" class="nav-link">About us</a></li>
+          <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
     </div>
@@ -154,7 +154,7 @@
         <div class="footer-col">
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
-            <li><a href="#">About the council</a></li>
+            <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
             <li><a href="#">Council meetings</a></li>
             <li><a href="#">Budget and spending</a></li>
@@ -192,7 +192,7 @@
             <li><a href="#">Privacy policy</a></li>
             <li><a href="#">Cookies</a></li>
             <li><a href="#">Freedom of information</a></li>
-            <li><a href="#">Contact us</a></li>
+            <li><a href="contact.html">Contact us</a></li>
           </ul>
         </div>
       </div>

--- a/LGR/Consolidated/county-school-admissions.html
+++ b/LGR/Consolidated/county-school-admissions.html
@@ -59,7 +59,7 @@
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
-        <li><a href="index.html#county-services">County-wide services</a></li>
+        <li><a href="#">Residents</a></li>
         <li aria-current="page">School admissions</li>
       </ol>
     </div>

--- a/LGR/Consolidated/county-school-admissions.html
+++ b/LGR/Consolidated/county-school-admissions.html
@@ -48,8 +48,8 @@
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
           <li><a href="#" class="nav-link">News</a></li>
-          <li><a href="#" class="nav-link">About us</a></li>
-          <li><a href="#" class="nav-link">Contact</a></li>
+          <li><a href="about.html" class="nav-link">About us</a></li>
+          <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
     </div>
@@ -157,7 +157,7 @@
         <div class="footer-col">
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
-            <li><a href="#">About the council</a></li>
+            <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
             <li><a href="#">Council meetings</a></li>
             <li><a href="#">Budget and spending</a></li>
@@ -195,7 +195,7 @@
             <li><a href="#">Privacy policy</a></li>
             <li><a href="#">Cookies</a></li>
             <li><a href="#">Freedom of information</a></li>
-            <li><a href="#">Contact us</a></li>
+            <li><a href="contact.html">Contact us</a></li>
           </ul>
         </div>
       </div>

--- a/LGR/Consolidated/housing-affordable.html
+++ b/LGR/Consolidated/housing-affordable.html
@@ -48,8 +48,8 @@
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
           <li><a href="#" class="nav-link">News</a></li>
-          <li><a href="#" class="nav-link">About us</a></li>
-          <li><a href="#" class="nav-link">Contact</a></li>
+          <li><a href="about.html" class="nav-link">About us</a></li>
+          <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
     </div>
@@ -195,7 +195,7 @@
         <div class="footer-col">
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
-            <li><a href="#">About the council</a></li>
+            <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
             <li><a href="#">Council meetings</a></li>
             <li><a href="#">Budget and spending</a></li>
@@ -229,7 +229,7 @@
             <li><a href="#">Privacy policy</a></li>
             <li><a href="#">Cookies</a></li>
             <li><a href="#">Freedom of information</a></li>
-            <li><a href="#">Contact us</a></li>
+            <li><a href="contact.html">Contact us</a></li>
           </ul>
         </div>
       </div>

--- a/LGR/Consolidated/housing-homelessness.html
+++ b/LGR/Consolidated/housing-homelessness.html
@@ -48,8 +48,8 @@
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
           <li><a href="#" class="nav-link">News</a></li>
-          <li><a href="#" class="nav-link">About us</a></li>
-          <li><a href="#" class="nav-link">Contact</a></li>
+          <li><a href="about.html" class="nav-link">About us</a></li>
+          <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
     </div>
@@ -225,7 +225,7 @@
         <div class="footer-col">
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
-            <li><a href="#">About the council</a></li>
+            <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
             <li><a href="#">Council meetings</a></li>
             <li><a href="#">Budget and spending</a></li>
@@ -259,7 +259,7 @@
             <li><a href="#">Privacy policy</a></li>
             <li><a href="#">Cookies</a></li>
             <li><a href="#">Freedom of information</a></li>
-            <li><a href="#">Contact us</a></li>
+            <li><a href="contact.html">Contact us</a></li>
           </ul>
         </div>
       </div>

--- a/LGR/Consolidated/housing-register.html
+++ b/LGR/Consolidated/housing-register.html
@@ -48,8 +48,8 @@
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
           <li><a href="#" class="nav-link">News</a></li>
-          <li><a href="#" class="nav-link">About us</a></li>
-          <li><a href="#" class="nav-link">Contact</a></li>
+          <li><a href="about.html" class="nav-link">About us</a></li>
+          <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
     </div>
@@ -211,7 +211,7 @@
         <div class="footer-col">
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
-            <li><a href="#">About the council</a></li>
+            <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
             <li><a href="#">Council meetings</a></li>
             <li><a href="#">Budget and spending</a></li>
@@ -245,7 +245,7 @@
             <li><a href="#">Privacy policy</a></li>
             <li><a href="#">Cookies</a></li>
             <li><a href="#">Freedom of information</a></li>
-            <li><a href="#">Contact us</a></li>
+            <li><a href="contact.html">Contact us</a></li>
           </ul>
         </div>
       </div>

--- a/LGR/Consolidated/housing-supported.html
+++ b/LGR/Consolidated/housing-supported.html
@@ -48,8 +48,8 @@
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
           <li><a href="#" class="nav-link">News</a></li>
-          <li><a href="#" class="nav-link">About us</a></li>
-          <li><a href="#" class="nav-link">Contact</a></li>
+          <li><a href="about.html" class="nav-link">About us</a></li>
+          <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
     </div>
@@ -192,7 +192,7 @@
         <div class="footer-col">
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
-            <li><a href="#">About the council</a></li>
+            <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
             <li><a href="#">Council meetings</a></li>
             <li><a href="#">Budget and spending</a></li>
@@ -226,7 +226,7 @@
             <li><a href="#">Privacy policy</a></li>
             <li><a href="#">Cookies</a></li>
             <li><a href="#">Freedom of information</a></li>
-            <li><a href="#">Contact us</a></li>
+            <li><a href="contact.html">Contact us</a></li>
           </ul>
         </div>
       </div>

--- a/LGR/Consolidated/housing.html
+++ b/LGR/Consolidated/housing.html
@@ -49,8 +49,8 @@
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
           <li><a href="#" class="nav-link">News</a></li>
-          <li><a href="#" class="nav-link">About us</a></li>
-          <li><a href="#" class="nav-link">Contact</a></li>
+          <li><a href="about.html" class="nav-link">About us</a></li>
+          <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
     </div>
@@ -192,7 +192,7 @@
         <div class="footer-col">
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
-            <li><a href="#">About the council</a></li>
+            <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
             <li><a href="#">Council meetings</a></li>
             <li><a href="#">Budget and spending</a></li>
@@ -226,7 +226,7 @@
             <li><a href="#">Privacy policy</a></li>
             <li><a href="#">Cookies</a></li>
             <li><a href="#">Freedom of information</a></li>
-            <li><a href="#">Contact us</a></li>
+            <li><a href="contact.html">Contact us</a></li>
           </ul>
         </div>
       </div>

--- a/LGR/Consolidated/index.html
+++ b/LGR/Consolidated/index.html
@@ -47,8 +47,8 @@
         <ul>
           <li><a href="#" class="nav-link nav-link--active">Home</a></li>
           <li><a href="#" class="nav-link">News</a></li>
-          <li><a href="#" class="nav-link">About us</a></li>
-          <li><a href="#" class="nav-link">Contact</a></li>
+          <li><a href="about.html" class="nav-link">About us</a></li>
+          <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
     </div>
@@ -414,7 +414,7 @@
         <div class="footer-col">
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
-            <li><a href="#">About the council</a></li>
+            <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
             <li><a href="#">Council meetings</a></li>
             <li><a href="#">Budget and spending</a></li>
@@ -448,7 +448,7 @@
             <li><a href="#">Privacy policy</a></li>
             <li><a href="#">Cookies</a></li>
             <li><a href="#">Freedom of information</a></li>
-            <li><a href="#">Contact us</a></li>
+            <li><a href="contact.html">Contact us</a></li>
           </ul>
         </div>
       </div>

--- a/LGR/Consolidated/planning-appeals.html
+++ b/LGR/Consolidated/planning-appeals.html
@@ -48,8 +48,8 @@
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
           <li><a href="#" class="nav-link">News</a></li>
-          <li><a href="#" class="nav-link">About us</a></li>
-          <li><a href="#" class="nav-link">Contact</a></li>
+          <li><a href="about.html" class="nav-link">About us</a></li>
+          <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
     </div>
@@ -195,7 +195,7 @@
         <div class="footer-col">
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
-            <li><a href="#">About the council</a></li>
+            <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
             <li><a href="#">Council meetings</a></li>
             <li><a href="#">Budget and spending</a></li>
@@ -229,7 +229,7 @@
             <li><a href="#">Privacy policy</a></li>
             <li><a href="#">Cookies</a></li>
             <li><a href="#">Freedom of information</a></li>
-            <li><a href="#">Contact us</a></li>
+            <li><a href="contact.html">Contact us</a></li>
           </ul>
         </div>
       </div>

--- a/LGR/Consolidated/planning-decision.html
+++ b/LGR/Consolidated/planning-decision.html
@@ -48,8 +48,8 @@
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
           <li><a href="#" class="nav-link">News</a></li>
-          <li><a href="#" class="nav-link">About us</a></li>
-          <li><a href="#" class="nav-link">Contact</a></li>
+          <li><a href="about.html" class="nav-link">About us</a></li>
+          <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
     </div>
@@ -203,7 +203,7 @@
         <div class="footer-col">
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
-            <li><a href="#">About the council</a></li>
+            <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
             <li><a href="#">Council meetings</a></li>
             <li><a href="#">Budget and spending</a></li>
@@ -237,7 +237,7 @@
             <li><a href="#">Privacy policy</a></li>
             <li><a href="#">Cookies</a></li>
             <li><a href="#">Freedom of information</a></li>
-            <li><a href="#">Contact us</a></li>
+            <li><a href="contact.html">Contact us</a></li>
           </ul>
         </div>
       </div>

--- a/LGR/Consolidated/planning-fees.html
+++ b/LGR/Consolidated/planning-fees.html
@@ -48,8 +48,8 @@
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
           <li><a href="#" class="nav-link">News</a></li>
-          <li><a href="#" class="nav-link">About us</a></li>
-          <li><a href="#" class="nav-link">Contact</a></li>
+          <li><a href="about.html" class="nav-link">About us</a></li>
+          <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
     </div>
@@ -196,7 +196,7 @@
         <div class="footer-col">
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
-            <li><a href="#">About the council</a></li>
+            <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
             <li><a href="#">Council meetings</a></li>
             <li><a href="#">Budget and spending</a></li>
@@ -230,7 +230,7 @@
             <li><a href="#">Privacy policy</a></li>
             <li><a href="#">Cookies</a></li>
             <li><a href="#">Freedom of information</a></li>
-            <li><a href="#">Contact us</a></li>
+            <li><a href="contact.html">Contact us</a></li>
           </ul>
         </div>
       </div>

--- a/LGR/Consolidated/planning-how-to-apply.html
+++ b/LGR/Consolidated/planning-how-to-apply.html
@@ -48,8 +48,8 @@
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
           <li><a href="#" class="nav-link">News</a></li>
-          <li><a href="#" class="nav-link">About us</a></li>
-          <li><a href="#" class="nav-link">Contact</a></li>
+          <li><a href="about.html" class="nav-link">About us</a></li>
+          <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
     </div>
@@ -208,7 +208,7 @@
         <div class="footer-col">
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
-            <li><a href="#">About the council</a></li>
+            <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
             <li><a href="#">Council meetings</a></li>
             <li><a href="#">Budget and spending</a></li>
@@ -242,7 +242,7 @@
             <li><a href="#">Privacy policy</a></li>
             <li><a href="#">Cookies</a></li>
             <li><a href="#">Freedom of information</a></li>
-            <li><a href="#">Contact us</a></li>
+            <li><a href="contact.html">Contact us</a></li>
           </ul>
         </div>
       </div>

--- a/LGR/Consolidated/planning-local-plan.html
+++ b/LGR/Consolidated/planning-local-plan.html
@@ -48,8 +48,8 @@
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
           <li><a href="#" class="nav-link">News</a></li>
-          <li><a href="#" class="nav-link">About us</a></li>
-          <li><a href="#" class="nav-link">Contact</a></li>
+          <li><a href="about.html" class="nav-link">About us</a></li>
+          <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
     </div>
@@ -192,7 +192,7 @@
         <div class="footer-col">
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
-            <li><a href="#">About the council</a></li>
+            <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
             <li><a href="#">Council meetings</a></li>
             <li><a href="#">Budget and spending</a></li>
@@ -226,7 +226,7 @@
             <li><a href="#">Privacy policy</a></li>
             <li><a href="#">Cookies</a></li>
             <li><a href="#">Freedom of information</a></li>
-            <li><a href="#">Contact us</a></li>
+            <li><a href="contact.html">Contact us</a></li>
           </ul>
         </div>
       </div>

--- a/LGR/Consolidated/planning.html
+++ b/LGR/Consolidated/planning.html
@@ -49,8 +49,8 @@
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
           <li><a href="#" class="nav-link">News</a></li>
-          <li><a href="#" class="nav-link">About us</a></li>
-          <li><a href="#" class="nav-link">Contact</a></li>
+          <li><a href="about.html" class="nav-link">About us</a></li>
+          <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
     </div>
@@ -197,7 +197,7 @@
         <div class="footer-col">
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
-            <li><a href="#">About the council</a></li>
+            <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
             <li><a href="#">Council meetings</a></li>
             <li><a href="#">Budget and spending</a></li>
@@ -231,7 +231,7 @@
             <li><a href="#">Privacy policy</a></li>
             <li><a href="#">Cookies</a></li>
             <li><a href="#">Freedom of information</a></li>
-            <li><a href="#">Contact us</a></li>
+            <li><a href="contact.html">Contact us</a></li>
           </ul>
         </div>
       </div>

--- a/LGR/Consolidated/style.css
+++ b/LGR/Consolidated/style.css
@@ -818,3 +818,76 @@ details[open] summary::before { transform: rotate(90deg); }
   .newsletter-form button { width: 100%; padding: 0.75rem; }
   .footer-grid { grid-template-columns: 1fr 1fr; }
 }
+
+/* =====================================================
+   Interior content pages (About / Contact)
+   ===================================================== */
+.page-hero { background: var(--blue-dark); color: var(--white); padding: 2.25rem 0; border-bottom: 3px solid var(--gold); }
+.page-hero__title { font-size: clamp(1.6rem, 3vw, 2.2rem); font-weight: 700; margin-bottom: 0.4rem; }
+.page-hero__sub { color: var(--blue-light); font-size: 1.0625rem; max-width: 640px; }
+
+.page-body { padding: 2.25rem 0 3rem; }
+.lead { font-size: 1.125rem; max-width: 760px; margin-bottom: 0.5rem; }
+.section-block { margin-top: 2.5rem; }
+.section-block > h2 { font-size: 1.375rem; color: var(--blue-dark); font-weight: 700; margin-bottom: 0.75rem; padding-bottom: 0.4rem; border-bottom: 2px solid var(--blue-light); }
+.section-block > p { margin-bottom: 0.9rem; max-width: 760px; }
+.section-block ul.tick { list-style: none; max-width: 760px; }
+.section-block ul.tick li { position: relative; padding-left: 1.75rem; margin-bottom: 0.5rem; }
+.section-block ul.tick li::before { content: "✓"; position: absolute; left: 0; color: var(--green); font-weight: 700; }
+
+/* Info cards */
+.info-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 1rem; margin-top: 1rem; }
+.info-card { background: var(--white); border: 1px solid var(--border); border-top: 3px solid var(--gold); border-radius: var(--radius); padding: 1.1rem 1.25rem; }
+.info-card h3 { font-size: 1rem; color: var(--blue-dark); font-weight: 700; margin-bottom: 0.4rem; }
+.info-card p { font-size: 0.9375rem; color: var(--text-muted); }
+
+/* People / cabinet */
+.people-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 1rem; margin-top: 1rem; }
+.person-card { background: var(--white); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; text-align: center; }
+.person-avatar { width: 64px; height: 64px; border-radius: 50%; margin: 0 auto 0.75rem; background: var(--blue-light); color: var(--blue-dark); display: flex; align-items: center; justify-content: center; font-size: 1.375rem; font-weight: 700; }
+.person-card h3 { font-size: 1rem; color: var(--blue-dark); margin-bottom: 0.15rem; }
+.person-role { font-size: 0.85rem; color: var(--text-muted); }
+
+/* Area grid */
+.area-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 0.75rem; margin-top: 1rem; }
+.area-item { background: var(--blue-xlight); border: 1px solid var(--blue-light); border-radius: var(--radius); padding: 0.875rem 1rem; }
+.area-item strong { display: block; color: var(--blue-dark); }
+.area-item span { font-size: 0.85rem; color: var(--text-muted); }
+
+/* Timeline */
+.timeline { list-style: none; margin-top: 1rem; border-left: 3px solid var(--blue-light); padding-left: 1.5rem; max-width: 760px; }
+.timeline li { position: relative; padding-bottom: 1.5rem; }
+.timeline li:last-child { padding-bottom: 0; }
+.timeline li::before { content: ""; position: absolute; left: -1.96rem; top: 0.2rem; width: 0.85rem; height: 0.85rem; border-radius: 50%; background: var(--gold); box-shadow: 0 0 0 3px var(--white), 0 0 0 5px var(--blue-light); }
+.timeline li.is-done::before { background: var(--green); }
+.timeline .t-date { font-weight: 700; color: var(--blue-dark); }
+.timeline .t-body { font-size: 0.9375rem; color: var(--text-muted); }
+
+/* Contact cards */
+.contact-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 1rem; margin-top: 1rem; }
+.contact-card { background: var(--white); border: 1px solid var(--border); border-left: 4px solid var(--blue-dark); border-radius: var(--radius); padding: 1.1rem 1.25rem; }
+.contact-card h3 { font-size: 1rem; color: var(--blue-dark); margin-bottom: 0.4rem; }
+.contact-card p { font-size: 0.9375rem; margin-bottom: 0.25rem; }
+
+/* CTA band */
+.cta-band { background: var(--blue-xlight); border: 1px solid var(--blue-light); border-radius: var(--radius); padding: 1.5rem; margin-top: 2.5rem; display: flex; gap: 1rem 1.5rem; align-items: center; justify-content: space-between; flex-wrap: wrap; }
+.cta-band__text h2 { font-size: 1.125rem; color: var(--blue-dark); margin-bottom: 0.2rem; padding: 0; border: 0; }
+.cta-band__text p { font-size: 0.9375rem; color: var(--text-muted); }
+.btn { display: inline-block; background: var(--blue-dark); color: var(--white); padding: 0.7rem 1.25rem; border-radius: var(--radius); text-decoration: none; font-weight: 700; transition: background var(--transition); white-space: nowrap; }
+.btn:hover { background: #163457; color: var(--white); }
+.btn:focus-visible { outline: 3px solid var(--focus); outline-offset: 2px; }
+
+/* Contact form */
+.contact-form { max-width: 640px; margin-top: 1rem; display: grid; gap: 1rem; }
+.form-row { display: flex; flex-direction: column; gap: 0.35rem; }
+.form-row label { font-weight: 600; font-size: 0.9375rem; }
+.form-row input, .form-row select, .form-row textarea { padding: 0.6rem 0.75rem; border: 2px solid var(--border); border-radius: var(--radius); font: inherit; font-size: 1rem; background: var(--white); }
+.form-row input:focus, .form-row select:focus, .form-row textarea:focus { outline: 3px solid var(--focus); outline-offset: 2px; border-color: var(--blue-dark); }
+.form-actions button { background: var(--blue-dark); color: var(--white); border: none; padding: 0.7rem 1.5rem; border-radius: var(--radius); font-weight: 700; font-size: 1rem; cursor: pointer; transition: background var(--transition); }
+.form-actions button:hover { background: #163457; }
+.form-actions button:focus-visible { outline: 3px solid var(--focus); outline-offset: 2px; }
+
+@media (max-width: 540px) {
+  .cta-band { flex-direction: column; align-items: flex-start; }
+  .btn { width: 100%; text-align: center; }
+}

--- a/LGR/Consolidated/waste-bulky.html
+++ b/LGR/Consolidated/waste-bulky.html
@@ -48,8 +48,8 @@
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
           <li><a href="#" class="nav-link">News</a></li>
-          <li><a href="#" class="nav-link">About us</a></li>
-          <li><a href="#" class="nav-link">Contact</a></li>
+          <li><a href="about.html" class="nav-link">About us</a></li>
+          <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
     </div>
@@ -200,7 +200,7 @@
         <div class="footer-col">
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
-            <li><a href="#">About the council</a></li>
+            <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
             <li><a href="#">Council meetings</a></li>
             <li><a href="#">Budget and spending</a></li>
@@ -234,7 +234,7 @@
             <li><a href="#">Privacy policy</a></li>
             <li><a href="#">Cookies</a></li>
             <li><a href="#">Freedom of information</a></li>
-            <li><a href="#">Contact us</a></li>
+            <li><a href="contact.html">Contact us</a></li>
           </ul>
         </div>
       </div>

--- a/LGR/Consolidated/waste-food-waste.html
+++ b/LGR/Consolidated/waste-food-waste.html
@@ -48,8 +48,8 @@
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
           <li><a href="#" class="nav-link">News</a></li>
-          <li><a href="#" class="nav-link">About us</a></li>
-          <li><a href="#" class="nav-link">Contact</a></li>
+          <li><a href="about.html" class="nav-link">About us</a></li>
+          <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
     </div>
@@ -194,7 +194,7 @@
         <div class="footer-col">
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
-            <li><a href="#">About the council</a></li>
+            <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
             <li><a href="#">Council meetings</a></li>
             <li><a href="#">Budget and spending</a></li>
@@ -228,7 +228,7 @@
             <li><a href="#">Privacy policy</a></li>
             <li><a href="#">Cookies</a></li>
             <li><a href="#">Freedom of information</a></li>
-            <li><a href="#">Contact us</a></li>
+            <li><a href="contact.html">Contact us</a></li>
           </ul>
         </div>
       </div>

--- a/LGR/Consolidated/waste-garden-waste.html
+++ b/LGR/Consolidated/waste-garden-waste.html
@@ -48,8 +48,8 @@
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
           <li><a href="#" class="nav-link">News</a></li>
-          <li><a href="#" class="nav-link">About us</a></li>
-          <li><a href="#" class="nav-link">Contact</a></li>
+          <li><a href="about.html" class="nav-link">About us</a></li>
+          <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
     </div>
@@ -193,7 +193,7 @@
         <div class="footer-col">
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
-            <li><a href="#">About the council</a></li>
+            <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
             <li><a href="#">Council meetings</a></li>
             <li><a href="#">Budget and spending</a></li>
@@ -227,7 +227,7 @@
             <li><a href="#">Privacy policy</a></li>
             <li><a href="#">Cookies</a></li>
             <li><a href="#">Freedom of information</a></li>
-            <li><a href="#">Contact us</a></li>
+            <li><a href="contact.html">Contact us</a></li>
           </ul>
         </div>
       </div>

--- a/LGR/Consolidated/waste-general-waste.html
+++ b/LGR/Consolidated/waste-general-waste.html
@@ -48,8 +48,8 @@
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
           <li><a href="#" class="nav-link">News</a></li>
-          <li><a href="#" class="nav-link">About us</a></li>
-          <li><a href="#" class="nav-link">Contact</a></li>
+          <li><a href="about.html" class="nav-link">About us</a></li>
+          <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
     </div>
@@ -207,7 +207,7 @@
         <div class="footer-col">
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
-            <li><a href="#">About the council</a></li>
+            <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
             <li><a href="#">Council meetings</a></li>
             <li><a href="#">Budget and spending</a></li>
@@ -241,7 +241,7 @@
             <li><a href="#">Privacy policy</a></li>
             <li><a href="#">Cookies</a></li>
             <li><a href="#">Freedom of information</a></li>
-            <li><a href="#">Contact us</a></li>
+            <li><a href="contact.html">Contact us</a></li>
           </ul>
         </div>
       </div>

--- a/LGR/Consolidated/waste-recycling-centres.html
+++ b/LGR/Consolidated/waste-recycling-centres.html
@@ -48,8 +48,8 @@
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
           <li><a href="#" class="nav-link">News</a></li>
-          <li><a href="#" class="nav-link">About us</a></li>
-          <li><a href="#" class="nav-link">Contact</a></li>
+          <li><a href="about.html" class="nav-link">About us</a></li>
+          <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
     </div>
@@ -148,7 +148,7 @@
         <div class="footer-col">
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
-            <li><a href="#">About the council</a></li>
+            <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
             <li><a href="#">Council meetings</a></li>
             <li><a href="#">Budget and spending</a></li>
@@ -182,7 +182,7 @@
             <li><a href="#">Privacy policy</a></li>
             <li><a href="#">Cookies</a></li>
             <li><a href="#">Freedom of information</a></li>
-            <li><a href="#">Contact us</a></li>
+            <li><a href="contact.html">Contact us</a></li>
           </ul>
         </div>
       </div>

--- a/LGR/Consolidated/waste-recycling-centres.html
+++ b/LGR/Consolidated/waste-recycling-centres.html
@@ -59,6 +59,7 @@
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
+        <li><a href="#">Residents</a></li>
         <li><a href="waste.html">Bins and recycling</a></li>
         <li aria-current="page">Recycling centres</li>
       </ol>

--- a/LGR/Consolidated/waste-recycling.html
+++ b/LGR/Consolidated/waste-recycling.html
@@ -48,8 +48,8 @@
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
           <li><a href="#" class="nav-link">News</a></li>
-          <li><a href="#" class="nav-link">About us</a></li>
-          <li><a href="#" class="nav-link">Contact</a></li>
+          <li><a href="about.html" class="nav-link">About us</a></li>
+          <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
     </div>
@@ -199,7 +199,7 @@
         <div class="footer-col">
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
-            <li><a href="#">About the council</a></li>
+            <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
             <li><a href="#">Council meetings</a></li>
             <li><a href="#">Budget and spending</a></li>
@@ -233,7 +233,7 @@
             <li><a href="#">Privacy policy</a></li>
             <li><a href="#">Cookies</a></li>
             <li><a href="#">Freedom of information</a></li>
-            <li><a href="#">Contact us</a></li>
+            <li><a href="contact.html">Contact us</a></li>
           </ul>
         </div>
       </div>

--- a/LGR/Consolidated/waste.html
+++ b/LGR/Consolidated/waste.html
@@ -49,8 +49,8 @@
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
           <li><a href="#" class="nav-link">News</a></li>
-          <li><a href="#" class="nav-link">About us</a></li>
-          <li><a href="#" class="nav-link">Contact</a></li>
+          <li><a href="about.html" class="nav-link">About us</a></li>
+          <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
     </div>
@@ -204,7 +204,7 @@
         <div class="footer-col">
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
-            <li><a href="#">About the council</a></li>
+            <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
             <li><a href="#">Council meetings</a></li>
             <li><a href="#">Budget and spending</a></li>
@@ -238,7 +238,7 @@
             <li><a href="#">Privacy policy</a></li>
             <li><a href="#">Cookies</a></li>
             <li><a href="#">Freedom of information</a></li>
-            <li><a href="#">Contact us</a></li>
+            <li><a href="contact.html">Contact us</a></li>
           </ul>
         </div>
       </div>

--- a/LGR/Veneer/about.html
+++ b/LGR/Veneer/about.html
@@ -1,0 +1,255 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>About the council – Newstershire Council</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <div class="utility-bar">
+    <div class="container utility-bar__inner">
+      <span class="utility-bar__item">
+        <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 16.92v3a2 2 0 01-2.18 2 19.79 19.79 0 01-8.63-3.07A19.5 19.5 0 013.07 9.8 19.79 19.79 0 01.22 1.18 2 2 0 012.22 0h3a2 2 0 012 1.72c.13 1 .37 1.97.72 2.9a2 2 0 01-.45 2.11L6.09 7.91a16 16 0 006 6l1.18-1.18a2 2 0 012.11-.45c.93.35 1.9.59 2.9.72A2 2 0 0122 14.92v2z"/></svg>
+        0800 123 4567
+      </span>
+      <span class="utility-bar__item">
+        <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
+        info@newstershire.gov.uk
+      </span>
+      <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
+    </div>
+  </div>
+
+  <header class="site-header">
+    <div class="container site-header__inner">
+      <div class="logo-lockup">
+        <a href="index.html" style="text-decoration:none;display:flex;align-items:center;gap:0.75rem;">
+          <svg class="logo-icon" aria-hidden="true" focusable="false" width="52" height="52" viewBox="0 0 52 52">
+            <circle cx="26" cy="26" r="26" fill="#1d4477"/>
+            <path d="M10 36 Q18 18 26 22 Q34 18 42 36 Z" fill="#c8a951" opacity="0.9"/>
+            <path d="M18 36 Q22 26 26 28 Q30 26 34 36 Z" fill="#ffffff" opacity="0.85"/>
+            <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
+          </svg>
+          <div>
+            <span class="org-name">Newstershire Council</span>
+            <span class="org-tagline">Serving Gloucestershire together</span>
+          </div>
+        </a>
+      </div>
+      <button class="nav-toggle" aria-expanded="false" aria-controls="header-nav" aria-label="Open menu">
+        <svg aria-hidden="true" focusable="false" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+      </button>
+      <nav id="header-nav" class="header-nav" aria-label="Site navigation">
+        <ul>
+          <li><a href="index.html" class="nav-link">Home</a></li>
+          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="about.html" class="nav-link nav-link--active">About us</a></li>
+          <li><a href="contact.html" class="nav-link">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+
+  <section class="page-hero" aria-label="About the council">
+    <div class="container">
+      <h1 class="page-hero__title">About the council</h1>
+      <p class="page-hero__sub">Who we are, the area we serve, how we're run, and the story of how Gloucestershire's councils came together as one.</p>
+    </div>
+  </section>
+
+  <main id="main-content">
+    <div class="container page-body">
+
+      <p class="lead">Newstershire Council is the new unitary authority for Gloucestershire. On 1 April 2027 we replaced Gloucestershire County Council and the six district and borough councils with a single council responsible for every local government service across the county — from adult social care and roads to bins, planning and council tax.</p>
+      <p>One council means one place to find services, one phone number to call, and one organisation accountable for getting things right — while keeping decisions as close as possible to the communities they affect.</p>
+      <p>We're still bringing everything together. While that happens, some services are still delivered through the former councils' websites — the tool on our <a href="index.html">home page</a> asks where you live and takes you straight to the right one.</p>
+
+      <section class="section-block" aria-labelledby="why-heading">
+        <h2 id="why-heading">Why local government reorganised</h2>
+        <p>For decades, Gloucestershire ran a two-tier system: a county council for services like education, social care and highways, and six district and borough councils for services like bins, housing and planning. It worked, but it also meant residents often weren't sure who to contact, and effort was duplicated across seven organisations.</p>
+        <p>Reorganisation brings those services together under one unitary council. The aim is simpler access for residents, lower running costs, and clearer accountability — with the savings reinvested in frontline services.</p>
+      </section>
+
+      <section class="section-block" aria-labelledby="area-heading">
+        <h2 id="area-heading">The area we serve</h2>
+        <p>We serve around 650,000 residents across the whole of Gloucestershire — the six former district and borough areas, now one council:</p>
+        <div class="area-grid">
+          <div class="area-item"><strong>Cheltenham</strong><span>approx. 117,000 residents</span></div>
+          <div class="area-item"><strong>Cotswold</strong><span>approx. 91,000 residents</span></div>
+          <div class="area-item"><strong>Forest of Dean</strong><span>approx. 87,000 residents</span></div>
+          <div class="area-item"><strong>Gloucester</strong><span>approx. 132,000 residents</span></div>
+          <div class="area-item"><strong>Stroud</strong><span>approx. 121,000 residents</span></div>
+          <div class="area-item"><strong>Tewkesbury</strong><span>approx. 96,000 residents</span></div>
+        </div>
+      </section>
+
+      <section class="section-block" aria-labelledby="how-heading">
+        <h2 id="how-heading">How the council works</h2>
+        <p>Newstershire Council is made up of elected councillors, supported by council officers. Councillors set the policies and budget; officers deliver the day-to-day services.</p>
+        <div class="info-grid">
+          <div class="info-card">
+            <h3>Full Council</h3>
+            <p>All elected councillors meet to agree the budget, the council's major plans, and the overall policy framework.</p>
+          </div>
+          <div class="info-card">
+            <h3>Leader &amp; Cabinet</h3>
+            <p>The Leader and a small Cabinet take most day-to-day decisions, each Cabinet member holding a specific portfolio.</p>
+          </div>
+          <div class="info-card">
+            <h3>Scrutiny committees</h3>
+            <p>Cross-party committees hold the Cabinet to account, review decisions, and examine how services are performing.</p>
+          </div>
+          <div class="info-card">
+            <h3>Regulatory committees</h3>
+            <p>Planning, licensing and audit committees take specific statutory decisions independently of political priorities.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section-block" aria-labelledby="cabinet-heading">
+        <h2 id="cabinet-heading">Our leadership</h2>
+        <p>The Cabinet is responsible for the council's key services and decisions.</p>
+        <div class="people-grid">
+          <div class="person-card"><div class="person-avatar" aria-hidden="true">ME</div><h3>Cllr Margaret Ellwood</h3><p class="person-role">Leader of the Council</p></div>
+          <div class="person-card"><div class="person-avatar" aria-hidden="true">DN</div><h3>Cllr David Nkomo</h3><p class="person-role">Deputy Leader &amp; Finance</p></div>
+          <div class="person-card"><div class="person-avatar" aria-hidden="true">PS</div><h3>Cllr Priya Shah</h3><p class="person-role">Adult Social Care &amp; Health</p></div>
+          <div class="person-card"><div class="person-avatar" aria-hidden="true">TB</div><h3>Cllr Tom Beckett</h3><p class="person-role">Children &amp; Education</p></div>
+          <div class="person-card"><div class="person-avatar" aria-hidden="true">RA</div><h3>Cllr Rachel Attwood</h3><p class="person-role">Environment &amp; Waste</p></div>
+          <div class="person-card"><div class="person-avatar" aria-hidden="true">JO</div><h3>Cllr James Okafor</h3><p class="person-role">Housing &amp; Planning</p></div>
+          <div class="person-card"><div class="person-avatar" aria-hidden="true">SP</div><h3>Cllr Susan Pretchard</h3><p class="person-role">Highways &amp; Transport</p></div>
+          <div class="person-card"><div class="person-avatar" aria-hidden="true">FM</div><h3>Fiona Marsh</h3><p class="person-role">Chief Executive (officer)</p></div>
+        </div>
+      </section>
+
+      <section class="section-block" aria-labelledby="priorities-heading">
+        <h2 id="priorities-heading">Our priorities</h2>
+        <p>Our Council Plan sets out what we're focused on for residents:</p>
+        <ul class="tick">
+          <li>One council that's easier to deal with — services in one place, closer to communities</li>
+          <li>Value for money, with reorganisation savings reinvested in frontline services</li>
+          <li>A thriving local economy and vibrant town centres</li>
+          <li>Tackling climate change and protecting Gloucestershire's environment</li>
+          <li>Strong, healthy and connected communities</li>
+        </ul>
+      </section>
+
+      <section class="section-block" aria-labelledby="timeline-heading">
+        <h2 id="timeline-heading">The road to one council</h2>
+        <ol class="timeline">
+          <li class="is-done"><span class="t-date">2024</span><p class="t-body">Government invites Gloucestershire's councils to propose a single unitary authority.</p></li>
+          <li class="is-done"><span class="t-date">February 2026</span><p class="t-body">Newstershire Council is established in shadow form to plan the transition.</p></li>
+          <li class="is-done"><span class="t-date">June 2026</span><p class="t-body">Residents are invited to have their say on services, priorities and the new council's name.</p></li>
+          <li><span class="t-date">1 April 2027</span><p class="t-body">Newstershire Council goes live. The county council and the six district and borough councils are abolished.</p></li>
+          <li><span class="t-date">2027–2028</span><p class="t-body">Services are progressively brought onto one website, one phone line and one set of systems.</p></li>
+        </ol>
+      </section>
+
+      <section class="section-block" aria-labelledby="budget-heading">
+        <h2 id="budget-heading">Budget and spending</h2>
+        <p>Our budget is agreed each year by Full Council and funded through council tax, business rates, government grants and fees and charges. We publish our spending, contracts over £5,000, senior salaries and performance data as part of our commitment to transparency.</p>
+        <p>Reorganisation is expected to reduce running costs by removing duplication across the former seven councils — for example, one set of senior management, one payroll, and shared back-office systems.</p>
+      </section>
+
+      <div class="cta-band">
+        <div class="cta-band__text">
+          <h2>Get in touch</h2>
+          <p>Questions about the council, or need to reach a service? We're here to help.</p>
+        </div>
+        <a href="contact.html" class="btn">Contact us</a>
+      </div>
+
+    </div>
+  </main>
+
+  <section class="prefooter" aria-label="Stay connected">
+    <div class="container prefooter__inner">
+      <div class="prefooter__social">
+        <h2 class="prefooter__heading">Follow us</h2>
+        <div class="social-links">
+          <a href="#" class="social-link" aria-label="Newstershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
+          <a href="#" class="social-link" aria-label="Newstershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
+          <a href="#" class="social-link" aria-label="Newstershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
+          <a href="#" class="social-link" aria-label="Newstershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
+        </div>
+      </div>
+      <div class="prefooter__newsletter">
+        <h2 class="prefooter__heading">Stay informed</h2>
+        <p>Get council news and service updates straight to your inbox.</p>
+        <form class="newsletter-form" action="#" method="post" aria-label="Newsletter sign-up">
+          <label for="newsletter-email" class="sr-only">Email address</label>
+          <input type="email" id="newsletter-email" name="email" placeholder="Your email address" autocomplete="email">
+          <button type="submit">Sign up</button>
+        </form>
+      </div>
+    </div>
+  </section>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="footer-grid">
+        <div class="footer-col">
+          <h3 class="footer-col__title">About Newstershire</h3>
+          <ul>
+            <li><a href="about.html">About the council</a></li>
+            <li><a href="about.html#cabinet-heading">Councillors and committees</a></li>
+            <li><a href="about.html#how-heading">Council meetings</a></li>
+            <li><a href="about.html#budget-heading">Budget and spending</a></li>
+            <li><a href="about.html#timeline-heading">LGR transition</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <h3 class="footer-col__title">Residents</h3>
+          <ul>
+            <li><a href="index.html">Council tax</a></li>
+            <li><a href="index.html">Bins and recycling</a></li>
+            <li><a href="index.html">Planning</a></li>
+            <li><a href="index.html">Housing</a></li>
+            <li><a href="index.html">Benefits and support</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <h3 class="footer-col__title">Business</h3>
+          <ul>
+            <li><a href="#">Business rates</a></li>
+            <li><a href="#">Licences and permits</a></li>
+            <li><a href="#">Trading standards</a></li>
+            <li><a href="#">Economic development</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <h3 class="footer-col__title">Help &amp; legal</h3>
+          <ul>
+            <li><a href="#">Accessibility statement</a></li>
+            <li><a href="#">Privacy policy</a></li>
+            <li><a href="#">Cookies</a></li>
+            <li><a href="#">Freedom of information</a></li>
+            <li><a href="contact.html">Contact us</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. Councillor names, figures and dates on this page are illustrative.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    (function () {
+      var btn = document.querySelector('.nav-toggle');
+      var nav = document.getElementById('header-nav');
+      if (!btn || !nav) return;
+      btn.addEventListener('click', function () {
+        var open = nav.classList.toggle('header-nav--open');
+        btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+        btn.setAttribute('aria-label', open ? 'Close menu' : 'Open menu');
+      });
+    }());
+  </script>
+</body>
+</html>

--- a/LGR/Veneer/contact.html
+++ b/LGR/Veneer/contact.html
@@ -3,9 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Adult social care – Newstershire Council</title>
+  <title>Contact us – Newstershire Council</title>
   <link rel="stylesheet" href="style.css">
-  <link rel="stylesheet" href="council-tax.css">
 </head>
 <body>
 
@@ -49,94 +48,147 @@
           <li><a href="index.html" class="nav-link">Home</a></li>
           <li><a href="#" class="nav-link">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
-          <li><a href="contact.html" class="nav-link">Contact</a></li>
+          <li><a href="contact.html" class="nav-link nav-link--active">Contact</a></li>
         </ul>
       </nav>
     </div>
   </header>
 
-  <nav class="breadcrumb" aria-label="Breadcrumb">
-    <div class="container">
-      <ol>
-        <li><a href="index.html">Home</a></li>
-        <li><a href="#">Residents</a></li>
-        <li aria-current="page">Adult social care</li>
-      </ol>
-    </div>
-  </nav>
 
-  <section class="ct-hero" aria-label="Adult social care">
+  <section class="page-hero" aria-label="Contact us">
     <div class="container">
-      <h1 class="ct-hero__title">Adult social care</h1>
-      <p class="ct-hero__sub">Help for adults aged 18 and over to stay independent, safe and well — assessments, paying for care, safeguarding and support for carers.</p>
+      <h1 class="page-hero__title">Contact us</h1>
+      <p class="page-hero__sub">Reach the right team quickly. Many things can be done online any time — but if you'd rather talk to us, here's how.</p>
     </div>
   </section>
 
   <main id="main-content">
-    <div class="container ct-layout">
+    <div class="container page-body">
 
-      <div class="ct-note ct-note--info" style="margin-bottom:1.5rem;">
-        This is a <strong>county-wide service</strong>, run once for the whole of Gloucestershire (previously by Gloucestershire County Council). It works the same wherever you live in the county.
-      </div>
+      <p class="lead">The quickest way to get help is usually online — most services on this site can be started or completed 24/7. If you can't do it online, or your query is urgent, use the contacts below.</p>
 
-      <div class="ct-block ct-block--common">
-        <p>Adult Social Care helps adults aged 18 and over stay independent, safe and well — whatever's behind the need, whether that's a learning disability, physical disability, mental health condition, dementia, autism, or another long-term condition. Support for carers, including young carers, is part of the same service.</p>
-        <p>Some people only need help for a short period — recovering after a hospital stay, for example. Others need care that builds up gradually, or support for life. The starting point is the same either way: talk to the council, and they'll work with you to understand what you actually need.</p>
-
-        <h3>What support looks like</h3>
-        <ul>
-          <li>Information, advice and guidance, including for unpaid carers</li>
-          <li>Help staying connected — friends, family, social activities</li>
-          <li>Equipment, gadgets and home adaptations</li>
-          <li>Personal care: washing, dressing, household tasks</li>
-          <li>Supported living or a care home placement, where that's the right fit</li>
-        </ul>
-
-        <h3>Getting an assessment</h3>
-        <p>If you think you, or someone you care for, might need extra help, you can ask for a Care and Support Assessment. Gloucestershire calls this an "Adult Social Care Assessment" internally — the same process, just a different name to the one used in some national guidance.</p>
-
-        <h3>Paying for care</h3>
-        <p>Social care for adults is hardly ever free. Almost all care and support arranged or provided by the council is means-tested, and a financial assessment works out what you'll pay. From there:</p>
-        <ul>
-          <li><strong>Self-funding</strong> — if you don't qualify for council support, you pay for your own care</li>
-          <li><strong>Deferred payments</strong> — a way to delay paying certain care home costs, usually secured against your property</li>
-          <li><strong>Direct payments</strong> — money paid to you so you can arrange your own care</li>
-          <li><strong>Personal budgets</strong> — an agreed amount to spend on your care and support</li>
-          <li><strong>Property disregards</strong> — situations where your home isn't counted in the assessment, for example if a spouse or certain relatives still live there</li>
-        </ul>
-        <p>A full "Paying for Adult Social Care" booklet is available, including easy read and large print versions.</p>
-
-        <h3>Keeping people safe</h3>
-        <p>If you're worried a vulnerable adult is at risk of abuse or neglect, contact the Adult Social Care Helpdesk, or the police on 101 — 999 if it's an emergency. Professionals who suspect abuse or risk complete a safeguarding referral through the Adult Social Care portal. Where someone's freedom needs to be restricted for their own safety, usually in a care setting, that's handled through the Deprivation of Liberty Safeguards (DoLS) process.</p>
-
-        <h3>Getting in touch</h3>
-        <ul>
-          <li><strong>Adult Social Care Helpdesk:</strong> 01452 426868, Monday–Friday, 8am–5pm</li>
-          <li><strong>Email:</strong> socialcare.enq@gloucestershire.gov.uk</li>
-          <li><strong>Emergency Duty Team</strong> (out of hours, for serious social care emergencies including suspected abuse): via the council's emergency contacts page</li>
-          <li><strong>Referrals and enquiries:</strong> through the Helpdesk enquiry form, or the online Adult Social Care Portal</li>
-        </ul>
-        <p>Therapy referrals — community nursing, occupational therapy, physiotherapy, reablement — go through Integrated Community Teams, who can also carry out a carer's assessment for anyone supporting someone with support needs.</p>
-
-        <div class="ct-note ct-note--info">
-          <strong>The legal framework:</strong> adult social care operates under the Care Act 2014 and is regulated by the Care Quality Commission. The Your Circle directory signposts local voluntary and community care options — being listed isn't an endorsement, so check an organisation's own qualifications and inspection reports directly.
+      <section class="section-block" aria-labelledby="general-heading">
+        <h2 id="general-heading">General enquiries</h2>
+        <div class="contact-grid">
+          <div class="contact-card">
+            <h3>Phone</h3>
+            <p><strong>0800 123 4567</strong></p>
+            <p>Monday to Friday, 8:30am–5pm</p>
+            <p>Closed weekends and bank holidays</p>
+          </div>
+          <div class="contact-card">
+            <h3>Email</h3>
+            <p><a href="mailto:info@newstershire.gov.uk">info@newstershire.gov.uk</a></p>
+            <p>We aim to reply within 5 working days</p>
+          </div>
+          <div class="contact-card">
+            <h3>Out of hours emergencies</h3>
+            <p><strong>0800 123 9999</strong></p>
+            <p>For genuine emergencies that can't wait — dangerous roads, homelessness tonight, and adult or child safeguarding.</p>
+          </div>
         </div>
+      </section>
 
-      </div>
+      <section class="section-block" aria-labelledby="service-heading">
+        <h2 id="service-heading">Looking for a specific service?</h2>
+        <p>We're still bringing services together under the new council. For many things — bins, council tax, planning, housing and more — you'll currently be served by one of the former district or borough councils, or by county-level teams.</p>
+        <p>The quickest way to reach the right place is the finder on our home page: tell us where you live and we'll take you straight to the correct service.</p>
+        <div class="cta-band">
+          <div class="cta-band__text">
+            <h2>Find your local service</h2>
+            <p>Answer two quick questions and we'll point you to the right place.</p>
+          </div>
+          <a href="index.html" class="btn">Find your service</a>
+        </div>
+      </section>
 
-      <nav class="ct-related" aria-label="Other county-wide services">
-        <h2>Other county-wide services</h2>
-        <ul>
-          <li><a href="county-adult-social-care.html">Adult social care</a></li>
-          <li><a href="county-blue-badges.html">Blue Badges &amp; travel</a></li>
-          <li><a href="county-childrens-services.html">Children, young people &amp; families</a></li>
-          <li><a href="county-highways.html">Highways &amp; roads</a></li>
-          <li><a href="county-libraries.html">Libraries</a></li>
-          <li><a href="county-registrars.html">Registrars</a></li>
-          <li><a href="county-school-admissions.html">School admissions</a></li>
-        
+
+      <section class="section-block" aria-labelledby="offices-heading">
+        <h2 id="offices-heading">Visit us</h2>
+        <p>Our main offices are open by appointment. Please book before travelling — many enquiries can be resolved by phone or online without a visit.</p>
+        <div class="contact-grid">
+          <div class="contact-card">
+            <h3>Newstershire House (main office)</h3>
+            <p>1 Shire Way, Gloucester, GL1 1AA</p>
+            <p>Mon–Fri, 9am–4:30pm, by appointment</p>
+          </div>
+          <div class="contact-card">
+            <h3>Cheltenham hub</h3>
+            <p>Municipal Offices, Promenade, Cheltenham, GL50 1PP</p>
+            <p>Mon–Fri, 9am–4pm</p>
+          </div>
+          <div class="contact-card">
+            <h3>Stroud hub</h3>
+            <p>Ebley Mill, Ebley Wharf, Stroud, GL5 4UB</p>
+            <p>Mon–Thu, 9am–4:30pm; Fri, 9am–4pm</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section-block" aria-labelledby="form-heading">
+        <h2 id="form-heading">Send us a message</h2>
+        <p>Use this form for general enquiries. For anything urgent, please phone. Fields marked with an asterisk (*) are required.</p>
+        <form class="contact-form" action="#" method="post" aria-labelledby="form-heading">
+          <div class="form-row">
+            <label for="cf-name">Your name *</label>
+            <input type="text" id="cf-name" name="name" autocomplete="name" required>
+          </div>
+          <div class="form-row">
+            <label for="cf-email">Email address *</label>
+            <input type="email" id="cf-email" name="email" autocomplete="email" required>
+          </div>
+          <div class="form-row">
+            <label for="cf-topic">What's your enquiry about? *</label>
+            <select id="cf-topic" name="topic" required>
+              <option value="">Please choose…</option>
+              <option>Council tax or benefits</option>
+              <option>Bins and recycling</option>
+              <option>Planning</option>
+              <option>Housing</option>
+              <option>Adult social care</option>
+              <option>Children and families</option>
+              <option>Highways and roads</option>
+              <option>Something else</option>
+            </select>
+          </div>
+          <div class="form-row">
+            <label for="cf-message">Your message *</label>
+            <textarea id="cf-message" name="message" rows="6" required></textarea>
+          </div>
+          <div class="form-actions">
+            <button type="submit">Send message</button>
+          </div>
+        </form>
+      </section>
+
+      <section class="section-block" aria-labelledby="access-heading">
+        <h2 id="access-heading">Accessibility and other formats</h2>
+        <p>We want everyone to be able to reach us. We can provide information in large print, easy read, braille or audio, and arrange interpretation, including British Sign Language (BSL), on request.</p>
+        <ul class="tick">
+          <li>Text relay: dial <strong>18001</strong> then our number</li>
+          <li>Ask about a face-to-face or video BSL interpreter when you contact us</li>
+          <li>Tell us if you need documents in a different format and we'll arrange it</li>
         </ul>
-      </nav>
+      </section>
+
+      <section class="section-block" aria-labelledby="complaints-heading">
+        <h2 id="complaints-heading">Complaints, feedback and information requests</h2>
+        <p>If something's gone wrong, tell us — we use complaints to put things right and improve. You can also make a Freedom of Information request or ask what personal data we hold about you.</p>
+        <div class="contact-grid">
+          <div class="contact-card">
+            <h3>Complaints &amp; feedback</h3>
+            <p><a href="mailto:feedback@newstershire.gov.uk">feedback@newstershire.gov.uk</a></p>
+          </div>
+          <div class="contact-card">
+            <h3>Freedom of Information</h3>
+            <p><a href="mailto:foi@newstershire.gov.uk">foi@newstershire.gov.uk</a></p>
+          </div>
+          <div class="contact-card">
+            <h3>Data protection</h3>
+            <p><a href="mailto:dpo@newstershire.gov.uk">dpo@newstershire.gov.uk</a></p>
+          </div>
+        </div>
+      </section>
 
     </div>
   </main>
@@ -171,34 +223,29 @@
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
-            <li><a href="#">Councillors and committees</a></li>
-            <li><a href="#">Council meetings</a></li>
-            <li><a href="#">Budget and spending</a></li>
-            <li><a href="#">LGR transition</a></li>
+            <li><a href="about.html#cabinet-heading">Councillors and committees</a></li>
+            <li><a href="about.html#how-heading">Council meetings</a></li>
+            <li><a href="about.html#budget-heading">Budget and spending</a></li>
+            <li><a href="about.html#timeline-heading">LGR transition</a></li>
           </ul>
         </div>
         <div class="footer-col">
           <h3 class="footer-col__title">Residents</h3>
           <ul>
-            <li><a href="council-tax.html">Council tax</a></li>
-            <li><a href="waste.html">Bins and recycling</a></li>
-            <li><a href="planning.html">Planning</a></li>
-            <li><a href="housing.html">Housing</a></li>
-            <li><a href="benefits.html">Benefits and support</a></li>
-            <li><a href="county-highways.html">Roads and transport</a></li>
+            <li><a href="index.html">Council tax</a></li>
+            <li><a href="index.html">Bins and recycling</a></li>
+            <li><a href="index.html">Planning</a></li>
+            <li><a href="index.html">Housing</a></li>
+            <li><a href="index.html">Benefits and support</a></li>
           </ul>
         </div>
         <div class="footer-col">
-          <h3 class="footer-col__title">County services</h3>
+          <h3 class="footer-col__title">Business</h3>
           <ul>
-            <li><a href="county-adult-social-care.html">Adult social care</a></li>
-            <li><a href="county-blue-badges.html">Blue Badges</a></li>
-            <li><a href="county-childrens-services.html">Children &amp; families</a></li>
-            <li><a href="county-highways.html">Highways &amp; roads</a></li>
-            <li><a href="county-libraries.html">Libraries</a></li>
-            <li><a href="county-registrars.html">Registrars</a></li>
-            <li><a href="county-school-admissions.html">School admissions</a></li>
-          
+            <li><a href="#">Business rates</a></li>
+            <li><a href="#">Licences and permits</a></li>
+            <li><a href="#">Trading standards</a></li>
+            <li><a href="#">Economic development</a></li>
           </ul>
         </div>
         <div class="footer-col">
@@ -214,7 +261,7 @@
       </div>
       <div class="footer-bottom">
         <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
-        <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
+        <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. Contact details on this page are illustrative.</p>
       </div>
     </div>
   </footer>

--- a/LGR/Veneer/index.html
+++ b/LGR/Veneer/index.html
@@ -47,8 +47,8 @@
         <ul>
           <li><a href="#" class="nav-link nav-link--active">Home</a></li>
           <li><a href="#" class="nav-link">News</a></li>
-          <li><a href="#" class="nav-link">About us</a></li>
-          <li><a href="#" class="nav-link">Contact</a></li>
+          <li><a href="about.html" class="nav-link">About us</a></li>
+          <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
     </div>
@@ -348,7 +348,7 @@
         <div class="footer-col">
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
-            <li><a href="#">About the council</a></li>
+            <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
             <li><a href="#">Council meetings</a></li>
             <li><a href="#">Budget and spending</a></li>
@@ -381,7 +381,7 @@
             <li><a href="#">Privacy policy</a></li>
             <li><a href="#">Cookies</a></li>
             <li><a href="#">Freedom of information</a></li>
-            <li><a href="#">Contact us</a></li>
+            <li><a href="contact.html">Contact us</a></li>
           </ul>
         </div>
       </div>

--- a/LGR/Veneer/style.css
+++ b/LGR/Veneer/style.css
@@ -709,3 +709,76 @@ details[open] summary::before { transform: rotate(90deg); }
   .newsletter-form button { width: 100%; padding: 0.75rem; }
   .footer-grid { grid-template-columns: 1fr 1fr; }
 }
+
+/* =====================================================
+   Interior content pages (About / Contact)
+   ===================================================== */
+.page-hero { background: var(--blue-dark); color: var(--white); padding: 2.25rem 0; border-bottom: 3px solid var(--gold); }
+.page-hero__title { font-size: clamp(1.6rem, 3vw, 2.2rem); font-weight: 700; margin-bottom: 0.4rem; }
+.page-hero__sub { color: var(--blue-light); font-size: 1.0625rem; max-width: 640px; }
+
+.page-body { padding: 2.25rem 0 3rem; }
+.lead { font-size: 1.125rem; max-width: 760px; margin-bottom: 0.5rem; }
+.section-block { margin-top: 2.5rem; }
+.section-block > h2 { font-size: 1.375rem; color: var(--blue-dark); font-weight: 700; margin-bottom: 0.75rem; padding-bottom: 0.4rem; border-bottom: 2px solid var(--blue-light); }
+.section-block > p { margin-bottom: 0.9rem; max-width: 760px; }
+.section-block ul.tick { list-style: none; max-width: 760px; }
+.section-block ul.tick li { position: relative; padding-left: 1.75rem; margin-bottom: 0.5rem; }
+.section-block ul.tick li::before { content: "✓"; position: absolute; left: 0; color: var(--green); font-weight: 700; }
+
+/* Info cards */
+.info-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 1rem; margin-top: 1rem; }
+.info-card { background: var(--white); border: 1px solid var(--border); border-top: 3px solid var(--gold); border-radius: var(--radius); padding: 1.1rem 1.25rem; }
+.info-card h3 { font-size: 1rem; color: var(--blue-dark); font-weight: 700; margin-bottom: 0.4rem; }
+.info-card p { font-size: 0.9375rem; color: var(--text-muted); }
+
+/* People / cabinet */
+.people-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 1rem; margin-top: 1rem; }
+.person-card { background: var(--white); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; text-align: center; }
+.person-avatar { width: 64px; height: 64px; border-radius: 50%; margin: 0 auto 0.75rem; background: var(--blue-light); color: var(--blue-dark); display: flex; align-items: center; justify-content: center; font-size: 1.375rem; font-weight: 700; }
+.person-card h3 { font-size: 1rem; color: var(--blue-dark); margin-bottom: 0.15rem; }
+.person-role { font-size: 0.85rem; color: var(--text-muted); }
+
+/* Area grid */
+.area-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 0.75rem; margin-top: 1rem; }
+.area-item { background: var(--blue-xlight); border: 1px solid var(--blue-light); border-radius: var(--radius); padding: 0.875rem 1rem; }
+.area-item strong { display: block; color: var(--blue-dark); }
+.area-item span { font-size: 0.85rem; color: var(--text-muted); }
+
+/* Timeline */
+.timeline { list-style: none; margin-top: 1rem; border-left: 3px solid var(--blue-light); padding-left: 1.5rem; max-width: 760px; }
+.timeline li { position: relative; padding-bottom: 1.5rem; }
+.timeline li:last-child { padding-bottom: 0; }
+.timeline li::before { content: ""; position: absolute; left: -1.96rem; top: 0.2rem; width: 0.85rem; height: 0.85rem; border-radius: 50%; background: var(--gold); box-shadow: 0 0 0 3px var(--white), 0 0 0 5px var(--blue-light); }
+.timeline li.is-done::before { background: var(--green); }
+.timeline .t-date { font-weight: 700; color: var(--blue-dark); }
+.timeline .t-body { font-size: 0.9375rem; color: var(--text-muted); }
+
+/* Contact cards */
+.contact-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 1rem; margin-top: 1rem; }
+.contact-card { background: var(--white); border: 1px solid var(--border); border-left: 4px solid var(--blue-dark); border-radius: var(--radius); padding: 1.1rem 1.25rem; }
+.contact-card h3 { font-size: 1rem; color: var(--blue-dark); margin-bottom: 0.4rem; }
+.contact-card p { font-size: 0.9375rem; margin-bottom: 0.25rem; }
+
+/* CTA band */
+.cta-band { background: var(--blue-xlight); border: 1px solid var(--blue-light); border-radius: var(--radius); padding: 1.5rem; margin-top: 2.5rem; display: flex; gap: 1rem 1.5rem; align-items: center; justify-content: space-between; flex-wrap: wrap; }
+.cta-band__text h2 { font-size: 1.125rem; color: var(--blue-dark); margin-bottom: 0.2rem; padding: 0; border: 0; }
+.cta-band__text p { font-size: 0.9375rem; color: var(--text-muted); }
+.btn { display: inline-block; background: var(--blue-dark); color: var(--white); padding: 0.7rem 1.25rem; border-radius: var(--radius); text-decoration: none; font-weight: 700; transition: background var(--transition); white-space: nowrap; }
+.btn:hover { background: #163457; color: var(--white); }
+.btn:focus-visible { outline: 3px solid var(--focus); outline-offset: 2px; }
+
+/* Contact form */
+.contact-form { max-width: 640px; margin-top: 1rem; display: grid; gap: 1rem; }
+.form-row { display: flex; flex-direction: column; gap: 0.35rem; }
+.form-row label { font-weight: 600; font-size: 0.9375rem; }
+.form-row input, .form-row select, .form-row textarea { padding: 0.6rem 0.75rem; border: 2px solid var(--border); border-radius: var(--radius); font: inherit; font-size: 1rem; background: var(--white); }
+.form-row input:focus, .form-row select:focus, .form-row textarea:focus { outline: 3px solid var(--focus); outline-offset: 2px; border-color: var(--blue-dark); }
+.form-actions button { background: var(--blue-dark); color: var(--white); border: none; padding: 0.7rem 1.5rem; border-radius: var(--radius); font-weight: 700; font-size: 1rem; cursor: pointer; transition: background var(--transition); }
+.form-actions button:hover { background: #163457; }
+.form-actions button:focus-visible { outline: 3px solid var(--focus); outline-offset: 2px; }
+
+@media (max-width: 540px) {
+  .cta-band { flex-direction: column; align-items: flex-start; }
+  .btn { width: 100%; text-align: center; }
+}


### PR DESCRIPTION
## Summary

New **About the council** and **Contact us** pages for both the Veneer and Consolidated sites.

**About the council** — reorganisation story, the area served (six former districts + populations), how the council works (Full Council, Cabinet, scrutiny, regulatory), an illustrative Cabinet + Chief Executive, priorities, a transition timeline (2024 → 1 April 2027 go-live → 2027–28), and budget.

**Contact us** — general enquiries + out-of-hours, a contact-a-service grid, offices by appointment, a contact form (required fields, focus states), accessibility/alternative formats (BSL, text relay), and complaints/FOI/data-protection routes.

- Veneer versions are adapted to the redirect model: the contact page points residents to the home-page finder for specific services, and About notes services are still delivered via the former councils during transition.
- Shared component CSS (page hero, section blocks, info/person/contact cards, area grid, timeline, CTA band, contact form) appended to both stylesheets in the existing AAA palette.
- Header nav (About us, Contact) and footer (About the council, Contact us) wired to the new pages across every page on both sites.
- Illustrative names, figures and contacts are flagged as such. All internal links verified, markup balanced.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJ29uNGieSuureHRDAyPKy)_