### PR TITLE
Harden About/Contact against mobile-Safari horizontal overflow

### DIFF
--- a/LGR/Consolidated/council-tax.css
+++ b/LGR/Consolidated/council-tax.css
@@ -317,7 +317,7 @@
 .ct-related ul {
   list-style: none;
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 220px), 1fr));
   gap: 0.5rem;
 }
 .ct-related a {

--- a/LGR/Consolidated/style.css
+++ b/LGR/Consolidated/style.css
@@ -24,7 +24,7 @@
 }
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-html { font-size: 100%; scroll-behavior: smooth; }
+html { font-size: 100%; scroll-behavior: smooth; overflow-x: clip; }
 
 /* WCAG 2.3.3 / 2.2.2 — honour reduced-motion preference */
 @media (prefers-reduced-motion: reduce) {
@@ -323,7 +323,7 @@ fieldset { border: none; }
 
 .radio-group {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 160px), 1fr));
   gap: 0.75rem;
   margin-top: 0.5rem;
 }
@@ -624,7 +624,7 @@ details[open] summary::before { transform: rotate(90deg); }
 
 .footer-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 160px), 1fr));
   gap: 1.5rem;
   margin-bottom: 2rem;
 }
@@ -656,7 +656,7 @@ details[open] summary::before { transform: rotate(90deg); }
    ===================== */
 .service-tiles {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 200px), 1fr));
   gap: 0.875rem;
   margin-bottom: 2rem;
 }
@@ -836,20 +836,20 @@ details[open] summary::before { transform: rotate(90deg); }
 .section-block ul.tick li::before { content: "✓"; position: absolute; left: 0; color: var(--green); font-weight: 700; }
 
 /* Info cards */
-.info-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 1rem; margin-top: 1rem; }
+.info-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 220px), 1fr)); gap: 1rem; margin-top: 1rem; }
 .info-card { background: var(--white); border: 1px solid var(--border); border-top: 3px solid var(--gold); border-radius: var(--radius); padding: 1.1rem 1.25rem; }
 .info-card h3 { font-size: 1rem; color: var(--blue-dark); font-weight: 700; margin-bottom: 0.4rem; }
 .info-card p { font-size: 0.9375rem; color: var(--text-muted); }
 
 /* People / cabinet */
-.people-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 1rem; margin-top: 1rem; }
+.people-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(min(100%, 200px), 1fr)); gap: 1rem; margin-top: 1rem; }
 .person-card { background: var(--white); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; text-align: center; }
 .person-avatar { width: 64px; height: 64px; border-radius: 50%; margin: 0 auto 0.75rem; background: var(--blue-light); color: var(--blue-dark); display: flex; align-items: center; justify-content: center; font-size: 1.375rem; font-weight: 700; }
 .person-card h3 { font-size: 1rem; color: var(--blue-dark); margin-bottom: 0.15rem; }
 .person-role { font-size: 0.85rem; color: var(--text-muted); }
 
 /* Area grid */
-.area-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 0.75rem; margin-top: 1rem; }
+.area-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(min(100%, 180px), 1fr)); gap: 0.75rem; margin-top: 1rem; }
 .area-item { background: var(--blue-xlight); border: 1px solid var(--blue-light); border-radius: var(--radius); padding: 0.875rem 1rem; }
 .area-item strong { display: block; color: var(--blue-dark); }
 .area-item span { font-size: 0.85rem; color: var(--text-muted); }
@@ -864,7 +864,7 @@ details[open] summary::before { transform: rotate(90deg); }
 .timeline .t-body { font-size: 0.9375rem; color: var(--text-muted); }
 
 /* Contact cards */
-.contact-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 1rem; margin-top: 1rem; }
+.contact-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 240px), 1fr)); gap: 1rem; margin-top: 1rem; }
 .contact-card { background: var(--white); border: 1px solid var(--border); border-left: 4px solid var(--blue-dark); border-radius: var(--radius); padding: 1.1rem 1.25rem; }
 .contact-card h3 { font-size: 1rem; color: var(--blue-dark); margin-bottom: 0.4rem; }
 .contact-card p { font-size: 0.9375rem; margin-bottom: 0.25rem; }
@@ -881,7 +881,7 @@ details[open] summary::before { transform: rotate(90deg); }
 .contact-form { max-width: 640px; margin-top: 1rem; display: grid; gap: 1rem; }
 .form-row { display: flex; flex-direction: column; gap: 0.35rem; }
 .form-row label { font-weight: 600; font-size: 0.9375rem; }
-.form-row input, .form-row select, .form-row textarea { padding: 0.6rem 0.75rem; border: 2px solid var(--border); border-radius: var(--radius); font: inherit; font-size: 1rem; background: var(--white); }
+.form-row input, .form-row select, .form-row textarea { padding: 0.6rem 0.75rem; border: 2px solid var(--border); border-radius: var(--radius); font: inherit; font-size: 1rem; background: var(--white); width: 100%; max-width: 100%; }
 .form-row input:focus, .form-row select:focus, .form-row textarea:focus { outline: 3px solid var(--focus); outline-offset: 2px; border-color: var(--blue-dark); }
 .form-actions button { background: var(--blue-dark); color: var(--white); border: none; padding: 0.7rem 1.5rem; border-radius: var(--radius); font-weight: 700; font-size: 1rem; cursor: pointer; transition: background var(--transition); }
 .form-actions button:hover { background: #163457; }

--- a/LGR/Consolidated/style.css
+++ b/LGR/Consolidated/style.css
@@ -826,7 +826,7 @@ details[open] summary::before { transform: rotate(90deg); }
 .page-hero__title { font-size: clamp(1.6rem, 3vw, 2.2rem); font-weight: 700; margin-bottom: 0.4rem; }
 .page-hero__sub { color: var(--blue-light); font-size: 1.0625rem; max-width: 640px; }
 
-.page-body { padding: 2.25rem 0 3rem; }
+.page-body { padding-top: 2.25rem; padding-bottom: 3rem; }
 .lead { font-size: 1.125rem; max-width: 760px; margin-bottom: 0.5rem; }
 .section-block { margin-top: 2.5rem; }
 .section-block > h2 { font-size: 1.375rem; color: var(--blue-dark); font-weight: 700; margin-bottom: 0.75rem; padding-bottom: 0.4rem; border-bottom: 2px solid var(--blue-light); }

--- a/LGR/Veneer/style.css
+++ b/LGR/Veneer/style.css
@@ -717,7 +717,7 @@ details[open] summary::before { transform: rotate(90deg); }
 .page-hero__title { font-size: clamp(1.6rem, 3vw, 2.2rem); font-weight: 700; margin-bottom: 0.4rem; }
 .page-hero__sub { color: var(--blue-light); font-size: 1.0625rem; max-width: 640px; }
 
-.page-body { padding: 2.25rem 0 3rem; }
+.page-body { padding-top: 2.25rem; padding-bottom: 3rem; }
 .lead { font-size: 1.125rem; max-width: 760px; margin-bottom: 0.5rem; }
 .section-block { margin-top: 2.5rem; }
 .section-block > h2 { font-size: 1.375rem; color: var(--blue-dark); font-weight: 700; margin-bottom: 0.75rem; padding-bottom: 0.4rem; border-bottom: 2px solid var(--blue-light); }

--- a/LGR/Veneer/style.css
+++ b/LGR/Veneer/style.css
@@ -24,7 +24,7 @@
 }
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-html { font-size: 100%; scroll-behavior: smooth; }
+html { font-size: 100%; scroll-behavior: smooth; overflow-x: clip; }
 
 /* WCAG 2.3.3 / 2.2.2 — honour reduced-motion preference */
 @media (prefers-reduced-motion: reduce) {
@@ -324,7 +324,7 @@ fieldset { border: none; }
 
 .radio-group {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 160px), 1fr));
   gap: 0.75rem;
   margin-top: 0.5rem;
 }
@@ -625,7 +625,7 @@ details[open] summary::before { transform: rotate(90deg); }
 
 .footer-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 160px), 1fr));
   gap: 1.5rem;
   margin-bottom: 2rem;
 }
@@ -727,20 +727,20 @@ details[open] summary::before { transform: rotate(90deg); }
 .section-block ul.tick li::before { content: "✓"; position: absolute; left: 0; color: var(--green); font-weight: 700; }
 
 /* Info cards */
-.info-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 1rem; margin-top: 1rem; }
+.info-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 220px), 1fr)); gap: 1rem; margin-top: 1rem; }
 .info-card { background: var(--white); border: 1px solid var(--border); border-top: 3px solid var(--gold); border-radius: var(--radius); padding: 1.1rem 1.25rem; }
 .info-card h3 { font-size: 1rem; color: var(--blue-dark); font-weight: 700; margin-bottom: 0.4rem; }
 .info-card p { font-size: 0.9375rem; color: var(--text-muted); }
 
 /* People / cabinet */
-.people-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 1rem; margin-top: 1rem; }
+.people-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(min(100%, 200px), 1fr)); gap: 1rem; margin-top: 1rem; }
 .person-card { background: var(--white); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; text-align: center; }
 .person-avatar { width: 64px; height: 64px; border-radius: 50%; margin: 0 auto 0.75rem; background: var(--blue-light); color: var(--blue-dark); display: flex; align-items: center; justify-content: center; font-size: 1.375rem; font-weight: 700; }
 .person-card h3 { font-size: 1rem; color: var(--blue-dark); margin-bottom: 0.15rem; }
 .person-role { font-size: 0.85rem; color: var(--text-muted); }
 
 /* Area grid */
-.area-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 0.75rem; margin-top: 1rem; }
+.area-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(min(100%, 180px), 1fr)); gap: 0.75rem; margin-top: 1rem; }
 .area-item { background: var(--blue-xlight); border: 1px solid var(--blue-light); border-radius: var(--radius); padding: 0.875rem 1rem; }
 .area-item strong { display: block; color: var(--blue-dark); }
 .area-item span { font-size: 0.85rem; color: var(--text-muted); }
@@ -755,7 +755,7 @@ details[open] summary::before { transform: rotate(90deg); }
 .timeline .t-body { font-size: 0.9375rem; color: var(--text-muted); }
 
 /* Contact cards */
-.contact-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 1rem; margin-top: 1rem; }
+.contact-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 240px), 1fr)); gap: 1rem; margin-top: 1rem; }
 .contact-card { background: var(--white); border: 1px solid var(--border); border-left: 4px solid var(--blue-dark); border-radius: var(--radius); padding: 1.1rem 1.25rem; }
 .contact-card h3 { font-size: 1rem; color: var(--blue-dark); margin-bottom: 0.4rem; }
 .contact-card p { font-size: 0.9375rem; margin-bottom: 0.25rem; }
@@ -772,7 +772,7 @@ details[open] summary::before { transform: rotate(90deg); }
 .contact-form { max-width: 640px; margin-top: 1rem; display: grid; gap: 1rem; }
 .form-row { display: flex; flex-direction: column; gap: 0.35rem; }
 .form-row label { font-weight: 600; font-size: 0.9375rem; }
-.form-row input, .form-row select, .form-row textarea { padding: 0.6rem 0.75rem; border: 2px solid var(--border); border-radius: var(--radius); font: inherit; font-size: 1rem; background: var(--white); }
+.form-row input, .form-row select, .form-row textarea { padding: 0.6rem 0.75rem; border: 2px solid var(--border); border-radius: var(--radius); font: inherit; font-size: 1rem; background: var(--white); width: 100%; max-width: 100%; }
 .form-row input:focus, .form-row select:focus, .form-row textarea:focus { outline: 3px solid var(--focus); outline-offset: 2px; border-color: var(--blue-dark); }
 .form-actions button { background: var(--blue-dark); color: var(--white); border: none; padding: 0.7rem 1.5rem; border-radius: var(--radius); font-weight: 700; font-size: 1rem; cursor: pointer; transition: background var(--transition); }
 .form-actions button:hover { background: #163457; }


### PR DESCRIPTION
## Summary

The About and Contact pages render cleanly in Chromium at all mobile widths, but iOS Safari treats CSS grid `minmax(Npx, 1fr)` track minimums as a hard floor, so grids (leadership cards, area grid, contact cards) can push past a narrow viewport there — which is why even the form-less About page was affected.

- Switched every auto-fit/auto-fill grid to the robust `minmax(min(100%, Npx), 1fr)` pattern so tracks can shrink below their preferred width on narrow screens.
- Gave form controls `width: 100%; max-width: 100%` so they can't overflow their container.
- Added `overflow-x: clip` on `html` as a backstop.

Verified no regression in Chromium at 320–414px (no horizontal overflow, 20px gutters).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJ29uNGieSuureHRDAyPKy)_