### PR TITLE
Refine About page: name markers, corrected timeline, tidier layout

### DIFF
--- a/LGR/Consolidated/about.html
+++ b/LGR/Consolidated/about.html
@@ -75,7 +75,7 @@
   <main id="main-content">
     <div class="container page-body">
 
-      <p class="lead">Newstershire Council is the new unitary authority for Gloucestershire. On 1 April 2027 we replaced Gloucestershire County Council and the six district and borough councils with a single council responsible for every local government service across the county — from adult social care and roads to bins, planning and council tax.</p>
+      <p class="lead">Newstershire Council is the new unitary authority for Gloucestershire. From 1 April 2028 — vesting day — it brings together Gloucestershire County Council and the six district and borough councils into a single council responsible for every local government service across the county, from adult social care and roads to bins, planning and council tax.</p>
       <p>One council means one place to find services, one phone number to call, and one organisation accountable for getting things right — while keeping decisions as close as possible to the communities they affect.</p>
 
       <section class="section-block" aria-labelledby="why-heading">
@@ -122,16 +122,16 @@
 
       <section class="section-block" aria-labelledby="cabinet-heading">
         <h2 id="cabinet-heading">Our leadership</h2>
-        <p>The Cabinet is responsible for the council's key services and decisions.</p>
+        <p>The council is led by a Leader and Cabinet, each member holding a portfolio for a group of services, supported by senior officers. Councillors will be elected at the shadow elections in May 2027, so the people in these roles are still to be confirmed.</p>
         <div class="people-grid">
-          <div class="person-card"><div class="person-avatar" aria-hidden="true">ME</div><h3>Cllr Margaret Ellwood</h3><p class="person-role">Leader of the Council</p></div>
-          <div class="person-card"><div class="person-avatar" aria-hidden="true">DN</div><h3>Cllr David Nkomo</h3><p class="person-role">Deputy Leader &amp; Finance</p></div>
-          <div class="person-card"><div class="person-avatar" aria-hidden="true">PS</div><h3>Cllr Priya Shah</h3><p class="person-role">Adult Social Care &amp; Health</p></div>
-          <div class="person-card"><div class="person-avatar" aria-hidden="true">TB</div><h3>Cllr Tom Beckett</h3><p class="person-role">Children &amp; Education</p></div>
-          <div class="person-card"><div class="person-avatar" aria-hidden="true">RA</div><h3>Cllr Rachel Attwood</h3><p class="person-role">Environment &amp; Waste</p></div>
-          <div class="person-card"><div class="person-avatar" aria-hidden="true">JO</div><h3>Cllr James Okafor</h3><p class="person-role">Housing &amp; Planning</p></div>
-          <div class="person-card"><div class="person-avatar" aria-hidden="true">SP</div><h3>Cllr Susan Pretchard</h3><p class="person-role">Highways &amp; Transport</p></div>
-          <div class="person-card"><div class="person-avatar" aria-hidden="true">FM</div><h3>Fiona Marsh</h3><p class="person-role">Chief Executive (officer)</p></div>
+          <div class="person-card"><div class="person-avatar" aria-hidden="true"><svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="8" r="4"/><path d="M4 21v-1a6 6 0 016-6h4a6 6 0 016 6v1"/></svg></div><h3>[Name to be confirmed]</h3><p class="person-role">Leader of the Council</p></div>
+          <div class="person-card"><div class="person-avatar" aria-hidden="true"><svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="8" r="4"/><path d="M4 21v-1a6 6 0 016-6h4a6 6 0 016 6v1"/></svg></div><h3>[Name to be confirmed]</h3><p class="person-role">Deputy Leader &amp; Finance</p></div>
+          <div class="person-card"><div class="person-avatar" aria-hidden="true"><svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="8" r="4"/><path d="M4 21v-1a6 6 0 016-6h4a6 6 0 016 6v1"/></svg></div><h3>[Name to be confirmed]</h3><p class="person-role">Adult Social Care &amp; Health</p></div>
+          <div class="person-card"><div class="person-avatar" aria-hidden="true"><svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="8" r="4"/><path d="M4 21v-1a6 6 0 016-6h4a6 6 0 016 6v1"/></svg></div><h3>[Name to be confirmed]</h3><p class="person-role">Children &amp; Education</p></div>
+          <div class="person-card"><div class="person-avatar" aria-hidden="true"><svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="8" r="4"/><path d="M4 21v-1a6 6 0 016-6h4a6 6 0 016 6v1"/></svg></div><h3>[Name to be confirmed]</h3><p class="person-role">Environment &amp; Waste</p></div>
+          <div class="person-card"><div class="person-avatar" aria-hidden="true"><svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="8" r="4"/><path d="M4 21v-1a6 6 0 016-6h4a6 6 0 016 6v1"/></svg></div><h3>[Name to be confirmed]</h3><p class="person-role">Housing &amp; Planning</p></div>
+          <div class="person-card"><div class="person-avatar" aria-hidden="true"><svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="8" r="4"/><path d="M4 21v-1a6 6 0 016-6h4a6 6 0 016 6v1"/></svg></div><h3>[Name to be confirmed]</h3><p class="person-role">Highways &amp; Transport</p></div>
+          <div class="person-card"><div class="person-avatar" aria-hidden="true"><svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="8" r="4"/><path d="M4 21v-1a6 6 0 016-6h4a6 6 0 016 6v1"/></svg></div><h3>[Name to be confirmed]</h3><p class="person-role">Chief Executive (senior officer)</p></div>
         </div>
       </section>
 
@@ -150,11 +150,11 @@
       <section class="section-block" aria-labelledby="timeline-heading">
         <h2 id="timeline-heading">The road to one council</h2>
         <ol class="timeline">
-          <li class="is-done"><span class="t-date">2024</span><p class="t-body">Government invites Gloucestershire's councils to propose a single unitary authority.</p></li>
-          <li class="is-done"><span class="t-date">February 2026</span><p class="t-body">Newstershire Council is established in shadow form to plan the transition.</p></li>
-          <li class="is-done"><span class="t-date">June 2026</span><p class="t-body">Residents are invited to have their say on services, priorities and the new council's name.</p></li>
-          <li><span class="t-date">1 April 2027</span><p class="t-body">Newstershire Council goes live. The county council and the six district and borough councils are abolished.</p></li>
-          <li><span class="t-date">2027–2028</span><p class="t-body">Services are progressively brought onto one website, one phone line and one set of systems.</p></li>
+          <li class="is-done"><span class="t-date">2024–2025</span><p class="t-body">Government invites Gloucestershire's councils to propose a single unitary authority, and the proposal is agreed.</p></li>
+          <li class="is-done"><span class="t-date">2026</span><p class="t-body">Transition planning begins, and residents are invited to have their say on services, priorities and the new council's name.</p></li>
+          <li><span class="t-date">May 2027</span><p class="t-body">Shadow elections — residents elect the councillors who will form the new authority and oversee the final year of transition.</p></li>
+          <li><span class="t-date">1 April 2028</span><p class="t-body">Vesting day — Newstershire Council formally goes live. Gloucestershire County Council and the six district and borough councils are abolished.</p></li>
+          <li><span class="t-date">2028 onwards</span><p class="t-body">Services are progressively brought onto one website, one phone line and one set of systems.</p></li>
         </ol>
       </section>
 

--- a/LGR/Consolidated/style.css
+++ b/LGR/Consolidated/style.css
@@ -891,3 +891,7 @@ details[open] summary::before { transform: rotate(90deg); }
   .cta-band { flex-direction: column; align-items: flex-start; }
   .btn { width: 100%; text-align: center; }
 }
+
+/* About/Contact: keep intro paragraph line-length readable */
+.page-body > p { max-width: 760px; }
+.page-body > .lead { margin-bottom: 1rem; }

--- a/LGR/Veneer/about.html
+++ b/LGR/Veneer/about.html
@@ -65,9 +65,9 @@
   <main id="main-content">
     <div class="container page-body">
 
-      <p class="lead">Newstershire Council is the new unitary authority for Gloucestershire. On 1 April 2027 we replaced Gloucestershire County Council and the six district and borough councils with a single council responsible for every local government service across the county — from adult social care and roads to bins, planning and council tax.</p>
+      <p class="lead">Newstershire Council is the new unitary authority for Gloucestershire. From 1 April 2028 — vesting day — it brings together Gloucestershire County Council and the six district and borough councils into a single council responsible for every local government service across the county, from adult social care and roads to bins, planning and council tax.</p>
       <p>One council means one place to find services, one phone number to call, and one organisation accountable for getting things right — while keeping decisions as close as possible to the communities they affect.</p>
-      <p>We're still bringing everything together. While that happens, some services are still delivered through the former councils' websites — the tool on our <a href="index.html">home page</a> asks where you live and takes you straight to the right one.</p>
+      <p>We are still bringing everything together. While that happens, some services are still delivered through the former councils' websites — the tool on our <a href="index.html">home page</a> asks where you live and takes you straight to the right one.</p>
 
       <section class="section-block" aria-labelledby="why-heading">
         <h2 id="why-heading">Why local government reorganised</h2>
@@ -113,16 +113,16 @@
 
       <section class="section-block" aria-labelledby="cabinet-heading">
         <h2 id="cabinet-heading">Our leadership</h2>
-        <p>The Cabinet is responsible for the council's key services and decisions.</p>
+        <p>The council is led by a Leader and Cabinet, each member holding a portfolio for a group of services, supported by senior officers. Councillors will be elected at the shadow elections in May 2027, so the people in these roles are still to be confirmed.</p>
         <div class="people-grid">
-          <div class="person-card"><div class="person-avatar" aria-hidden="true">ME</div><h3>Cllr Margaret Ellwood</h3><p class="person-role">Leader of the Council</p></div>
-          <div class="person-card"><div class="person-avatar" aria-hidden="true">DN</div><h3>Cllr David Nkomo</h3><p class="person-role">Deputy Leader &amp; Finance</p></div>
-          <div class="person-card"><div class="person-avatar" aria-hidden="true">PS</div><h3>Cllr Priya Shah</h3><p class="person-role">Adult Social Care &amp; Health</p></div>
-          <div class="person-card"><div class="person-avatar" aria-hidden="true">TB</div><h3>Cllr Tom Beckett</h3><p class="person-role">Children &amp; Education</p></div>
-          <div class="person-card"><div class="person-avatar" aria-hidden="true">RA</div><h3>Cllr Rachel Attwood</h3><p class="person-role">Environment &amp; Waste</p></div>
-          <div class="person-card"><div class="person-avatar" aria-hidden="true">JO</div><h3>Cllr James Okafor</h3><p class="person-role">Housing &amp; Planning</p></div>
-          <div class="person-card"><div class="person-avatar" aria-hidden="true">SP</div><h3>Cllr Susan Pretchard</h3><p class="person-role">Highways &amp; Transport</p></div>
-          <div class="person-card"><div class="person-avatar" aria-hidden="true">FM</div><h3>Fiona Marsh</h3><p class="person-role">Chief Executive (officer)</p></div>
+          <div class="person-card"><div class="person-avatar" aria-hidden="true"><svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="8" r="4"/><path d="M4 21v-1a6 6 0 016-6h4a6 6 0 016 6v1"/></svg></div><h3>[Name to be confirmed]</h3><p class="person-role">Leader of the Council</p></div>
+          <div class="person-card"><div class="person-avatar" aria-hidden="true"><svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="8" r="4"/><path d="M4 21v-1a6 6 0 016-6h4a6 6 0 016 6v1"/></svg></div><h3>[Name to be confirmed]</h3><p class="person-role">Deputy Leader &amp; Finance</p></div>
+          <div class="person-card"><div class="person-avatar" aria-hidden="true"><svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="8" r="4"/><path d="M4 21v-1a6 6 0 016-6h4a6 6 0 016 6v1"/></svg></div><h3>[Name to be confirmed]</h3><p class="person-role">Adult Social Care &amp; Health</p></div>
+          <div class="person-card"><div class="person-avatar" aria-hidden="true"><svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="8" r="4"/><path d="M4 21v-1a6 6 0 016-6h4a6 6 0 016 6v1"/></svg></div><h3>[Name to be confirmed]</h3><p class="person-role">Children &amp; Education</p></div>
+          <div class="person-card"><div class="person-avatar" aria-hidden="true"><svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="8" r="4"/><path d="M4 21v-1a6 6 0 016-6h4a6 6 0 016 6v1"/></svg></div><h3>[Name to be confirmed]</h3><p class="person-role">Environment &amp; Waste</p></div>
+          <div class="person-card"><div class="person-avatar" aria-hidden="true"><svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="8" r="4"/><path d="M4 21v-1a6 6 0 016-6h4a6 6 0 016 6v1"/></svg></div><h3>[Name to be confirmed]</h3><p class="person-role">Housing &amp; Planning</p></div>
+          <div class="person-card"><div class="person-avatar" aria-hidden="true"><svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="8" r="4"/><path d="M4 21v-1a6 6 0 016-6h4a6 6 0 016 6v1"/></svg></div><h3>[Name to be confirmed]</h3><p class="person-role">Highways &amp; Transport</p></div>
+          <div class="person-card"><div class="person-avatar" aria-hidden="true"><svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="8" r="4"/><path d="M4 21v-1a6 6 0 016-6h4a6 6 0 016 6v1"/></svg></div><h3>[Name to be confirmed]</h3><p class="person-role">Chief Executive (senior officer)</p></div>
         </div>
       </section>
 
@@ -141,11 +141,11 @@
       <section class="section-block" aria-labelledby="timeline-heading">
         <h2 id="timeline-heading">The road to one council</h2>
         <ol class="timeline">
-          <li class="is-done"><span class="t-date">2024</span><p class="t-body">Government invites Gloucestershire's councils to propose a single unitary authority.</p></li>
-          <li class="is-done"><span class="t-date">February 2026</span><p class="t-body">Newstershire Council is established in shadow form to plan the transition.</p></li>
-          <li class="is-done"><span class="t-date">June 2026</span><p class="t-body">Residents are invited to have their say on services, priorities and the new council's name.</p></li>
-          <li><span class="t-date">1 April 2027</span><p class="t-body">Newstershire Council goes live. The county council and the six district and borough councils are abolished.</p></li>
-          <li><span class="t-date">2027–2028</span><p class="t-body">Services are progressively brought onto one website, one phone line and one set of systems.</p></li>
+          <li class="is-done"><span class="t-date">2024–2025</span><p class="t-body">Government invites Gloucestershire's councils to propose a single unitary authority, and the proposal is agreed.</p></li>
+          <li class="is-done"><span class="t-date">2026</span><p class="t-body">Transition planning begins, and residents are invited to have their say on services, priorities and the new council's name.</p></li>
+          <li><span class="t-date">May 2027</span><p class="t-body">Shadow elections — residents elect the councillors who will form the new authority and oversee the final year of transition.</p></li>
+          <li><span class="t-date">1 April 2028</span><p class="t-body">Vesting day — Newstershire Council formally goes live. Gloucestershire County Council and the six district and borough councils are abolished.</p></li>
+          <li><span class="t-date">2028 onwards</span><p class="t-body">Services are progressively brought onto one website, one phone line and one set of systems.</p></li>
         </ol>
       </section>
 

--- a/LGR/Veneer/style.css
+++ b/LGR/Veneer/style.css
@@ -782,3 +782,7 @@ details[open] summary::before { transform: rotate(90deg); }
   .cta-band { flex-direction: column; align-items: flex-start; }
   .btn { width: 100%; text-align: center; }
 }
+
+/* About/Contact: keep intro paragraph line-length readable */
+.page-body > p { max-width: 760px; }
+.page-body > .lead { margin-bottom: 1rem; }


### PR DESCRIPTION
## Summary

- Dropped the illustrative councillor and officer names. Leadership cards now show each portfolio with a `[Name to be confirmed]` marker and a neutral avatar, noting councillors are elected at the May 2027 shadow elections.
- Corrected the transition timeline: added **May 2027 shadow elections** and set **1 April 2028 as vesting day** (was 1 April 2027); lead paragraph updated to match.
- Constrained intro paragraph line-length (max-width 760px) for readability.
- Applied to both the Consolidated and Veneer About pages.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJ29uNGieSuureHRDAyPKy)_