### PR TITLE
Fix About/Contact mobile margins

### DIFF
--- a/LGR/Consolidated/style.css
+++ b/LGR/Consolidated/style.css
@@ -826,7 +826,7 @@ details[open] summary::before { transform: rotate(90deg); }
 .page-hero__title { font-size: clamp(1.6rem, 3vw, 2.2rem); font-weight: 700; margin-bottom: 0.4rem; }
 .page-hero__sub { color: var(--blue-light); font-size: 1.0625rem; max-width: 640px; }
 
-.page-body { padding: 2.25rem 0 3rem; }
+.page-body { padding-top: 2.25rem; padding-bottom: 3rem; }
 .lead { font-size: 1.125rem; max-width: 760px; margin-bottom: 0.5rem; }
 .section-block { margin-top: 2.5rem; }
 .section-block > h2 { font-size: 1.375rem; color: var(--blue-dark); font-weight: 700; margin-bottom: 0.75rem; padding-bottom: 0.4rem; border-bottom: 2px solid var(--blue-light); }

--- a/LGR/Veneer/style.css
+++ b/LGR/Veneer/style.css
@@ -717,7 +717,7 @@ details[open] summary::before { transform: rotate(90deg); }
 .page-hero__title { font-size: clamp(1.6rem, 3vw, 2.2rem); font-weight: 700; margin-bottom: 0.4rem; }
 .page-hero__sub { color: var(--blue-light); font-size: 1.0625rem; max-width: 640px; }
 
-.page-body { padding: 2.25rem 0 3rem; }
+.page-body { padding-top: 2.25rem; padding-bottom: 3rem; }
 .lead { font-size: 1.125rem; max-width: 760px; margin-bottom: 0.5rem; }
 .section-block { margin-top: 2.5rem; }
 .section-block > h2 { font-size: 1.375rem; color: var(--blue-dark); font-weight: 700; margin-bottom: 0.75rem; padding-bottom: 0.4rem; border-bottom: 2px solid var(--blue-light); }


### PR DESCRIPTION
`.page-body` used the padding shorthand `2.25rem 0 3rem`, which zeroed the horizontal padding and overrode `.container`'s side padding — so content and the timeline's negatively-offset bullets ran to (and slightly beyond) the screen edge on mobile. Switched to `padding-top`/`padding-bottom` only, so the container's 1.25rem side padding applies again. Fixed on the About and Contact pages across both sites.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJ29uNGieSuureHRDAyPKy)_