### PR TITLE
Add a News section to both LGR sites

### DIFF
--- a/LGR/Consolidated/about.html
+++ b/LGR/Consolidated/about.html
@@ -47,7 +47,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link">News</a></li>
           <li><a href="about.html" class="nav-link nav-link--active">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>

--- a/LGR/Consolidated/benefits-cost-of-living.html
+++ b/LGR/Consolidated/benefits-cost-of-living.html
@@ -47,7 +47,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>

--- a/LGR/Consolidated/benefits-housing-payments.html
+++ b/LGR/Consolidated/benefits-housing-payments.html
@@ -47,7 +47,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>

--- a/LGR/Consolidated/benefits-universal-credit.html
+++ b/LGR/Consolidated/benefits-universal-credit.html
@@ -47,7 +47,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>

--- a/LGR/Consolidated/benefits.html
+++ b/LGR/Consolidated/benefits.html
@@ -48,7 +48,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>

--- a/LGR/Consolidated/contact.html
+++ b/LGR/Consolidated/contact.html
@@ -47,7 +47,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link nav-link--active">Contact</a></li>
         </ul>

--- a/LGR/Consolidated/council-tax.html
+++ b/LGR/Consolidated/council-tax.html
@@ -48,7 +48,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>

--- a/LGR/Consolidated/county-adult-social-care.html
+++ b/LGR/Consolidated/county-adult-social-care.html
@@ -47,7 +47,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>

--- a/LGR/Consolidated/county-blue-badges.html
+++ b/LGR/Consolidated/county-blue-badges.html
@@ -47,7 +47,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>

--- a/LGR/Consolidated/county-childrens-services.html
+++ b/LGR/Consolidated/county-childrens-services.html
@@ -47,7 +47,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>

--- a/LGR/Consolidated/county-highways.html
+++ b/LGR/Consolidated/county-highways.html
@@ -47,7 +47,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>

--- a/LGR/Consolidated/county-libraries.html
+++ b/LGR/Consolidated/county-libraries.html
@@ -47,7 +47,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>

--- a/LGR/Consolidated/county-registrars.html
+++ b/LGR/Consolidated/county-registrars.html
@@ -47,7 +47,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>

--- a/LGR/Consolidated/county-school-admissions.html
+++ b/LGR/Consolidated/county-school-admissions.html
@@ -47,7 +47,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>

--- a/LGR/Consolidated/housing-affordable.html
+++ b/LGR/Consolidated/housing-affordable.html
@@ -47,7 +47,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>

--- a/LGR/Consolidated/housing-homelessness.html
+++ b/LGR/Consolidated/housing-homelessness.html
@@ -47,7 +47,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>

--- a/LGR/Consolidated/housing-register.html
+++ b/LGR/Consolidated/housing-register.html
@@ -47,7 +47,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>

--- a/LGR/Consolidated/housing-supported.html
+++ b/LGR/Consolidated/housing-supported.html
@@ -47,7 +47,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>

--- a/LGR/Consolidated/housing.html
+++ b/LGR/Consolidated/housing.html
@@ -48,7 +48,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>

--- a/LGR/Consolidated/index.html
+++ b/LGR/Consolidated/index.html
@@ -46,7 +46,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="#" class="nav-link nav-link--active">Home</a></li>
-          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
@@ -334,22 +334,23 @@
           <ul class="news-list">
             <li class="news-item">
               <span class="news-date">27 Jun 2026</span>
-              <a href="#" class="news-title">Newstershire Council officially launches on 1 April 2027</a>
+              <a href="news-new-council.html" class="news-title">One council for Gloucestershire goes live in 2028</a>
             </li>
             <li class="news-item">
               <span class="news-date">20 Jun 2026</span>
-              <a href="#" class="news-title">New recycling centres confirmed for all six districts</a>
+              <a href="news-have-your-say.html" class="news-title">Have your say on services for the new council</a>
             </li>
             <li class="news-item">
-              <span class="news-date">14 Jun 2026</span>
-              <a href="#" class="news-title">Residents invited to have their say on future council services</a>
+              <span class="news-date">12 Jun 2026</span>
+              <a href="news-bins.html" class="news-title">Bins and recycling: what's changing</a>
             </li>
             <li class="news-item">
-              <span class="news-date">5 Jun 2026</span>
-              <a href="#" class="news-title">Transition board appoints interim chief executive</a>
+              <span class="news-date">28 May 2026</span>
+              <a href="news-shadow-elections.html" class="news-title">Shadow elections planned for May 2027</a>
             </li>
           </ul>
-          <a href="#" class="view-all-link">View all news →</a>
+          <a href="news.html" class="view-all-link">View all news →</a>
+
         </div>
 
         <!-- Contact -->

--- a/LGR/Consolidated/news-bins.html
+++ b/LGR/Consolidated/news-bins.html
@@ -3,9 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Household Recycling Centres – Newstershire Council</title>
+  <title>Bins and recycling: what's changing – Newstershire Council</title>
   <link rel="stylesheet" href="style.css">
-  <link rel="stylesheet" href="council-tax.css">
 </head>
 <body>
 
@@ -47,7 +46,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="news.html" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link nav-link--active">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
@@ -59,62 +58,34 @@
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
-        <li><a href="#">Residents</a></li>
-        <li><a href="waste.html">Bins and recycling</a></li>
-        <li aria-current="page">Recycling centres</li>
+        <li><a href="news.html">News</a></li>
+        <li aria-current="page">Bins and recycling: what's changing</li>
       </ol>
     </div>
   </nav>
 
-  <section class="ct-hero" aria-label="Household Recycling Centres">
+  <section class="page-hero" aria-label="Bins and recycling: what's changing">
     <div class="container">
-      <h1 class="ct-hero__title">Household Recycling Centres</h1>
-      <p class="ct-hero__sub">The county's recycling centres (Gloucestershire Recycles) — how to book a visit, what you can bring, and where the sites are.</p>
+      <h1 class="page-hero__title">Bins and recycling: what's changing</h1>
+      <p class="page-hero__sub">Why your collections carry on as normal through the transition.</p>
     </div>
   </section>
 
   <main id="main-content">
-    <div class="container ct-layout">
+    <div class="container page-body">
 
-      <p class="ct-back"><a href="waste.html">&larr; All bins and recycling topics</a></p>
+      <p class="ct-back" style="margin-bottom:1rem;"><a href="news.html" style="color:var(--blue-mid);font-weight:600;text-decoration:none;">&larr; All news</a></p>
 
-      <div class="ct-note ct-note--info" style="margin-bottom:1.5rem;">
-        Household Recycling Centres are run once for the whole of Gloucestershire, so the sites, booking system and rules are the same wherever you live — separate from the kerbside bin collections, which differ by area.
-      </div>
+      <p class="article-meta">Published 12 June 2026</p>
 
-      <div class="ct-block ct-block--common">
-        <p>Newstershire Council is the Waste Disposal Authority for the county — a different role to kerbside bin collection, which is covered on the <a href="waste.html">bins and recycling</a> pages. It runs the county's Household Recycling Centres, branded Gloucestershire Recycles.</p>
-
-        <h3>Book before you go</h3>
-        <p>Every visit — car or van — needs a booking made in advance online. This isn't a suggestion; you can be turned away without one. It keeps queues and congestion down and makes the sites safer. With over 10,000 bookings a week across the five sites, there isn't capacity to take bookings by phone as standard. If you genuinely can't book online, and nobody can book on your behalf, there's a phone line: 01452 596 626, weekdays 9am–5pm.</p>
-        <p>Bookings run in fixed 30-minute slots — arrive within yours or you may be turned away and asked to rebook. You'll need to give your name, email, postcode, vehicle make and model, registration, and what waste you're bringing. Bring your booking reference — printed or on your phone — to get in. Need to change your vehicle or slot? There are separate amendment forms for cars and for vans, pick-ups and large trailers.</p>
-
-        <h3>What counts as a car visit</h3>
-        <p>Passenger cars, optionally with a small trailer (under 6ft × 4ft internally). Anything bigger — a van, pick-up, or larger trailer — needs a separate van/large-vehicle booking. HRCs are for household waste only; bringing commercial or trade waste is a criminal offence, and vehicle types are checked against council policy.</p>
-
-        <h3>What you can't bring</h3>
-        <p>Fly-tipped waste isn't accepted — the sites aren't licensed for it. Waste fly-tipped on private land needs a private licensed disposal route instead. Bring only what genuinely can't go through kerbside collection or another route.</p>
-
-        <h3>Sites</h3>
-        <p>Five council-run sites across the county, plus one separate site at Swindon Road in Cheltenham, run independently by Cheltenham Borough Council and currently closed pending review. Known sites: <strong>Hempsted</strong> (Gloucester) — due to close during 2026 for essential repairs and improvements, exact dates to be confirmed — <strong>Pyke Quarry</strong> (near Horsley, Stroud), and <strong>Wingmoor Farm</strong> (Bishop's Cleeve).</p>
-        <p>Each site closes one weekday a week, staggered across the county so there's always a reasonable alternative open — deliberately keeping sites open on Bank Holiday Mondays and Good Friday, historically the busiest days. All sites close on Christmas Day, Boxing Day and New Year's Day. If you need help lifting your waste, ask the staff member at the entrance.</p>
-
-        <div class="ct-note ct-note--info">
-          A zero-tolerance policy applies to violence, aggression, threats or harassment toward staff or other visitors — anyone responsible loses access to the service. General enquiries: waste@gloucestershire.gov.uk.
-        </div>
+      <div class="article-body">
+        <p>With one council coming for the whole county, a common question is what happens to bin collections. The short answer: nothing changes for now, and any future changes would be made carefully and communicated well in advance.</p>
+        <p>Bin colours, collection days and what goes in which container are currently set locally, so they still vary between areas. Those arrangements continue as they are through the transition.</p>
+        <h2>Looking ahead</h2>
+        <p>Over time, bringing collections under one council may create opportunities to make services more consistent and efficient across the county. Any changes would be planned with residents in mind and announced clearly before they took effect.</p>
+        <p>In the meantime, the simplest way to check your own collection details is to look up your area on the bins and recycling pages.</p>
 
       </div>
-
-      <nav class="ct-related" aria-label="Other bins and recycling topics">
-        <h2>Other bins and recycling topics</h2>
-        <ul>
-          <li><a href="waste-general-waste.html">General waste</a></li>
-          <li><a href="waste-recycling.html">Recycling</a></li>
-          <li><a href="waste-food-waste.html">Food waste</a></li>
-          <li><a href="waste-garden-waste.html">Garden waste</a></li>
-          <li><a href="waste-bulky.html">Bulky waste</a></li>
-        </ul>
-      </nav>
 
     </div>
   </main>
@@ -149,10 +120,10 @@
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
-            <li><a href="#">Councillors and committees</a></li>
-            <li><a href="#">Council meetings</a></li>
-            <li><a href="#">Budget and spending</a></li>
-            <li><a href="#">LGR transition</a></li>
+            <li><a href="about.html#cabinet-heading">Councillors and committees</a></li>
+            <li><a href="about.html#how-heading">Council meetings</a></li>
+            <li><a href="about.html#budget-heading">Budget and spending</a></li>
+            <li><a href="news.html">News</a></li>
           </ul>
         </div>
         <div class="footer-col">
@@ -163,16 +134,15 @@
             <li><a href="planning.html">Planning</a></li>
             <li><a href="housing.html">Housing</a></li>
             <li><a href="benefits.html">Benefits and support</a></li>
-            <li><a href="county-highways.html">Roads and transport</a></li>
           </ul>
         </div>
         <div class="footer-col">
-          <h3 class="footer-col__title">County services</h3>
+          <h3 class="footer-col__title">Business</h3>
           <ul>
-            <li><a href="county-adult-social-care.html">Adult social care</a></li>
-            <li><a href="county-childrens-services.html">Children &amp; families</a></li>
-            <li><a href="county-libraries.html">Libraries</a></li>
-            <li><a href="waste-recycling-centres.html">Recycling centres</a></li>
+            <li><a href="#">Business rates</a></li>
+            <li><a href="#">Licences and permits</a></li>
+            <li><a href="#">Trading standards</a></li>
+            <li><a href="#">Economic development</a></li>
           </ul>
         </div>
         <div class="footer-col">
@@ -188,7 +158,7 @@
       </div>
       <div class="footer-bottom">
         <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
-        <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
+        <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. News articles on this page are illustrative.</p>
       </div>
     </div>
   </footer>

--- a/LGR/Consolidated/news-council-tax.html
+++ b/LGR/Consolidated/news-council-tax.html
@@ -3,9 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Household Recycling Centres – Newstershire Council</title>
+  <title>Council tax: one bill, clearer support – Newstershire Council</title>
   <link rel="stylesheet" href="style.css">
-  <link rel="stylesheet" href="council-tax.css">
 </head>
 <body>
 
@@ -47,7 +46,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="news.html" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link nav-link--active">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
@@ -59,62 +58,34 @@
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
-        <li><a href="#">Residents</a></li>
-        <li><a href="waste.html">Bins and recycling</a></li>
-        <li aria-current="page">Recycling centres</li>
+        <li><a href="news.html">News</a></li>
+        <li aria-current="page">Council tax: one bill, clearer support</li>
       </ol>
     </div>
   </nav>
 
-  <section class="ct-hero" aria-label="Household Recycling Centres">
+  <section class="page-hero" aria-label="Council tax: one bill, clearer support">
     <div class="container">
-      <h1 class="ct-hero__title">Household Recycling Centres</h1>
-      <p class="ct-hero__sub">The county's recycling centres (Gloucestershire Recycles) — how to book a visit, what you can bring, and where the sites are.</p>
+      <h1 class="page-hero__title">Council tax: one bill, clearer support</h1>
+      <p class="page-hero__sub">How council tax and support for residents are affected by the change.</p>
     </div>
   </section>
 
   <main id="main-content">
-    <div class="container ct-layout">
+    <div class="container page-body">
 
-      <p class="ct-back"><a href="waste.html">&larr; All bins and recycling topics</a></p>
+      <p class="ct-back" style="margin-bottom:1rem;"><a href="news.html" style="color:var(--blue-mid);font-weight:600;text-decoration:none;">&larr; All news</a></p>
 
-      <div class="ct-note ct-note--info" style="margin-bottom:1.5rem;">
-        Household Recycling Centres are run once for the whole of Gloucestershire, so the sites, booking system and rules are the same wherever you live — separate from the kerbside bin collections, which differ by area.
-      </div>
+      <p class="article-meta">Published 5 June 2026</p>
 
-      <div class="ct-block ct-block--common">
-        <p>Newstershire Council is the Waste Disposal Authority for the county — a different role to kerbside bin collection, which is covered on the <a href="waste.html">bins and recycling</a> pages. It runs the county's Household Recycling Centres, branded Gloucestershire Recycles.</p>
-
-        <h3>Book before you go</h3>
-        <p>Every visit — car or van — needs a booking made in advance online. This isn't a suggestion; you can be turned away without one. It keeps queues and congestion down and makes the sites safer. With over 10,000 bookings a week across the five sites, there isn't capacity to take bookings by phone as standard. If you genuinely can't book online, and nobody can book on your behalf, there's a phone line: 01452 596 626, weekdays 9am–5pm.</p>
-        <p>Bookings run in fixed 30-minute slots — arrive within yours or you may be turned away and asked to rebook. You'll need to give your name, email, postcode, vehicle make and model, registration, and what waste you're bringing. Bring your booking reference — printed or on your phone — to get in. Need to change your vehicle or slot? There are separate amendment forms for cars and for vans, pick-ups and large trailers.</p>
-
-        <h3>What counts as a car visit</h3>
-        <p>Passenger cars, optionally with a small trailer (under 6ft × 4ft internally). Anything bigger — a van, pick-up, or larger trailer — needs a separate van/large-vehicle booking. HRCs are for household waste only; bringing commercial or trade waste is a criminal offence, and vehicle types are checked against council policy.</p>
-
-        <h3>What you can't bring</h3>
-        <p>Fly-tipped waste isn't accepted — the sites aren't licensed for it. Waste fly-tipped on private land needs a private licensed disposal route instead. Bring only what genuinely can't go through kerbside collection or another route.</p>
-
-        <h3>Sites</h3>
-        <p>Five council-run sites across the county, plus one separate site at Swindon Road in Cheltenham, run independently by Cheltenham Borough Council and currently closed pending review. Known sites: <strong>Hempsted</strong> (Gloucester) — due to close during 2026 for essential repairs and improvements, exact dates to be confirmed — <strong>Pyke Quarry</strong> (near Horsley, Stroud), and <strong>Wingmoor Farm</strong> (Bishop's Cleeve).</p>
-        <p>Each site closes one weekday a week, staggered across the county so there's always a reasonable alternative open — deliberately keeping sites open on Bank Holiday Mondays and Good Friday, historically the busiest days. All sites close on Christmas Day, Boxing Day and New Year's Day. If you need help lifting your waste, ask the staff member at the entrance.</p>
-
-        <div class="ct-note ct-note--info">
-          A zero-tolerance policy applies to violence, aggression, threats or harassment toward staff or other visitors — anyone responsible loses access to the service. General enquiries: waste@gloucestershire.gov.uk.
-        </div>
+      <div class="article-body">
+        <p>Council tax will continue to be billed as normal through the move to a single council. Residents don't need to take any action, and support for those on a low income remains available.</p>
+        <p>Council tax is made up of charges set by different bodies. As services come together under one council, the aim is to make bills clearer and support easier to find — without changing the help available to those who need it.</p>
+        <h2>Getting help with your bill</h2>
+        <p>If you're struggling to pay, or think you may be entitled to a discount, exemption or reduction, it's worth checking sooner rather than later. Support is means-tested for those on a low income, and various discounts and exemptions apply depending on circumstances.</p>
+        <p>You can find the current rules, discounts and support on the council tax pages, and check what applies to your area.</p>
 
       </div>
-
-      <nav class="ct-related" aria-label="Other bins and recycling topics">
-        <h2>Other bins and recycling topics</h2>
-        <ul>
-          <li><a href="waste-general-waste.html">General waste</a></li>
-          <li><a href="waste-recycling.html">Recycling</a></li>
-          <li><a href="waste-food-waste.html">Food waste</a></li>
-          <li><a href="waste-garden-waste.html">Garden waste</a></li>
-          <li><a href="waste-bulky.html">Bulky waste</a></li>
-        </ul>
-      </nav>
 
     </div>
   </main>
@@ -149,10 +120,10 @@
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
-            <li><a href="#">Councillors and committees</a></li>
-            <li><a href="#">Council meetings</a></li>
-            <li><a href="#">Budget and spending</a></li>
-            <li><a href="#">LGR transition</a></li>
+            <li><a href="about.html#cabinet-heading">Councillors and committees</a></li>
+            <li><a href="about.html#how-heading">Council meetings</a></li>
+            <li><a href="about.html#budget-heading">Budget and spending</a></li>
+            <li><a href="news.html">News</a></li>
           </ul>
         </div>
         <div class="footer-col">
@@ -163,16 +134,15 @@
             <li><a href="planning.html">Planning</a></li>
             <li><a href="housing.html">Housing</a></li>
             <li><a href="benefits.html">Benefits and support</a></li>
-            <li><a href="county-highways.html">Roads and transport</a></li>
           </ul>
         </div>
         <div class="footer-col">
-          <h3 class="footer-col__title">County services</h3>
+          <h3 class="footer-col__title">Business</h3>
           <ul>
-            <li><a href="county-adult-social-care.html">Adult social care</a></li>
-            <li><a href="county-childrens-services.html">Children &amp; families</a></li>
-            <li><a href="county-libraries.html">Libraries</a></li>
-            <li><a href="waste-recycling-centres.html">Recycling centres</a></li>
+            <li><a href="#">Business rates</a></li>
+            <li><a href="#">Licences and permits</a></li>
+            <li><a href="#">Trading standards</a></li>
+            <li><a href="#">Economic development</a></li>
           </ul>
         </div>
         <div class="footer-col">
@@ -188,7 +158,7 @@
       </div>
       <div class="footer-bottom">
         <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
-        <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
+        <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. News articles on this page are illustrative.</p>
       </div>
     </div>
   </footer>

--- a/LGR/Consolidated/news-have-your-say.html
+++ b/LGR/Consolidated/news-have-your-say.html
@@ -3,9 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Household Recycling Centres – Newstershire Council</title>
+  <title>Have your say on services for the new council – Newstershire Council</title>
   <link rel="stylesheet" href="style.css">
-  <link rel="stylesheet" href="council-tax.css">
 </head>
 <body>
 
@@ -47,7 +46,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="news.html" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link nav-link--active">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
@@ -59,62 +58,39 @@
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
-        <li><a href="#">Residents</a></li>
-        <li><a href="waste.html">Bins and recycling</a></li>
-        <li aria-current="page">Recycling centres</li>
+        <li><a href="news.html">News</a></li>
+        <li aria-current="page">Have your say on services for the new council</li>
       </ol>
     </div>
   </nav>
 
-  <section class="ct-hero" aria-label="Household Recycling Centres">
+  <section class="page-hero" aria-label="Have your say on services for the new council">
     <div class="container">
-      <h1 class="ct-hero__title">Household Recycling Centres</h1>
-      <p class="ct-hero__sub">The county's recycling centres (Gloucestershire Recycles) — how to book a visit, what you can bring, and where the sites are.</p>
+      <h1 class="page-hero__title">Have your say on services for the new council</h1>
+      <p class="page-hero__sub">Residents are invited to help shape how the new council works.</p>
     </div>
   </section>
 
   <main id="main-content">
-    <div class="container ct-layout">
+    <div class="container page-body">
 
-      <p class="ct-back"><a href="waste.html">&larr; All bins and recycling topics</a></p>
+      <p class="ct-back" style="margin-bottom:1rem;"><a href="news.html" style="color:var(--blue-mid);font-weight:600;text-decoration:none;">&larr; All news</a></p>
 
-      <div class="ct-note ct-note--info" style="margin-bottom:1.5rem;">
-        Household Recycling Centres are run once for the whole of Gloucestershire, so the sites, booking system and rules are the same wherever you live — separate from the kerbside bin collections, which differ by area.
-      </div>
+      <p class="article-meta">Published 20 June 2026</p>
 
-      <div class="ct-block ct-block--common">
-        <p>Newstershire Council is the Waste Disposal Authority for the county — a different role to kerbside bin collection, which is covered on the <a href="waste.html">bins and recycling</a> pages. It runs the county's Household Recycling Centres, branded Gloucestershire Recycles.</p>
-
-        <h3>Book before you go</h3>
-        <p>Every visit — car or van — needs a booking made in advance online. This isn't a suggestion; you can be turned away without one. It keeps queues and congestion down and makes the sites safer. With over 10,000 bookings a week across the five sites, there isn't capacity to take bookings by phone as standard. If you genuinely can't book online, and nobody can book on your behalf, there's a phone line: 01452 596 626, weekdays 9am–5pm.</p>
-        <p>Bookings run in fixed 30-minute slots — arrive within yours or you may be turned away and asked to rebook. You'll need to give your name, email, postcode, vehicle make and model, registration, and what waste you're bringing. Bring your booking reference — printed or on your phone — to get in. Need to change your vehicle or slot? There are separate amendment forms for cars and for vans, pick-ups and large trailers.</p>
-
-        <h3>What counts as a car visit</h3>
-        <p>Passenger cars, optionally with a small trailer (under 6ft × 4ft internally). Anything bigger — a van, pick-up, or larger trailer — needs a separate van/large-vehicle booking. HRCs are for household waste only; bringing commercial or trade waste is a criminal offence, and vehicle types are checked against council policy.</p>
-
-        <h3>What you can't bring</h3>
-        <p>Fly-tipped waste isn't accepted — the sites aren't licensed for it. Waste fly-tipped on private land needs a private licensed disposal route instead. Bring only what genuinely can't go through kerbside collection or another route.</p>
-
-        <h3>Sites</h3>
-        <p>Five council-run sites across the county, plus one separate site at Swindon Road in Cheltenham, run independently by Cheltenham Borough Council and currently closed pending review. Known sites: <strong>Hempsted</strong> (Gloucester) — due to close during 2026 for essential repairs and improvements, exact dates to be confirmed — <strong>Pyke Quarry</strong> (near Horsley, Stroud), and <strong>Wingmoor Farm</strong> (Bishop's Cleeve).</p>
-        <p>Each site closes one weekday a week, staggered across the county so there's always a reasonable alternative open — deliberately keeping sites open on Bank Holiday Mondays and Good Friday, historically the busiest days. All sites close on Christmas Day, Boxing Day and New Year's Day. If you need help lifting your waste, ask the staff member at the entrance.</p>
-
-        <div class="ct-note ct-note--info">
-          A zero-tolerance policy applies to violence, aggression, threats or harassment toward staff or other visitors — anyone responsible loses access to the service. General enquiries: waste@gloucestershire.gov.uk.
-        </div>
-
-      </div>
-
-      <nav class="ct-related" aria-label="Other bins and recycling topics">
-        <h2>Other bins and recycling topics</h2>
+      <div class="article-body">
+        <p>Residents across Gloucestershire are being invited to help shape how the new council works — from the services people rely on most to how they'd prefer to get in touch.</p>
+        <p>The move to a single council is a rare chance to design services around residents rather than around existing organisational boundaries. Feedback gathered now will help set priorities for the new council ahead of vesting day.</p>
+        <h2>How to take part</h2>
         <ul>
-          <li><a href="waste-general-waste.html">General waste</a></li>
-          <li><a href="waste-recycling.html">Recycling</a></li>
-          <li><a href="waste-food-waste.html">Food waste</a></li>
-          <li><a href="waste-garden-waste.html">Garden waste</a></li>
-          <li><a href="waste-bulky.html">Bulky waste</a></li>
+          <li>Share your views through the online survey while it's open</li>
+          <li>Come along to a local drop-in session in your area</li>
+          <li>Tell us which services matter most to you and how you'd like to access them</li>
         </ul>
-      </nav>
+        <p>Everyone who lives, works or studies in the county is welcome to take part. Responses are anonymous and used only to inform planning for the new council.</p>
+        <p>Watch this page for dates and details as sessions are confirmed.</p>
+
+      </div>
 
     </div>
   </main>
@@ -149,10 +125,10 @@
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
-            <li><a href="#">Councillors and committees</a></li>
-            <li><a href="#">Council meetings</a></li>
-            <li><a href="#">Budget and spending</a></li>
-            <li><a href="#">LGR transition</a></li>
+            <li><a href="about.html#cabinet-heading">Councillors and committees</a></li>
+            <li><a href="about.html#how-heading">Council meetings</a></li>
+            <li><a href="about.html#budget-heading">Budget and spending</a></li>
+            <li><a href="news.html">News</a></li>
           </ul>
         </div>
         <div class="footer-col">
@@ -163,16 +139,15 @@
             <li><a href="planning.html">Planning</a></li>
             <li><a href="housing.html">Housing</a></li>
             <li><a href="benefits.html">Benefits and support</a></li>
-            <li><a href="county-highways.html">Roads and transport</a></li>
           </ul>
         </div>
         <div class="footer-col">
-          <h3 class="footer-col__title">County services</h3>
+          <h3 class="footer-col__title">Business</h3>
           <ul>
-            <li><a href="county-adult-social-care.html">Adult social care</a></li>
-            <li><a href="county-childrens-services.html">Children &amp; families</a></li>
-            <li><a href="county-libraries.html">Libraries</a></li>
-            <li><a href="waste-recycling-centres.html">Recycling centres</a></li>
+            <li><a href="#">Business rates</a></li>
+            <li><a href="#">Licences and permits</a></li>
+            <li><a href="#">Trading standards</a></li>
+            <li><a href="#">Economic development</a></li>
           </ul>
         </div>
         <div class="footer-col">
@@ -188,7 +163,7 @@
       </div>
       <div class="footer-bottom">
         <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
-        <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
+        <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. News articles on this page are illustrative.</p>
       </div>
     </div>
   </footer>

--- a/LGR/Consolidated/news-new-council.html
+++ b/LGR/Consolidated/news-new-council.html
@@ -3,9 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Household Recycling Centres – Newstershire Council</title>
+  <title>One council for Gloucestershire goes live in 2028 – Newstershire Council</title>
   <link rel="stylesheet" href="style.css">
-  <link rel="stylesheet" href="council-tax.css">
 </head>
 <body>
 
@@ -47,7 +46,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="news.html" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link nav-link--active">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
@@ -59,62 +58,36 @@
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
-        <li><a href="#">Residents</a></li>
-        <li><a href="waste.html">Bins and recycling</a></li>
-        <li aria-current="page">Recycling centres</li>
+        <li><a href="news.html">News</a></li>
+        <li aria-current="page">One council for Gloucestershire goes live in 2028</li>
       </ol>
     </div>
   </nav>
 
-  <section class="ct-hero" aria-label="Household Recycling Centres">
+  <section class="page-hero" aria-label="One council for Gloucestershire goes live in 2028">
     <div class="container">
-      <h1 class="ct-hero__title">Household Recycling Centres</h1>
-      <p class="ct-hero__sub">The county's recycling centres (Gloucestershire Recycles) — how to book a visit, what you can bring, and where the sites are.</p>
+      <h1 class="page-hero__title">One council for Gloucestershire goes live in 2028</h1>
+      <p class="page-hero__sub">What vesting day means for residents — and what stays exactly the same.</p>
     </div>
   </section>
 
   <main id="main-content">
-    <div class="container ct-layout">
+    <div class="container page-body">
 
-      <p class="ct-back"><a href="waste.html">&larr; All bins and recycling topics</a></p>
+      <p class="ct-back" style="margin-bottom:1rem;"><a href="news.html" style="color:var(--blue-mid);font-weight:600;text-decoration:none;">&larr; All news</a></p>
 
-      <div class="ct-note ct-note--info" style="margin-bottom:1.5rem;">
-        Household Recycling Centres are run once for the whole of Gloucestershire, so the sites, booking system and rules are the same wherever you live — separate from the kerbside bin collections, which differ by area.
-      </div>
+      <p class="article-meta">Published 27 June 2026</p>
 
-      <div class="ct-block ct-block--common">
-        <p>Newstershire Council is the Waste Disposal Authority for the county — a different role to kerbside bin collection, which is covered on the <a href="waste.html">bins and recycling</a> pages. It runs the county's Household Recycling Centres, branded Gloucestershire Recycles.</p>
-
-        <h3>Book before you go</h3>
-        <p>Every visit — car or van — needs a booking made in advance online. This isn't a suggestion; you can be turned away without one. It keeps queues and congestion down and makes the sites safer. With over 10,000 bookings a week across the five sites, there isn't capacity to take bookings by phone as standard. If you genuinely can't book online, and nobody can book on your behalf, there's a phone line: 01452 596 626, weekdays 9am–5pm.</p>
-        <p>Bookings run in fixed 30-minute slots — arrive within yours or you may be turned away and asked to rebook. You'll need to give your name, email, postcode, vehicle make and model, registration, and what waste you're bringing. Bring your booking reference — printed or on your phone — to get in. Need to change your vehicle or slot? There are separate amendment forms for cars and for vans, pick-ups and large trailers.</p>
-
-        <h3>What counts as a car visit</h3>
-        <p>Passenger cars, optionally with a small trailer (under 6ft × 4ft internally). Anything bigger — a van, pick-up, or larger trailer — needs a separate van/large-vehicle booking. HRCs are for household waste only; bringing commercial or trade waste is a criminal offence, and vehicle types are checked against council policy.</p>
-
-        <h3>What you can't bring</h3>
-        <p>Fly-tipped waste isn't accepted — the sites aren't licensed for it. Waste fly-tipped on private land needs a private licensed disposal route instead. Bring only what genuinely can't go through kerbside collection or another route.</p>
-
-        <h3>Sites</h3>
-        <p>Five council-run sites across the county, plus one separate site at Swindon Road in Cheltenham, run independently by Cheltenham Borough Council and currently closed pending review. Known sites: <strong>Hempsted</strong> (Gloucester) — due to close during 2026 for essential repairs and improvements, exact dates to be confirmed — <strong>Pyke Quarry</strong> (near Horsley, Stroud), and <strong>Wingmoor Farm</strong> (Bishop's Cleeve).</p>
-        <p>Each site closes one weekday a week, staggered across the county so there's always a reasonable alternative open — deliberately keeping sites open on Bank Holiday Mondays and Good Friday, historically the busiest days. All sites close on Christmas Day, Boxing Day and New Year's Day. If you need help lifting your waste, ask the staff member at the entrance.</p>
-
-        <div class="ct-note ct-note--info">
-          A zero-tolerance policy applies to violence, aggression, threats or harassment toward staff or other visitors — anyone responsible loses access to the service. General enquiries: waste@gloucestershire.gov.uk.
-        </div>
+      <div class="article-body">
+        <p>Newstershire Council, the new single council for the whole of Gloucestershire, will formally take over local services on <strong>1 April 2028</strong> — known as vesting day. From that date, one council will be responsible for everything from adult social care and roads to bins, planning and council tax.</p>
+        <p>Until then, the current county, district and borough councils continue to run services as normal. Residents don't need to do anything — bins will be collected, bills will be issued, and services will run as usual through the changeover.</p>
+        <h2>What's changing</h2>
+        <p>Bringing seven councils together into one is intended to make services simpler to find and use. Over time, residents will have a single website, one phone number and one account for their council services, rather than needing to work out which organisation to contact.</p>
+        <h2>What's staying the same</h2>
+        <p>Day-to-day services continue without interruption. Where a service is delivered locally today, it will keep running — the change is about how the council is organised behind the scenes, not about stopping or reducing services.</p>
+        <p>We'll keep publishing updates here as the transition progresses.</p>
 
       </div>
-
-      <nav class="ct-related" aria-label="Other bins and recycling topics">
-        <h2>Other bins and recycling topics</h2>
-        <ul>
-          <li><a href="waste-general-waste.html">General waste</a></li>
-          <li><a href="waste-recycling.html">Recycling</a></li>
-          <li><a href="waste-food-waste.html">Food waste</a></li>
-          <li><a href="waste-garden-waste.html">Garden waste</a></li>
-          <li><a href="waste-bulky.html">Bulky waste</a></li>
-        </ul>
-      </nav>
 
     </div>
   </main>
@@ -149,10 +122,10 @@
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
-            <li><a href="#">Councillors and committees</a></li>
-            <li><a href="#">Council meetings</a></li>
-            <li><a href="#">Budget and spending</a></li>
-            <li><a href="#">LGR transition</a></li>
+            <li><a href="about.html#cabinet-heading">Councillors and committees</a></li>
+            <li><a href="about.html#how-heading">Council meetings</a></li>
+            <li><a href="about.html#budget-heading">Budget and spending</a></li>
+            <li><a href="news.html">News</a></li>
           </ul>
         </div>
         <div class="footer-col">
@@ -163,16 +136,15 @@
             <li><a href="planning.html">Planning</a></li>
             <li><a href="housing.html">Housing</a></li>
             <li><a href="benefits.html">Benefits and support</a></li>
-            <li><a href="county-highways.html">Roads and transport</a></li>
           </ul>
         </div>
         <div class="footer-col">
-          <h3 class="footer-col__title">County services</h3>
+          <h3 class="footer-col__title">Business</h3>
           <ul>
-            <li><a href="county-adult-social-care.html">Adult social care</a></li>
-            <li><a href="county-childrens-services.html">Children &amp; families</a></li>
-            <li><a href="county-libraries.html">Libraries</a></li>
-            <li><a href="waste-recycling-centres.html">Recycling centres</a></li>
+            <li><a href="#">Business rates</a></li>
+            <li><a href="#">Licences and permits</a></li>
+            <li><a href="#">Trading standards</a></li>
+            <li><a href="#">Economic development</a></li>
           </ul>
         </div>
         <div class="footer-col">
@@ -188,7 +160,7 @@
       </div>
       <div class="footer-bottom">
         <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
-        <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
+        <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. News articles on this page are illustrative.</p>
       </div>
     </div>
   </footer>

--- a/LGR/Consolidated/news-shadow-elections.html
+++ b/LGR/Consolidated/news-shadow-elections.html
@@ -3,9 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Household Recycling Centres – Newstershire Council</title>
+  <title>Shadow elections planned for May 2027 – Newstershire Council</title>
   <link rel="stylesheet" href="style.css">
-  <link rel="stylesheet" href="council-tax.css">
 </head>
 <body>
 
@@ -47,7 +46,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="news.html" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link nav-link--active">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
@@ -59,62 +58,34 @@
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
-        <li><a href="#">Residents</a></li>
-        <li><a href="waste.html">Bins and recycling</a></li>
-        <li aria-current="page">Recycling centres</li>
+        <li><a href="news.html">News</a></li>
+        <li aria-current="page">Shadow elections planned for May 2027</li>
       </ol>
     </div>
   </nav>
 
-  <section class="ct-hero" aria-label="Household Recycling Centres">
+  <section class="page-hero" aria-label="Shadow elections planned for May 2027">
     <div class="container">
-      <h1 class="ct-hero__title">Household Recycling Centres</h1>
-      <p class="ct-hero__sub">The county's recycling centres (Gloucestershire Recycles) — how to book a visit, what you can bring, and where the sites are.</p>
+      <h1 class="page-hero__title">Shadow elections planned for May 2027</h1>
+      <p class="page-hero__sub">Residents will elect the councillors who form the new authority.</p>
     </div>
   </section>
 
   <main id="main-content">
-    <div class="container ct-layout">
+    <div class="container page-body">
 
-      <p class="ct-back"><a href="waste.html">&larr; All bins and recycling topics</a></p>
+      <p class="ct-back" style="margin-bottom:1rem;"><a href="news.html" style="color:var(--blue-mid);font-weight:600;text-decoration:none;">&larr; All news</a></p>
 
-      <div class="ct-note ct-note--info" style="margin-bottom:1.5rem;">
-        Household Recycling Centres are run once for the whole of Gloucestershire, so the sites, booking system and rules are the same wherever you live — separate from the kerbside bin collections, which differ by area.
-      </div>
+      <p class="article-meta">Published 28 May 2026</p>
 
-      <div class="ct-block ct-block--common">
-        <p>Newstershire Council is the Waste Disposal Authority for the county — a different role to kerbside bin collection, which is covered on the <a href="waste.html">bins and recycling</a> pages. It runs the county's Household Recycling Centres, branded Gloucestershire Recycles.</p>
-
-        <h3>Book before you go</h3>
-        <p>Every visit — car or van — needs a booking made in advance online. This isn't a suggestion; you can be turned away without one. It keeps queues and congestion down and makes the sites safer. With over 10,000 bookings a week across the five sites, there isn't capacity to take bookings by phone as standard. If you genuinely can't book online, and nobody can book on your behalf, there's a phone line: 01452 596 626, weekdays 9am–5pm.</p>
-        <p>Bookings run in fixed 30-minute slots — arrive within yours or you may be turned away and asked to rebook. You'll need to give your name, email, postcode, vehicle make and model, registration, and what waste you're bringing. Bring your booking reference — printed or on your phone — to get in. Need to change your vehicle or slot? There are separate amendment forms for cars and for vans, pick-ups and large trailers.</p>
-
-        <h3>What counts as a car visit</h3>
-        <p>Passenger cars, optionally with a small trailer (under 6ft × 4ft internally). Anything bigger — a van, pick-up, or larger trailer — needs a separate van/large-vehicle booking. HRCs are for household waste only; bringing commercial or trade waste is a criminal offence, and vehicle types are checked against council policy.</p>
-
-        <h3>What you can't bring</h3>
-        <p>Fly-tipped waste isn't accepted — the sites aren't licensed for it. Waste fly-tipped on private land needs a private licensed disposal route instead. Bring only what genuinely can't go through kerbside collection or another route.</p>
-
-        <h3>Sites</h3>
-        <p>Five council-run sites across the county, plus one separate site at Swindon Road in Cheltenham, run independently by Cheltenham Borough Council and currently closed pending review. Known sites: <strong>Hempsted</strong> (Gloucester) — due to close during 2026 for essential repairs and improvements, exact dates to be confirmed — <strong>Pyke Quarry</strong> (near Horsley, Stroud), and <strong>Wingmoor Farm</strong> (Bishop's Cleeve).</p>
-        <p>Each site closes one weekday a week, staggered across the county so there's always a reasonable alternative open — deliberately keeping sites open on Bank Holiday Mondays and Good Friday, historically the busiest days. All sites close on Christmas Day, Boxing Day and New Year's Day. If you need help lifting your waste, ask the staff member at the entrance.</p>
-
-        <div class="ct-note ct-note--info">
-          A zero-tolerance policy applies to violence, aggression, threats or harassment toward staff or other visitors — anyone responsible loses access to the service. General enquiries: waste@gloucestershire.gov.uk.
-        </div>
+      <div class="article-body">
+        <p>Ahead of the new council going live, residents will elect the councillors who will form it. These <strong>shadow elections</strong> are planned for <strong>May 2027</strong>.</p>
+        <p>The councillors elected then will oversee the final year of preparation and take up their full responsibilities on vesting day, 1 April 2028. It's an important moment: the people elected will shape the priorities and decisions of the new council from day one.</p>
+        <h2>Registering to vote</h2>
+        <p>If you're eligible and registered to vote, you'll be able to take part as usual. If you're not yet registered, it's worth doing so in good time — registration is free and can be done online through the national service.</p>
+        <p>More detail on candidates, polling arrangements and dates will be published closer to the time.</p>
 
       </div>
-
-      <nav class="ct-related" aria-label="Other bins and recycling topics">
-        <h2>Other bins and recycling topics</h2>
-        <ul>
-          <li><a href="waste-general-waste.html">General waste</a></li>
-          <li><a href="waste-recycling.html">Recycling</a></li>
-          <li><a href="waste-food-waste.html">Food waste</a></li>
-          <li><a href="waste-garden-waste.html">Garden waste</a></li>
-          <li><a href="waste-bulky.html">Bulky waste</a></li>
-        </ul>
-      </nav>
 
     </div>
   </main>
@@ -149,10 +120,10 @@
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
-            <li><a href="#">Councillors and committees</a></li>
-            <li><a href="#">Council meetings</a></li>
-            <li><a href="#">Budget and spending</a></li>
-            <li><a href="#">LGR transition</a></li>
+            <li><a href="about.html#cabinet-heading">Councillors and committees</a></li>
+            <li><a href="about.html#how-heading">Council meetings</a></li>
+            <li><a href="about.html#budget-heading">Budget and spending</a></li>
+            <li><a href="news.html">News</a></li>
           </ul>
         </div>
         <div class="footer-col">
@@ -163,16 +134,15 @@
             <li><a href="planning.html">Planning</a></li>
             <li><a href="housing.html">Housing</a></li>
             <li><a href="benefits.html">Benefits and support</a></li>
-            <li><a href="county-highways.html">Roads and transport</a></li>
           </ul>
         </div>
         <div class="footer-col">
-          <h3 class="footer-col__title">County services</h3>
+          <h3 class="footer-col__title">Business</h3>
           <ul>
-            <li><a href="county-adult-social-care.html">Adult social care</a></li>
-            <li><a href="county-childrens-services.html">Children &amp; families</a></li>
-            <li><a href="county-libraries.html">Libraries</a></li>
-            <li><a href="waste-recycling-centres.html">Recycling centres</a></li>
+            <li><a href="#">Business rates</a></li>
+            <li><a href="#">Licences and permits</a></li>
+            <li><a href="#">Trading standards</a></li>
+            <li><a href="#">Economic development</a></li>
           </ul>
         </div>
         <div class="footer-col">
@@ -188,7 +158,7 @@
       </div>
       <div class="footer-bottom">
         <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
-        <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
+        <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. News articles on this page are illustrative.</p>
       </div>
     </div>
   </footer>

--- a/LGR/Consolidated/news.html
+++ b/LGR/Consolidated/news.html
@@ -3,9 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Household Recycling Centres – Newstershire Council</title>
+  <title>News – Newstershire Council</title>
   <link rel="stylesheet" href="style.css">
-  <link rel="stylesheet" href="council-tax.css">
 </head>
 <body>
 
@@ -47,7 +46,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="news.html" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link nav-link--active">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
@@ -59,62 +58,51 @@
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
-        <li><a href="#">Residents</a></li>
-        <li><a href="waste.html">Bins and recycling</a></li>
-        <li aria-current="page">Recycling centres</li>
+        <li aria-current="page">News</li>
       </ol>
     </div>
   </nav>
 
-  <section class="ct-hero" aria-label="Household Recycling Centres">
+  <section class="page-hero" aria-label="News">
     <div class="container">
-      <h1 class="ct-hero__title">Household Recycling Centres</h1>
-      <p class="ct-hero__sub">The county's recycling centres (Gloucestershire Recycles) — how to book a visit, what you can bring, and where the sites are.</p>
+      <h1 class="page-hero__title">News</h1>
+      <p class="page-hero__sub">Updates on the move to a single council for Gloucestershire, and on local services.</p>
     </div>
   </section>
 
   <main id="main-content">
-    <div class="container ct-layout">
+    <div class="container page-body">
 
-      <p class="ct-back"><a href="waste.html">&larr; All bins and recycling topics</a></p>
+      <p class="lead">The latest updates on local government reorganisation and services across Gloucestershire.</p>
 
-      <div class="ct-note ct-note--info" style="margin-bottom:1.5rem;">
-        Household Recycling Centres are run once for the whole of Gloucestershire, so the sites, booking system and rules are the same wherever you live — separate from the kerbside bin collections, which differ by area.
+      <div class="news-feed">
+        <article class="news-article-card">
+          <time datetime="2026-06-27">27 June 2026</time>
+          <h2><a href="news-new-council.html">One council for Gloucestershire goes live in 2028</a></h2>
+          <p>What vesting day on 1 April 2028 means for residents — and what stays exactly the same.</p>
+        </article>
+        <article class="news-article-card">
+          <time datetime="2026-06-20">20 June 2026</time>
+          <h2><a href="news-have-your-say.html">Have your say on services for the new council</a></h2>
+          <p>Residents across the county are invited to help shape how the new council works.</p>
+        </article>
+        <article class="news-article-card">
+          <time datetime="2026-06-12">12 June 2026</time>
+          <h2><a href="news-bins.html">Bins and recycling: what's changing</a></h2>
+          <p>Why your collections carry on as normal through the transition to one council.</p>
+        </article>
+        <article class="news-article-card">
+          <time datetime="2026-06-05">5 June 2026</time>
+          <h2><a href="news-council-tax.html">Council tax: one bill, clearer support</a></h2>
+          <p>How council tax and support for residents are affected by the change.</p>
+        </article>
+        <article class="news-article-card">
+          <time datetime="2026-05-28">28 May 2026</time>
+          <h2><a href="news-shadow-elections.html">Shadow elections planned for May 2027</a></h2>
+          <p>Residents will elect the councillors who form the new authority.</p>
+        </article>
       </div>
 
-      <div class="ct-block ct-block--common">
-        <p>Newstershire Council is the Waste Disposal Authority for the county — a different role to kerbside bin collection, which is covered on the <a href="waste.html">bins and recycling</a> pages. It runs the county's Household Recycling Centres, branded Gloucestershire Recycles.</p>
-
-        <h3>Book before you go</h3>
-        <p>Every visit — car or van — needs a booking made in advance online. This isn't a suggestion; you can be turned away without one. It keeps queues and congestion down and makes the sites safer. With over 10,000 bookings a week across the five sites, there isn't capacity to take bookings by phone as standard. If you genuinely can't book online, and nobody can book on your behalf, there's a phone line: 01452 596 626, weekdays 9am–5pm.</p>
-        <p>Bookings run in fixed 30-minute slots — arrive within yours or you may be turned away and asked to rebook. You'll need to give your name, email, postcode, vehicle make and model, registration, and what waste you're bringing. Bring your booking reference — printed or on your phone — to get in. Need to change your vehicle or slot? There are separate amendment forms for cars and for vans, pick-ups and large trailers.</p>
-
-        <h3>What counts as a car visit</h3>
-        <p>Passenger cars, optionally with a small trailer (under 6ft × 4ft internally). Anything bigger — a van, pick-up, or larger trailer — needs a separate van/large-vehicle booking. HRCs are for household waste only; bringing commercial or trade waste is a criminal offence, and vehicle types are checked against council policy.</p>
-
-        <h3>What you can't bring</h3>
-        <p>Fly-tipped waste isn't accepted — the sites aren't licensed for it. Waste fly-tipped on private land needs a private licensed disposal route instead. Bring only what genuinely can't go through kerbside collection or another route.</p>
-
-        <h3>Sites</h3>
-        <p>Five council-run sites across the county, plus one separate site at Swindon Road in Cheltenham, run independently by Cheltenham Borough Council and currently closed pending review. Known sites: <strong>Hempsted</strong> (Gloucester) — due to close during 2026 for essential repairs and improvements, exact dates to be confirmed — <strong>Pyke Quarry</strong> (near Horsley, Stroud), and <strong>Wingmoor Farm</strong> (Bishop's Cleeve).</p>
-        <p>Each site closes one weekday a week, staggered across the county so there's always a reasonable alternative open — deliberately keeping sites open on Bank Holiday Mondays and Good Friday, historically the busiest days. All sites close on Christmas Day, Boxing Day and New Year's Day. If you need help lifting your waste, ask the staff member at the entrance.</p>
-
-        <div class="ct-note ct-note--info">
-          A zero-tolerance policy applies to violence, aggression, threats or harassment toward staff or other visitors — anyone responsible loses access to the service. General enquiries: waste@gloucestershire.gov.uk.
-        </div>
-
-      </div>
-
-      <nav class="ct-related" aria-label="Other bins and recycling topics">
-        <h2>Other bins and recycling topics</h2>
-        <ul>
-          <li><a href="waste-general-waste.html">General waste</a></li>
-          <li><a href="waste-recycling.html">Recycling</a></li>
-          <li><a href="waste-food-waste.html">Food waste</a></li>
-          <li><a href="waste-garden-waste.html">Garden waste</a></li>
-          <li><a href="waste-bulky.html">Bulky waste</a></li>
-        </ul>
-      </nav>
 
     </div>
   </main>
@@ -149,10 +137,10 @@
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
-            <li><a href="#">Councillors and committees</a></li>
-            <li><a href="#">Council meetings</a></li>
-            <li><a href="#">Budget and spending</a></li>
-            <li><a href="#">LGR transition</a></li>
+            <li><a href="about.html#cabinet-heading">Councillors and committees</a></li>
+            <li><a href="about.html#how-heading">Council meetings</a></li>
+            <li><a href="about.html#budget-heading">Budget and spending</a></li>
+            <li><a href="news.html">News</a></li>
           </ul>
         </div>
         <div class="footer-col">
@@ -163,16 +151,15 @@
             <li><a href="planning.html">Planning</a></li>
             <li><a href="housing.html">Housing</a></li>
             <li><a href="benefits.html">Benefits and support</a></li>
-            <li><a href="county-highways.html">Roads and transport</a></li>
           </ul>
         </div>
         <div class="footer-col">
-          <h3 class="footer-col__title">County services</h3>
+          <h3 class="footer-col__title">Business</h3>
           <ul>
-            <li><a href="county-adult-social-care.html">Adult social care</a></li>
-            <li><a href="county-childrens-services.html">Children &amp; families</a></li>
-            <li><a href="county-libraries.html">Libraries</a></li>
-            <li><a href="waste-recycling-centres.html">Recycling centres</a></li>
+            <li><a href="#">Business rates</a></li>
+            <li><a href="#">Licences and permits</a></li>
+            <li><a href="#">Trading standards</a></li>
+            <li><a href="#">Economic development</a></li>
           </ul>
         </div>
         <div class="footer-col">
@@ -188,7 +175,7 @@
       </div>
       <div class="footer-bottom">
         <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
-        <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
+        <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. News articles on this page are illustrative.</p>
       </div>
     </div>
   </footer>

--- a/LGR/Consolidated/planning-appeals.html
+++ b/LGR/Consolidated/planning-appeals.html
@@ -47,7 +47,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>

--- a/LGR/Consolidated/planning-decision.html
+++ b/LGR/Consolidated/planning-decision.html
@@ -47,7 +47,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>

--- a/LGR/Consolidated/planning-fees.html
+++ b/LGR/Consolidated/planning-fees.html
@@ -47,7 +47,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>

--- a/LGR/Consolidated/planning-how-to-apply.html
+++ b/LGR/Consolidated/planning-how-to-apply.html
@@ -47,7 +47,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>

--- a/LGR/Consolidated/planning-local-plan.html
+++ b/LGR/Consolidated/planning-local-plan.html
@@ -47,7 +47,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>

--- a/LGR/Consolidated/planning.html
+++ b/LGR/Consolidated/planning.html
@@ -48,7 +48,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>

--- a/LGR/Consolidated/style.css
+++ b/LGR/Consolidated/style.css
@@ -895,3 +895,21 @@ details[open] summary::before { transform: rotate(90deg); }
 /* About/Contact: keep intro paragraph line-length readable */
 .page-body > p { max-width: 760px; }
 .page-body > .lead { margin-bottom: 1rem; }
+
+/* =====================================================
+   News listing and articles
+   ===================================================== */
+.news-feed { display: grid; gap: 1rem; margin-top: 1rem; max-width: 760px; }
+.news-article-card { background: var(--white); border: 1px solid var(--border); border-left: 4px solid var(--gold); border-radius: var(--radius); padding: 1.1rem 1.25rem; }
+.news-article-card time { display: block; font-size: 0.8125rem; color: var(--text-muted); margin-bottom: 0.25rem; }
+.news-article-card h2 { font-size: 1.125rem; margin-bottom: 0.35rem; }
+.news-article-card h2 a { color: var(--blue-dark); text-decoration: none; }
+.news-article-card h2 a:hover { text-decoration: underline; }
+.news-article-card p { font-size: 0.9375rem; color: var(--text-muted); }
+
+.article-meta { color: var(--text-muted); font-size: 0.9375rem; margin-bottom: 1.25rem; }
+.article-body { max-width: 760px; }
+.article-body p { margin-bottom: 1rem; }
+.article-body h2 { font-size: 1.25rem; color: var(--blue-dark); margin: 1.75rem 0 0.6rem; }
+.article-body ul { max-width: 760px; padding-left: 1.25rem; margin-bottom: 1rem; }
+.article-body li { margin-bottom: 0.4rem; }

--- a/LGR/Consolidated/waste-bulky.html
+++ b/LGR/Consolidated/waste-bulky.html
@@ -47,7 +47,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>

--- a/LGR/Consolidated/waste-food-waste.html
+++ b/LGR/Consolidated/waste-food-waste.html
@@ -47,7 +47,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>

--- a/LGR/Consolidated/waste-garden-waste.html
+++ b/LGR/Consolidated/waste-garden-waste.html
@@ -47,7 +47,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>

--- a/LGR/Consolidated/waste-general-waste.html
+++ b/LGR/Consolidated/waste-general-waste.html
@@ -47,7 +47,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>

--- a/LGR/Consolidated/waste-recycling.html
+++ b/LGR/Consolidated/waste-recycling.html
@@ -47,7 +47,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>

--- a/LGR/Consolidated/waste.html
+++ b/LGR/Consolidated/waste.html
@@ -48,7 +48,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>

--- a/LGR/Veneer/about.html
+++ b/LGR/Veneer/about.html
@@ -46,7 +46,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link">News</a></li>
           <li><a href="about.html" class="nav-link nav-link--active">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>

--- a/LGR/Veneer/contact.html
+++ b/LGR/Veneer/contact.html
@@ -46,7 +46,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link nav-link--active">Contact</a></li>
         </ul>

--- a/LGR/Veneer/index.html
+++ b/LGR/Veneer/index.html
@@ -46,7 +46,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="#" class="nav-link nav-link--active">Home</a></li>
-          <li><a href="#" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
@@ -268,22 +268,23 @@
           <ul class="news-list">
             <li class="news-item">
               <span class="news-date">27 Jun 2026</span>
-              <a href="#" class="news-title">Newstershire Council officially launches on 1 April 2027</a>
+              <a href="news-new-council.html" class="news-title">One council for Gloucestershire goes live in 2028</a>
             </li>
             <li class="news-item">
               <span class="news-date">20 Jun 2026</span>
-              <a href="#" class="news-title">New recycling centres confirmed for all six districts</a>
+              <a href="news-have-your-say.html" class="news-title">Have your say on services for the new council</a>
             </li>
             <li class="news-item">
-              <span class="news-date">14 Jun 2026</span>
-              <a href="#" class="news-title">Residents invited to have their say on future council services</a>
+              <span class="news-date">12 Jun 2026</span>
+              <a href="news-bins.html" class="news-title">Bins and recycling: what's changing</a>
             </li>
             <li class="news-item">
-              <span class="news-date">5 Jun 2026</span>
-              <a href="#" class="news-title">Transition board appoints interim chief executive</a>
+              <span class="news-date">28 May 2026</span>
+              <a href="news-shadow-elections.html" class="news-title">Shadow elections planned for May 2027</a>
             </li>
           </ul>
-          <a href="#" class="view-all-link">View all news →</a>
+          <a href="news.html" class="view-all-link">View all news →</a>
+
         </div>
 
         <!-- Contact -->

--- a/LGR/Veneer/news-bins.html
+++ b/LGR/Veneer/news-bins.html
@@ -3,9 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Household Recycling Centres – Newstershire Council</title>
+  <title>Bins and recycling: what's changing – Newstershire Council</title>
   <link rel="stylesheet" href="style.css">
-  <link rel="stylesheet" href="council-tax.css">
 </head>
 <body>
 
@@ -47,7 +46,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="news.html" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link nav-link--active">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
@@ -59,62 +58,34 @@
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
-        <li><a href="#">Residents</a></li>
-        <li><a href="waste.html">Bins and recycling</a></li>
-        <li aria-current="page">Recycling centres</li>
+        <li><a href="news.html">News</a></li>
+        <li aria-current="page">Bins and recycling: what's changing</li>
       </ol>
     </div>
   </nav>
 
-  <section class="ct-hero" aria-label="Household Recycling Centres">
+  <section class="page-hero" aria-label="Bins and recycling: what's changing">
     <div class="container">
-      <h1 class="ct-hero__title">Household Recycling Centres</h1>
-      <p class="ct-hero__sub">The county's recycling centres (Gloucestershire Recycles) — how to book a visit, what you can bring, and where the sites are.</p>
+      <h1 class="page-hero__title">Bins and recycling: what's changing</h1>
+      <p class="page-hero__sub">Why your collections carry on as normal through the transition.</p>
     </div>
   </section>
 
   <main id="main-content">
-    <div class="container ct-layout">
+    <div class="container page-body">
 
-      <p class="ct-back"><a href="waste.html">&larr; All bins and recycling topics</a></p>
+      <p class="ct-back" style="margin-bottom:1rem;"><a href="news.html" style="color:var(--blue-mid);font-weight:600;text-decoration:none;">&larr; All news</a></p>
 
-      <div class="ct-note ct-note--info" style="margin-bottom:1.5rem;">
-        Household Recycling Centres are run once for the whole of Gloucestershire, so the sites, booking system and rules are the same wherever you live — separate from the kerbside bin collections, which differ by area.
-      </div>
+      <p class="article-meta">Published 12 June 2026</p>
 
-      <div class="ct-block ct-block--common">
-        <p>Newstershire Council is the Waste Disposal Authority for the county — a different role to kerbside bin collection, which is covered on the <a href="waste.html">bins and recycling</a> pages. It runs the county's Household Recycling Centres, branded Gloucestershire Recycles.</p>
-
-        <h3>Book before you go</h3>
-        <p>Every visit — car or van — needs a booking made in advance online. This isn't a suggestion; you can be turned away without one. It keeps queues and congestion down and makes the sites safer. With over 10,000 bookings a week across the five sites, there isn't capacity to take bookings by phone as standard. If you genuinely can't book online, and nobody can book on your behalf, there's a phone line: 01452 596 626, weekdays 9am–5pm.</p>
-        <p>Bookings run in fixed 30-minute slots — arrive within yours or you may be turned away and asked to rebook. You'll need to give your name, email, postcode, vehicle make and model, registration, and what waste you're bringing. Bring your booking reference — printed or on your phone — to get in. Need to change your vehicle or slot? There are separate amendment forms for cars and for vans, pick-ups and large trailers.</p>
-
-        <h3>What counts as a car visit</h3>
-        <p>Passenger cars, optionally with a small trailer (under 6ft × 4ft internally). Anything bigger — a van, pick-up, or larger trailer — needs a separate van/large-vehicle booking. HRCs are for household waste only; bringing commercial or trade waste is a criminal offence, and vehicle types are checked against council policy.</p>
-
-        <h3>What you can't bring</h3>
-        <p>Fly-tipped waste isn't accepted — the sites aren't licensed for it. Waste fly-tipped on private land needs a private licensed disposal route instead. Bring only what genuinely can't go through kerbside collection or another route.</p>
-
-        <h3>Sites</h3>
-        <p>Five council-run sites across the county, plus one separate site at Swindon Road in Cheltenham, run independently by Cheltenham Borough Council and currently closed pending review. Known sites: <strong>Hempsted</strong> (Gloucester) — due to close during 2026 for essential repairs and improvements, exact dates to be confirmed — <strong>Pyke Quarry</strong> (near Horsley, Stroud), and <strong>Wingmoor Farm</strong> (Bishop's Cleeve).</p>
-        <p>Each site closes one weekday a week, staggered across the county so there's always a reasonable alternative open — deliberately keeping sites open on Bank Holiday Mondays and Good Friday, historically the busiest days. All sites close on Christmas Day, Boxing Day and New Year's Day. If you need help lifting your waste, ask the staff member at the entrance.</p>
-
-        <div class="ct-note ct-note--info">
-          A zero-tolerance policy applies to violence, aggression, threats or harassment toward staff or other visitors — anyone responsible loses access to the service. General enquiries: waste@gloucestershire.gov.uk.
-        </div>
+      <div class="article-body">
+        <p>With one council coming for the whole county, a common question is what happens to bin collections. The short answer: nothing changes for now, and any future changes would be made carefully and communicated well in advance.</p>
+        <p>Bin colours, collection days and what goes in which container are currently set locally, so they still vary between areas. Those arrangements continue as they are through the transition.</p>
+        <h2>Looking ahead</h2>
+        <p>Over time, bringing collections under one council may create opportunities to make services more consistent and efficient across the county. Any changes would be planned with residents in mind and announced clearly before they took effect.</p>
+        <p>In the meantime, the simplest way to check your own collection details is to look up your area on the bins and recycling pages.</p>
 
       </div>
-
-      <nav class="ct-related" aria-label="Other bins and recycling topics">
-        <h2>Other bins and recycling topics</h2>
-        <ul>
-          <li><a href="waste-general-waste.html">General waste</a></li>
-          <li><a href="waste-recycling.html">Recycling</a></li>
-          <li><a href="waste-food-waste.html">Food waste</a></li>
-          <li><a href="waste-garden-waste.html">Garden waste</a></li>
-          <li><a href="waste-bulky.html">Bulky waste</a></li>
-        </ul>
-      </nav>
 
     </div>
   </main>
@@ -149,30 +120,29 @@
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
-            <li><a href="#">Councillors and committees</a></li>
-            <li><a href="#">Council meetings</a></li>
-            <li><a href="#">Budget and spending</a></li>
-            <li><a href="#">LGR transition</a></li>
+            <li><a href="about.html#cabinet-heading">Councillors and committees</a></li>
+            <li><a href="about.html#how-heading">Council meetings</a></li>
+            <li><a href="about.html#budget-heading">Budget and spending</a></li>
+            <li><a href="news.html">News</a></li>
           </ul>
         </div>
         <div class="footer-col">
           <h3 class="footer-col__title">Residents</h3>
           <ul>
-            <li><a href="council-tax.html">Council tax</a></li>
-            <li><a href="waste.html">Bins and recycling</a></li>
-            <li><a href="planning.html">Planning</a></li>
-            <li><a href="housing.html">Housing</a></li>
-            <li><a href="benefits.html">Benefits and support</a></li>
-            <li><a href="county-highways.html">Roads and transport</a></li>
+            <li><a href="index.html">Council tax</a></li>
+            <li><a href="index.html">Bins and recycling</a></li>
+            <li><a href="index.html">Planning</a></li>
+            <li><a href="index.html">Housing</a></li>
+            <li><a href="index.html">Benefits and support</a></li>
           </ul>
         </div>
         <div class="footer-col">
-          <h3 class="footer-col__title">County services</h3>
+          <h3 class="footer-col__title">Business</h3>
           <ul>
-            <li><a href="county-adult-social-care.html">Adult social care</a></li>
-            <li><a href="county-childrens-services.html">Children &amp; families</a></li>
-            <li><a href="county-libraries.html">Libraries</a></li>
-            <li><a href="waste-recycling-centres.html">Recycling centres</a></li>
+            <li><a href="#">Business rates</a></li>
+            <li><a href="#">Licences and permits</a></li>
+            <li><a href="#">Trading standards</a></li>
+            <li><a href="#">Economic development</a></li>
           </ul>
         </div>
         <div class="footer-col">
@@ -188,7 +158,7 @@
       </div>
       <div class="footer-bottom">
         <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
-        <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
+        <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. News articles on this page are illustrative.</p>
       </div>
     </div>
   </footer>

--- a/LGR/Veneer/news-council-tax.html
+++ b/LGR/Veneer/news-council-tax.html
@@ -3,9 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Household Recycling Centres – Newstershire Council</title>
+  <title>Council tax: one bill, clearer support – Newstershire Council</title>
   <link rel="stylesheet" href="style.css">
-  <link rel="stylesheet" href="council-tax.css">
 </head>
 <body>
 
@@ -47,7 +46,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="news.html" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link nav-link--active">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
@@ -59,62 +58,34 @@
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
-        <li><a href="#">Residents</a></li>
-        <li><a href="waste.html">Bins and recycling</a></li>
-        <li aria-current="page">Recycling centres</li>
+        <li><a href="news.html">News</a></li>
+        <li aria-current="page">Council tax: one bill, clearer support</li>
       </ol>
     </div>
   </nav>
 
-  <section class="ct-hero" aria-label="Household Recycling Centres">
+  <section class="page-hero" aria-label="Council tax: one bill, clearer support">
     <div class="container">
-      <h1 class="ct-hero__title">Household Recycling Centres</h1>
-      <p class="ct-hero__sub">The county's recycling centres (Gloucestershire Recycles) — how to book a visit, what you can bring, and where the sites are.</p>
+      <h1 class="page-hero__title">Council tax: one bill, clearer support</h1>
+      <p class="page-hero__sub">How council tax and support for residents are affected by the change.</p>
     </div>
   </section>
 
   <main id="main-content">
-    <div class="container ct-layout">
+    <div class="container page-body">
 
-      <p class="ct-back"><a href="waste.html">&larr; All bins and recycling topics</a></p>
+      <p class="ct-back" style="margin-bottom:1rem;"><a href="news.html" style="color:var(--blue-mid);font-weight:600;text-decoration:none;">&larr; All news</a></p>
 
-      <div class="ct-note ct-note--info" style="margin-bottom:1.5rem;">
-        Household Recycling Centres are run once for the whole of Gloucestershire, so the sites, booking system and rules are the same wherever you live — separate from the kerbside bin collections, which differ by area.
-      </div>
+      <p class="article-meta">Published 5 June 2026</p>
 
-      <div class="ct-block ct-block--common">
-        <p>Newstershire Council is the Waste Disposal Authority for the county — a different role to kerbside bin collection, which is covered on the <a href="waste.html">bins and recycling</a> pages. It runs the county's Household Recycling Centres, branded Gloucestershire Recycles.</p>
-
-        <h3>Book before you go</h3>
-        <p>Every visit — car or van — needs a booking made in advance online. This isn't a suggestion; you can be turned away without one. It keeps queues and congestion down and makes the sites safer. With over 10,000 bookings a week across the five sites, there isn't capacity to take bookings by phone as standard. If you genuinely can't book online, and nobody can book on your behalf, there's a phone line: 01452 596 626, weekdays 9am–5pm.</p>
-        <p>Bookings run in fixed 30-minute slots — arrive within yours or you may be turned away and asked to rebook. You'll need to give your name, email, postcode, vehicle make and model, registration, and what waste you're bringing. Bring your booking reference — printed or on your phone — to get in. Need to change your vehicle or slot? There are separate amendment forms for cars and for vans, pick-ups and large trailers.</p>
-
-        <h3>What counts as a car visit</h3>
-        <p>Passenger cars, optionally with a small trailer (under 6ft × 4ft internally). Anything bigger — a van, pick-up, or larger trailer — needs a separate van/large-vehicle booking. HRCs are for household waste only; bringing commercial or trade waste is a criminal offence, and vehicle types are checked against council policy.</p>
-
-        <h3>What you can't bring</h3>
-        <p>Fly-tipped waste isn't accepted — the sites aren't licensed for it. Waste fly-tipped on private land needs a private licensed disposal route instead. Bring only what genuinely can't go through kerbside collection or another route.</p>
-
-        <h3>Sites</h3>
-        <p>Five council-run sites across the county, plus one separate site at Swindon Road in Cheltenham, run independently by Cheltenham Borough Council and currently closed pending review. Known sites: <strong>Hempsted</strong> (Gloucester) — due to close during 2026 for essential repairs and improvements, exact dates to be confirmed — <strong>Pyke Quarry</strong> (near Horsley, Stroud), and <strong>Wingmoor Farm</strong> (Bishop's Cleeve).</p>
-        <p>Each site closes one weekday a week, staggered across the county so there's always a reasonable alternative open — deliberately keeping sites open on Bank Holiday Mondays and Good Friday, historically the busiest days. All sites close on Christmas Day, Boxing Day and New Year's Day. If you need help lifting your waste, ask the staff member at the entrance.</p>
-
-        <div class="ct-note ct-note--info">
-          A zero-tolerance policy applies to violence, aggression, threats or harassment toward staff or other visitors — anyone responsible loses access to the service. General enquiries: waste@gloucestershire.gov.uk.
-        </div>
+      <div class="article-body">
+        <p>Council tax will continue to be billed as normal through the move to a single council. Residents don't need to take any action, and support for those on a low income remains available.</p>
+        <p>Council tax is made up of charges set by different bodies. As services come together under one council, the aim is to make bills clearer and support easier to find — without changing the help available to those who need it.</p>
+        <h2>Getting help with your bill</h2>
+        <p>If you're struggling to pay, or think you may be entitled to a discount, exemption or reduction, it's worth checking sooner rather than later. Support is means-tested for those on a low income, and various discounts and exemptions apply depending on circumstances.</p>
+        <p>You can find the current rules, discounts and support on the council tax pages, and check what applies to your area.</p>
 
       </div>
-
-      <nav class="ct-related" aria-label="Other bins and recycling topics">
-        <h2>Other bins and recycling topics</h2>
-        <ul>
-          <li><a href="waste-general-waste.html">General waste</a></li>
-          <li><a href="waste-recycling.html">Recycling</a></li>
-          <li><a href="waste-food-waste.html">Food waste</a></li>
-          <li><a href="waste-garden-waste.html">Garden waste</a></li>
-          <li><a href="waste-bulky.html">Bulky waste</a></li>
-        </ul>
-      </nav>
 
     </div>
   </main>
@@ -149,30 +120,29 @@
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
-            <li><a href="#">Councillors and committees</a></li>
-            <li><a href="#">Council meetings</a></li>
-            <li><a href="#">Budget and spending</a></li>
-            <li><a href="#">LGR transition</a></li>
+            <li><a href="about.html#cabinet-heading">Councillors and committees</a></li>
+            <li><a href="about.html#how-heading">Council meetings</a></li>
+            <li><a href="about.html#budget-heading">Budget and spending</a></li>
+            <li><a href="news.html">News</a></li>
           </ul>
         </div>
         <div class="footer-col">
           <h3 class="footer-col__title">Residents</h3>
           <ul>
-            <li><a href="council-tax.html">Council tax</a></li>
-            <li><a href="waste.html">Bins and recycling</a></li>
-            <li><a href="planning.html">Planning</a></li>
-            <li><a href="housing.html">Housing</a></li>
-            <li><a href="benefits.html">Benefits and support</a></li>
-            <li><a href="county-highways.html">Roads and transport</a></li>
+            <li><a href="index.html">Council tax</a></li>
+            <li><a href="index.html">Bins and recycling</a></li>
+            <li><a href="index.html">Planning</a></li>
+            <li><a href="index.html">Housing</a></li>
+            <li><a href="index.html">Benefits and support</a></li>
           </ul>
         </div>
         <div class="footer-col">
-          <h3 class="footer-col__title">County services</h3>
+          <h3 class="footer-col__title">Business</h3>
           <ul>
-            <li><a href="county-adult-social-care.html">Adult social care</a></li>
-            <li><a href="county-childrens-services.html">Children &amp; families</a></li>
-            <li><a href="county-libraries.html">Libraries</a></li>
-            <li><a href="waste-recycling-centres.html">Recycling centres</a></li>
+            <li><a href="#">Business rates</a></li>
+            <li><a href="#">Licences and permits</a></li>
+            <li><a href="#">Trading standards</a></li>
+            <li><a href="#">Economic development</a></li>
           </ul>
         </div>
         <div class="footer-col">
@@ -188,7 +158,7 @@
       </div>
       <div class="footer-bottom">
         <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
-        <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
+        <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. News articles on this page are illustrative.</p>
       </div>
     </div>
   </footer>

--- a/LGR/Veneer/news-have-your-say.html
+++ b/LGR/Veneer/news-have-your-say.html
@@ -3,9 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Household Recycling Centres – Newstershire Council</title>
+  <title>Have your say on services for the new council – Newstershire Council</title>
   <link rel="stylesheet" href="style.css">
-  <link rel="stylesheet" href="council-tax.css">
 </head>
 <body>
 
@@ -47,7 +46,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="news.html" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link nav-link--active">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
@@ -59,62 +58,39 @@
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
-        <li><a href="#">Residents</a></li>
-        <li><a href="waste.html">Bins and recycling</a></li>
-        <li aria-current="page">Recycling centres</li>
+        <li><a href="news.html">News</a></li>
+        <li aria-current="page">Have your say on services for the new council</li>
       </ol>
     </div>
   </nav>
 
-  <section class="ct-hero" aria-label="Household Recycling Centres">
+  <section class="page-hero" aria-label="Have your say on services for the new council">
     <div class="container">
-      <h1 class="ct-hero__title">Household Recycling Centres</h1>
-      <p class="ct-hero__sub">The county's recycling centres (Gloucestershire Recycles) — how to book a visit, what you can bring, and where the sites are.</p>
+      <h1 class="page-hero__title">Have your say on services for the new council</h1>
+      <p class="page-hero__sub">Residents are invited to help shape how the new council works.</p>
     </div>
   </section>
 
   <main id="main-content">
-    <div class="container ct-layout">
+    <div class="container page-body">
 
-      <p class="ct-back"><a href="waste.html">&larr; All bins and recycling topics</a></p>
+      <p class="ct-back" style="margin-bottom:1rem;"><a href="news.html" style="color:var(--blue-mid);font-weight:600;text-decoration:none;">&larr; All news</a></p>
 
-      <div class="ct-note ct-note--info" style="margin-bottom:1.5rem;">
-        Household Recycling Centres are run once for the whole of Gloucestershire, so the sites, booking system and rules are the same wherever you live — separate from the kerbside bin collections, which differ by area.
-      </div>
+      <p class="article-meta">Published 20 June 2026</p>
 
-      <div class="ct-block ct-block--common">
-        <p>Newstershire Council is the Waste Disposal Authority for the county — a different role to kerbside bin collection, which is covered on the <a href="waste.html">bins and recycling</a> pages. It runs the county's Household Recycling Centres, branded Gloucestershire Recycles.</p>
-
-        <h3>Book before you go</h3>
-        <p>Every visit — car or van — needs a booking made in advance online. This isn't a suggestion; you can be turned away without one. It keeps queues and congestion down and makes the sites safer. With over 10,000 bookings a week across the five sites, there isn't capacity to take bookings by phone as standard. If you genuinely can't book online, and nobody can book on your behalf, there's a phone line: 01452 596 626, weekdays 9am–5pm.</p>
-        <p>Bookings run in fixed 30-minute slots — arrive within yours or you may be turned away and asked to rebook. You'll need to give your name, email, postcode, vehicle make and model, registration, and what waste you're bringing. Bring your booking reference — printed or on your phone — to get in. Need to change your vehicle or slot? There are separate amendment forms for cars and for vans, pick-ups and large trailers.</p>
-
-        <h3>What counts as a car visit</h3>
-        <p>Passenger cars, optionally with a small trailer (under 6ft × 4ft internally). Anything bigger — a van, pick-up, or larger trailer — needs a separate van/large-vehicle booking. HRCs are for household waste only; bringing commercial or trade waste is a criminal offence, and vehicle types are checked against council policy.</p>
-
-        <h3>What you can't bring</h3>
-        <p>Fly-tipped waste isn't accepted — the sites aren't licensed for it. Waste fly-tipped on private land needs a private licensed disposal route instead. Bring only what genuinely can't go through kerbside collection or another route.</p>
-
-        <h3>Sites</h3>
-        <p>Five council-run sites across the county, plus one separate site at Swindon Road in Cheltenham, run independently by Cheltenham Borough Council and currently closed pending review. Known sites: <strong>Hempsted</strong> (Gloucester) — due to close during 2026 for essential repairs and improvements, exact dates to be confirmed — <strong>Pyke Quarry</strong> (near Horsley, Stroud), and <strong>Wingmoor Farm</strong> (Bishop's Cleeve).</p>
-        <p>Each site closes one weekday a week, staggered across the county so there's always a reasonable alternative open — deliberately keeping sites open on Bank Holiday Mondays and Good Friday, historically the busiest days. All sites close on Christmas Day, Boxing Day and New Year's Day. If you need help lifting your waste, ask the staff member at the entrance.</p>
-
-        <div class="ct-note ct-note--info">
-          A zero-tolerance policy applies to violence, aggression, threats or harassment toward staff or other visitors — anyone responsible loses access to the service. General enquiries: waste@gloucestershire.gov.uk.
-        </div>
-
-      </div>
-
-      <nav class="ct-related" aria-label="Other bins and recycling topics">
-        <h2>Other bins and recycling topics</h2>
+      <div class="article-body">
+        <p>Residents across Gloucestershire are being invited to help shape how the new council works — from the services people rely on most to how they'd prefer to get in touch.</p>
+        <p>The move to a single council is a rare chance to design services around residents rather than around existing organisational boundaries. Feedback gathered now will help set priorities for the new council ahead of vesting day.</p>
+        <h2>How to take part</h2>
         <ul>
-          <li><a href="waste-general-waste.html">General waste</a></li>
-          <li><a href="waste-recycling.html">Recycling</a></li>
-          <li><a href="waste-food-waste.html">Food waste</a></li>
-          <li><a href="waste-garden-waste.html">Garden waste</a></li>
-          <li><a href="waste-bulky.html">Bulky waste</a></li>
+          <li>Share your views through the online survey while it's open</li>
+          <li>Come along to a local drop-in session in your area</li>
+          <li>Tell us which services matter most to you and how you'd like to access them</li>
         </ul>
-      </nav>
+        <p>Everyone who lives, works or studies in the county is welcome to take part. Responses are anonymous and used only to inform planning for the new council.</p>
+        <p>Watch this page for dates and details as sessions are confirmed.</p>
+
+      </div>
 
     </div>
   </main>
@@ -149,30 +125,29 @@
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
-            <li><a href="#">Councillors and committees</a></li>
-            <li><a href="#">Council meetings</a></li>
-            <li><a href="#">Budget and spending</a></li>
-            <li><a href="#">LGR transition</a></li>
+            <li><a href="about.html#cabinet-heading">Councillors and committees</a></li>
+            <li><a href="about.html#how-heading">Council meetings</a></li>
+            <li><a href="about.html#budget-heading">Budget and spending</a></li>
+            <li><a href="news.html">News</a></li>
           </ul>
         </div>
         <div class="footer-col">
           <h3 class="footer-col__title">Residents</h3>
           <ul>
-            <li><a href="council-tax.html">Council tax</a></li>
-            <li><a href="waste.html">Bins and recycling</a></li>
-            <li><a href="planning.html">Planning</a></li>
-            <li><a href="housing.html">Housing</a></li>
-            <li><a href="benefits.html">Benefits and support</a></li>
-            <li><a href="county-highways.html">Roads and transport</a></li>
+            <li><a href="index.html">Council tax</a></li>
+            <li><a href="index.html">Bins and recycling</a></li>
+            <li><a href="index.html">Planning</a></li>
+            <li><a href="index.html">Housing</a></li>
+            <li><a href="index.html">Benefits and support</a></li>
           </ul>
         </div>
         <div class="footer-col">
-          <h3 class="footer-col__title">County services</h3>
+          <h3 class="footer-col__title">Business</h3>
           <ul>
-            <li><a href="county-adult-social-care.html">Adult social care</a></li>
-            <li><a href="county-childrens-services.html">Children &amp; families</a></li>
-            <li><a href="county-libraries.html">Libraries</a></li>
-            <li><a href="waste-recycling-centres.html">Recycling centres</a></li>
+            <li><a href="#">Business rates</a></li>
+            <li><a href="#">Licences and permits</a></li>
+            <li><a href="#">Trading standards</a></li>
+            <li><a href="#">Economic development</a></li>
           </ul>
         </div>
         <div class="footer-col">
@@ -188,7 +163,7 @@
       </div>
       <div class="footer-bottom">
         <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
-        <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
+        <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. News articles on this page are illustrative.</p>
       </div>
     </div>
   </footer>

--- a/LGR/Veneer/news-new-council.html
+++ b/LGR/Veneer/news-new-council.html
@@ -3,9 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Household Recycling Centres – Newstershire Council</title>
+  <title>One council for Gloucestershire goes live in 2028 – Newstershire Council</title>
   <link rel="stylesheet" href="style.css">
-  <link rel="stylesheet" href="council-tax.css">
 </head>
 <body>
 
@@ -47,7 +46,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="news.html" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link nav-link--active">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
@@ -59,62 +58,36 @@
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
-        <li><a href="#">Residents</a></li>
-        <li><a href="waste.html">Bins and recycling</a></li>
-        <li aria-current="page">Recycling centres</li>
+        <li><a href="news.html">News</a></li>
+        <li aria-current="page">One council for Gloucestershire goes live in 2028</li>
       </ol>
     </div>
   </nav>
 
-  <section class="ct-hero" aria-label="Household Recycling Centres">
+  <section class="page-hero" aria-label="One council for Gloucestershire goes live in 2028">
     <div class="container">
-      <h1 class="ct-hero__title">Household Recycling Centres</h1>
-      <p class="ct-hero__sub">The county's recycling centres (Gloucestershire Recycles) — how to book a visit, what you can bring, and where the sites are.</p>
+      <h1 class="page-hero__title">One council for Gloucestershire goes live in 2028</h1>
+      <p class="page-hero__sub">What vesting day means for residents — and what stays exactly the same.</p>
     </div>
   </section>
 
   <main id="main-content">
-    <div class="container ct-layout">
+    <div class="container page-body">
 
-      <p class="ct-back"><a href="waste.html">&larr; All bins and recycling topics</a></p>
+      <p class="ct-back" style="margin-bottom:1rem;"><a href="news.html" style="color:var(--blue-mid);font-weight:600;text-decoration:none;">&larr; All news</a></p>
 
-      <div class="ct-note ct-note--info" style="margin-bottom:1.5rem;">
-        Household Recycling Centres are run once for the whole of Gloucestershire, so the sites, booking system and rules are the same wherever you live — separate from the kerbside bin collections, which differ by area.
-      </div>
+      <p class="article-meta">Published 27 June 2026</p>
 
-      <div class="ct-block ct-block--common">
-        <p>Newstershire Council is the Waste Disposal Authority for the county — a different role to kerbside bin collection, which is covered on the <a href="waste.html">bins and recycling</a> pages. It runs the county's Household Recycling Centres, branded Gloucestershire Recycles.</p>
-
-        <h3>Book before you go</h3>
-        <p>Every visit — car or van — needs a booking made in advance online. This isn't a suggestion; you can be turned away without one. It keeps queues and congestion down and makes the sites safer. With over 10,000 bookings a week across the five sites, there isn't capacity to take bookings by phone as standard. If you genuinely can't book online, and nobody can book on your behalf, there's a phone line: 01452 596 626, weekdays 9am–5pm.</p>
-        <p>Bookings run in fixed 30-minute slots — arrive within yours or you may be turned away and asked to rebook. You'll need to give your name, email, postcode, vehicle make and model, registration, and what waste you're bringing. Bring your booking reference — printed or on your phone — to get in. Need to change your vehicle or slot? There are separate amendment forms for cars and for vans, pick-ups and large trailers.</p>
-
-        <h3>What counts as a car visit</h3>
-        <p>Passenger cars, optionally with a small trailer (under 6ft × 4ft internally). Anything bigger — a van, pick-up, or larger trailer — needs a separate van/large-vehicle booking. HRCs are for household waste only; bringing commercial or trade waste is a criminal offence, and vehicle types are checked against council policy.</p>
-
-        <h3>What you can't bring</h3>
-        <p>Fly-tipped waste isn't accepted — the sites aren't licensed for it. Waste fly-tipped on private land needs a private licensed disposal route instead. Bring only what genuinely can't go through kerbside collection or another route.</p>
-
-        <h3>Sites</h3>
-        <p>Five council-run sites across the county, plus one separate site at Swindon Road in Cheltenham, run independently by Cheltenham Borough Council and currently closed pending review. Known sites: <strong>Hempsted</strong> (Gloucester) — due to close during 2026 for essential repairs and improvements, exact dates to be confirmed — <strong>Pyke Quarry</strong> (near Horsley, Stroud), and <strong>Wingmoor Farm</strong> (Bishop's Cleeve).</p>
-        <p>Each site closes one weekday a week, staggered across the county so there's always a reasonable alternative open — deliberately keeping sites open on Bank Holiday Mondays and Good Friday, historically the busiest days. All sites close on Christmas Day, Boxing Day and New Year's Day. If you need help lifting your waste, ask the staff member at the entrance.</p>
-
-        <div class="ct-note ct-note--info">
-          A zero-tolerance policy applies to violence, aggression, threats or harassment toward staff or other visitors — anyone responsible loses access to the service. General enquiries: waste@gloucestershire.gov.uk.
-        </div>
+      <div class="article-body">
+        <p>Newstershire Council, the new single council for the whole of Gloucestershire, will formally take over local services on <strong>1 April 2028</strong> — known as vesting day. From that date, one council will be responsible for everything from adult social care and roads to bins, planning and council tax.</p>
+        <p>Until then, the current county, district and borough councils continue to run services as normal. Residents don't need to do anything — bins will be collected, bills will be issued, and services will run as usual through the changeover.</p>
+        <h2>What's changing</h2>
+        <p>Bringing seven councils together into one is intended to make services simpler to find and use. Over time, residents will have a single website, one phone number and one account for their council services, rather than needing to work out which organisation to contact.</p>
+        <h2>What's staying the same</h2>
+        <p>Day-to-day services continue without interruption. Where a service is delivered locally today, it will keep running — the change is about how the council is organised behind the scenes, not about stopping or reducing services.</p>
+        <p>We'll keep publishing updates here as the transition progresses.</p>
 
       </div>
-
-      <nav class="ct-related" aria-label="Other bins and recycling topics">
-        <h2>Other bins and recycling topics</h2>
-        <ul>
-          <li><a href="waste-general-waste.html">General waste</a></li>
-          <li><a href="waste-recycling.html">Recycling</a></li>
-          <li><a href="waste-food-waste.html">Food waste</a></li>
-          <li><a href="waste-garden-waste.html">Garden waste</a></li>
-          <li><a href="waste-bulky.html">Bulky waste</a></li>
-        </ul>
-      </nav>
 
     </div>
   </main>
@@ -149,30 +122,29 @@
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
-            <li><a href="#">Councillors and committees</a></li>
-            <li><a href="#">Council meetings</a></li>
-            <li><a href="#">Budget and spending</a></li>
-            <li><a href="#">LGR transition</a></li>
+            <li><a href="about.html#cabinet-heading">Councillors and committees</a></li>
+            <li><a href="about.html#how-heading">Council meetings</a></li>
+            <li><a href="about.html#budget-heading">Budget and spending</a></li>
+            <li><a href="news.html">News</a></li>
           </ul>
         </div>
         <div class="footer-col">
           <h3 class="footer-col__title">Residents</h3>
           <ul>
-            <li><a href="council-tax.html">Council tax</a></li>
-            <li><a href="waste.html">Bins and recycling</a></li>
-            <li><a href="planning.html">Planning</a></li>
-            <li><a href="housing.html">Housing</a></li>
-            <li><a href="benefits.html">Benefits and support</a></li>
-            <li><a href="county-highways.html">Roads and transport</a></li>
+            <li><a href="index.html">Council tax</a></li>
+            <li><a href="index.html">Bins and recycling</a></li>
+            <li><a href="index.html">Planning</a></li>
+            <li><a href="index.html">Housing</a></li>
+            <li><a href="index.html">Benefits and support</a></li>
           </ul>
         </div>
         <div class="footer-col">
-          <h3 class="footer-col__title">County services</h3>
+          <h3 class="footer-col__title">Business</h3>
           <ul>
-            <li><a href="county-adult-social-care.html">Adult social care</a></li>
-            <li><a href="county-childrens-services.html">Children &amp; families</a></li>
-            <li><a href="county-libraries.html">Libraries</a></li>
-            <li><a href="waste-recycling-centres.html">Recycling centres</a></li>
+            <li><a href="#">Business rates</a></li>
+            <li><a href="#">Licences and permits</a></li>
+            <li><a href="#">Trading standards</a></li>
+            <li><a href="#">Economic development</a></li>
           </ul>
         </div>
         <div class="footer-col">
@@ -188,7 +160,7 @@
       </div>
       <div class="footer-bottom">
         <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
-        <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
+        <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. News articles on this page are illustrative.</p>
       </div>
     </div>
   </footer>

--- a/LGR/Veneer/news-shadow-elections.html
+++ b/LGR/Veneer/news-shadow-elections.html
@@ -3,9 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Household Recycling Centres – Newstershire Council</title>
+  <title>Shadow elections planned for May 2027 – Newstershire Council</title>
   <link rel="stylesheet" href="style.css">
-  <link rel="stylesheet" href="council-tax.css">
 </head>
 <body>
 
@@ -47,7 +46,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="news.html" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link nav-link--active">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
@@ -59,62 +58,34 @@
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
-        <li><a href="#">Residents</a></li>
-        <li><a href="waste.html">Bins and recycling</a></li>
-        <li aria-current="page">Recycling centres</li>
+        <li><a href="news.html">News</a></li>
+        <li aria-current="page">Shadow elections planned for May 2027</li>
       </ol>
     </div>
   </nav>
 
-  <section class="ct-hero" aria-label="Household Recycling Centres">
+  <section class="page-hero" aria-label="Shadow elections planned for May 2027">
     <div class="container">
-      <h1 class="ct-hero__title">Household Recycling Centres</h1>
-      <p class="ct-hero__sub">The county's recycling centres (Gloucestershire Recycles) — how to book a visit, what you can bring, and where the sites are.</p>
+      <h1 class="page-hero__title">Shadow elections planned for May 2027</h1>
+      <p class="page-hero__sub">Residents will elect the councillors who form the new authority.</p>
     </div>
   </section>
 
   <main id="main-content">
-    <div class="container ct-layout">
+    <div class="container page-body">
 
-      <p class="ct-back"><a href="waste.html">&larr; All bins and recycling topics</a></p>
+      <p class="ct-back" style="margin-bottom:1rem;"><a href="news.html" style="color:var(--blue-mid);font-weight:600;text-decoration:none;">&larr; All news</a></p>
 
-      <div class="ct-note ct-note--info" style="margin-bottom:1.5rem;">
-        Household Recycling Centres are run once for the whole of Gloucestershire, so the sites, booking system and rules are the same wherever you live — separate from the kerbside bin collections, which differ by area.
-      </div>
+      <p class="article-meta">Published 28 May 2026</p>
 
-      <div class="ct-block ct-block--common">
-        <p>Newstershire Council is the Waste Disposal Authority for the county — a different role to kerbside bin collection, which is covered on the <a href="waste.html">bins and recycling</a> pages. It runs the county's Household Recycling Centres, branded Gloucestershire Recycles.</p>
-
-        <h3>Book before you go</h3>
-        <p>Every visit — car or van — needs a booking made in advance online. This isn't a suggestion; you can be turned away without one. It keeps queues and congestion down and makes the sites safer. With over 10,000 bookings a week across the five sites, there isn't capacity to take bookings by phone as standard. If you genuinely can't book online, and nobody can book on your behalf, there's a phone line: 01452 596 626, weekdays 9am–5pm.</p>
-        <p>Bookings run in fixed 30-minute slots — arrive within yours or you may be turned away and asked to rebook. You'll need to give your name, email, postcode, vehicle make and model, registration, and what waste you're bringing. Bring your booking reference — printed or on your phone — to get in. Need to change your vehicle or slot? There are separate amendment forms for cars and for vans, pick-ups and large trailers.</p>
-
-        <h3>What counts as a car visit</h3>
-        <p>Passenger cars, optionally with a small trailer (under 6ft × 4ft internally). Anything bigger — a van, pick-up, or larger trailer — needs a separate van/large-vehicle booking. HRCs are for household waste only; bringing commercial or trade waste is a criminal offence, and vehicle types are checked against council policy.</p>
-
-        <h3>What you can't bring</h3>
-        <p>Fly-tipped waste isn't accepted — the sites aren't licensed for it. Waste fly-tipped on private land needs a private licensed disposal route instead. Bring only what genuinely can't go through kerbside collection or another route.</p>
-
-        <h3>Sites</h3>
-        <p>Five council-run sites across the county, plus one separate site at Swindon Road in Cheltenham, run independently by Cheltenham Borough Council and currently closed pending review. Known sites: <strong>Hempsted</strong> (Gloucester) — due to close during 2026 for essential repairs and improvements, exact dates to be confirmed — <strong>Pyke Quarry</strong> (near Horsley, Stroud), and <strong>Wingmoor Farm</strong> (Bishop's Cleeve).</p>
-        <p>Each site closes one weekday a week, staggered across the county so there's always a reasonable alternative open — deliberately keeping sites open on Bank Holiday Mondays and Good Friday, historically the busiest days. All sites close on Christmas Day, Boxing Day and New Year's Day. If you need help lifting your waste, ask the staff member at the entrance.</p>
-
-        <div class="ct-note ct-note--info">
-          A zero-tolerance policy applies to violence, aggression, threats or harassment toward staff or other visitors — anyone responsible loses access to the service. General enquiries: waste@gloucestershire.gov.uk.
-        </div>
+      <div class="article-body">
+        <p>Ahead of the new council going live, residents will elect the councillors who will form it. These <strong>shadow elections</strong> are planned for <strong>May 2027</strong>.</p>
+        <p>The councillors elected then will oversee the final year of preparation and take up their full responsibilities on vesting day, 1 April 2028. It's an important moment: the people elected will shape the priorities and decisions of the new council from day one.</p>
+        <h2>Registering to vote</h2>
+        <p>If you're eligible and registered to vote, you'll be able to take part as usual. If you're not yet registered, it's worth doing so in good time — registration is free and can be done online through the national service.</p>
+        <p>More detail on candidates, polling arrangements and dates will be published closer to the time.</p>
 
       </div>
-
-      <nav class="ct-related" aria-label="Other bins and recycling topics">
-        <h2>Other bins and recycling topics</h2>
-        <ul>
-          <li><a href="waste-general-waste.html">General waste</a></li>
-          <li><a href="waste-recycling.html">Recycling</a></li>
-          <li><a href="waste-food-waste.html">Food waste</a></li>
-          <li><a href="waste-garden-waste.html">Garden waste</a></li>
-          <li><a href="waste-bulky.html">Bulky waste</a></li>
-        </ul>
-      </nav>
 
     </div>
   </main>
@@ -149,30 +120,29 @@
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
-            <li><a href="#">Councillors and committees</a></li>
-            <li><a href="#">Council meetings</a></li>
-            <li><a href="#">Budget and spending</a></li>
-            <li><a href="#">LGR transition</a></li>
+            <li><a href="about.html#cabinet-heading">Councillors and committees</a></li>
+            <li><a href="about.html#how-heading">Council meetings</a></li>
+            <li><a href="about.html#budget-heading">Budget and spending</a></li>
+            <li><a href="news.html">News</a></li>
           </ul>
         </div>
         <div class="footer-col">
           <h3 class="footer-col__title">Residents</h3>
           <ul>
-            <li><a href="council-tax.html">Council tax</a></li>
-            <li><a href="waste.html">Bins and recycling</a></li>
-            <li><a href="planning.html">Planning</a></li>
-            <li><a href="housing.html">Housing</a></li>
-            <li><a href="benefits.html">Benefits and support</a></li>
-            <li><a href="county-highways.html">Roads and transport</a></li>
+            <li><a href="index.html">Council tax</a></li>
+            <li><a href="index.html">Bins and recycling</a></li>
+            <li><a href="index.html">Planning</a></li>
+            <li><a href="index.html">Housing</a></li>
+            <li><a href="index.html">Benefits and support</a></li>
           </ul>
         </div>
         <div class="footer-col">
-          <h3 class="footer-col__title">County services</h3>
+          <h3 class="footer-col__title">Business</h3>
           <ul>
-            <li><a href="county-adult-social-care.html">Adult social care</a></li>
-            <li><a href="county-childrens-services.html">Children &amp; families</a></li>
-            <li><a href="county-libraries.html">Libraries</a></li>
-            <li><a href="waste-recycling-centres.html">Recycling centres</a></li>
+            <li><a href="#">Business rates</a></li>
+            <li><a href="#">Licences and permits</a></li>
+            <li><a href="#">Trading standards</a></li>
+            <li><a href="#">Economic development</a></li>
           </ul>
         </div>
         <div class="footer-col">
@@ -188,7 +158,7 @@
       </div>
       <div class="footer-bottom">
         <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
-        <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
+        <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. News articles on this page are illustrative.</p>
       </div>
     </div>
   </footer>

--- a/LGR/Veneer/news.html
+++ b/LGR/Veneer/news.html
@@ -3,9 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Household Recycling Centres – Newstershire Council</title>
+  <title>News – Newstershire Council</title>
   <link rel="stylesheet" href="style.css">
-  <link rel="stylesheet" href="council-tax.css">
 </head>
 <body>
 
@@ -47,7 +46,7 @@
       <nav id="header-nav" class="header-nav" aria-label="Site navigation">
         <ul>
           <li><a href="index.html" class="nav-link">Home</a></li>
-          <li><a href="news.html" class="nav-link">News</a></li>
+          <li><a href="news.html" class="nav-link nav-link--active">News</a></li>
           <li><a href="about.html" class="nav-link">About us</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
@@ -59,62 +58,51 @@
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
-        <li><a href="#">Residents</a></li>
-        <li><a href="waste.html">Bins and recycling</a></li>
-        <li aria-current="page">Recycling centres</li>
+        <li aria-current="page">News</li>
       </ol>
     </div>
   </nav>
 
-  <section class="ct-hero" aria-label="Household Recycling Centres">
+  <section class="page-hero" aria-label="News">
     <div class="container">
-      <h1 class="ct-hero__title">Household Recycling Centres</h1>
-      <p class="ct-hero__sub">The county's recycling centres (Gloucestershire Recycles) — how to book a visit, what you can bring, and where the sites are.</p>
+      <h1 class="page-hero__title">News</h1>
+      <p class="page-hero__sub">Updates on the move to a single council for Gloucestershire, and on local services.</p>
     </div>
   </section>
 
   <main id="main-content">
-    <div class="container ct-layout">
+    <div class="container page-body">
 
-      <p class="ct-back"><a href="waste.html">&larr; All bins and recycling topics</a></p>
+      <p class="lead">The latest updates on local government reorganisation and services across Gloucestershire.</p>
 
-      <div class="ct-note ct-note--info" style="margin-bottom:1.5rem;">
-        Household Recycling Centres are run once for the whole of Gloucestershire, so the sites, booking system and rules are the same wherever you live — separate from the kerbside bin collections, which differ by area.
+      <div class="news-feed">
+        <article class="news-article-card">
+          <time datetime="2026-06-27">27 June 2026</time>
+          <h2><a href="news-new-council.html">One council for Gloucestershire goes live in 2028</a></h2>
+          <p>What vesting day on 1 April 2028 means for residents — and what stays exactly the same.</p>
+        </article>
+        <article class="news-article-card">
+          <time datetime="2026-06-20">20 June 2026</time>
+          <h2><a href="news-have-your-say.html">Have your say on services for the new council</a></h2>
+          <p>Residents across the county are invited to help shape how the new council works.</p>
+        </article>
+        <article class="news-article-card">
+          <time datetime="2026-06-12">12 June 2026</time>
+          <h2><a href="news-bins.html">Bins and recycling: what's changing</a></h2>
+          <p>Why your collections carry on as normal through the transition to one council.</p>
+        </article>
+        <article class="news-article-card">
+          <time datetime="2026-06-05">5 June 2026</time>
+          <h2><a href="news-council-tax.html">Council tax: one bill, clearer support</a></h2>
+          <p>How council tax and support for residents are affected by the change.</p>
+        </article>
+        <article class="news-article-card">
+          <time datetime="2026-05-28">28 May 2026</time>
+          <h2><a href="news-shadow-elections.html">Shadow elections planned for May 2027</a></h2>
+          <p>Residents will elect the councillors who form the new authority.</p>
+        </article>
       </div>
 
-      <div class="ct-block ct-block--common">
-        <p>Newstershire Council is the Waste Disposal Authority for the county — a different role to kerbside bin collection, which is covered on the <a href="waste.html">bins and recycling</a> pages. It runs the county's Household Recycling Centres, branded Gloucestershire Recycles.</p>
-
-        <h3>Book before you go</h3>
-        <p>Every visit — car or van — needs a booking made in advance online. This isn't a suggestion; you can be turned away without one. It keeps queues and congestion down and makes the sites safer. With over 10,000 bookings a week across the five sites, there isn't capacity to take bookings by phone as standard. If you genuinely can't book online, and nobody can book on your behalf, there's a phone line: 01452 596 626, weekdays 9am–5pm.</p>
-        <p>Bookings run in fixed 30-minute slots — arrive within yours or you may be turned away and asked to rebook. You'll need to give your name, email, postcode, vehicle make and model, registration, and what waste you're bringing. Bring your booking reference — printed or on your phone — to get in. Need to change your vehicle or slot? There are separate amendment forms for cars and for vans, pick-ups and large trailers.</p>
-
-        <h3>What counts as a car visit</h3>
-        <p>Passenger cars, optionally with a small trailer (under 6ft × 4ft internally). Anything bigger — a van, pick-up, or larger trailer — needs a separate van/large-vehicle booking. HRCs are for household waste only; bringing commercial or trade waste is a criminal offence, and vehicle types are checked against council policy.</p>
-
-        <h3>What you can't bring</h3>
-        <p>Fly-tipped waste isn't accepted — the sites aren't licensed for it. Waste fly-tipped on private land needs a private licensed disposal route instead. Bring only what genuinely can't go through kerbside collection or another route.</p>
-
-        <h3>Sites</h3>
-        <p>Five council-run sites across the county, plus one separate site at Swindon Road in Cheltenham, run independently by Cheltenham Borough Council and currently closed pending review. Known sites: <strong>Hempsted</strong> (Gloucester) — due to close during 2026 for essential repairs and improvements, exact dates to be confirmed — <strong>Pyke Quarry</strong> (near Horsley, Stroud), and <strong>Wingmoor Farm</strong> (Bishop's Cleeve).</p>
-        <p>Each site closes one weekday a week, staggered across the county so there's always a reasonable alternative open — deliberately keeping sites open on Bank Holiday Mondays and Good Friday, historically the busiest days. All sites close on Christmas Day, Boxing Day and New Year's Day. If you need help lifting your waste, ask the staff member at the entrance.</p>
-
-        <div class="ct-note ct-note--info">
-          A zero-tolerance policy applies to violence, aggression, threats or harassment toward staff or other visitors — anyone responsible loses access to the service. General enquiries: waste@gloucestershire.gov.uk.
-        </div>
-
-      </div>
-
-      <nav class="ct-related" aria-label="Other bins and recycling topics">
-        <h2>Other bins and recycling topics</h2>
-        <ul>
-          <li><a href="waste-general-waste.html">General waste</a></li>
-          <li><a href="waste-recycling.html">Recycling</a></li>
-          <li><a href="waste-food-waste.html">Food waste</a></li>
-          <li><a href="waste-garden-waste.html">Garden waste</a></li>
-          <li><a href="waste-bulky.html">Bulky waste</a></li>
-        </ul>
-      </nav>
 
     </div>
   </main>
@@ -149,30 +137,29 @@
           <h3 class="footer-col__title">About Newstershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
-            <li><a href="#">Councillors and committees</a></li>
-            <li><a href="#">Council meetings</a></li>
-            <li><a href="#">Budget and spending</a></li>
-            <li><a href="#">LGR transition</a></li>
+            <li><a href="about.html#cabinet-heading">Councillors and committees</a></li>
+            <li><a href="about.html#how-heading">Council meetings</a></li>
+            <li><a href="about.html#budget-heading">Budget and spending</a></li>
+            <li><a href="news.html">News</a></li>
           </ul>
         </div>
         <div class="footer-col">
           <h3 class="footer-col__title">Residents</h3>
           <ul>
-            <li><a href="council-tax.html">Council tax</a></li>
-            <li><a href="waste.html">Bins and recycling</a></li>
-            <li><a href="planning.html">Planning</a></li>
-            <li><a href="housing.html">Housing</a></li>
-            <li><a href="benefits.html">Benefits and support</a></li>
-            <li><a href="county-highways.html">Roads and transport</a></li>
+            <li><a href="index.html">Council tax</a></li>
+            <li><a href="index.html">Bins and recycling</a></li>
+            <li><a href="index.html">Planning</a></li>
+            <li><a href="index.html">Housing</a></li>
+            <li><a href="index.html">Benefits and support</a></li>
           </ul>
         </div>
         <div class="footer-col">
-          <h3 class="footer-col__title">County services</h3>
+          <h3 class="footer-col__title">Business</h3>
           <ul>
-            <li><a href="county-adult-social-care.html">Adult social care</a></li>
-            <li><a href="county-childrens-services.html">Children &amp; families</a></li>
-            <li><a href="county-libraries.html">Libraries</a></li>
-            <li><a href="waste-recycling-centres.html">Recycling centres</a></li>
+            <li><a href="#">Business rates</a></li>
+            <li><a href="#">Licences and permits</a></li>
+            <li><a href="#">Trading standards</a></li>
+            <li><a href="#">Economic development</a></li>
           </ul>
         </div>
         <div class="footer-col">
@@ -188,7 +175,7 @@
       </div>
       <div class="footer-bottom">
         <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
-        <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
+        <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. News articles on this page are illustrative.</p>
       </div>
     </div>
   </footer>

--- a/LGR/Veneer/style.css
+++ b/LGR/Veneer/style.css
@@ -786,3 +786,21 @@ details[open] summary::before { transform: rotate(90deg); }
 /* About/Contact: keep intro paragraph line-length readable */
 .page-body > p { max-width: 760px; }
 .page-body > .lead { margin-bottom: 1rem; }
+
+/* =====================================================
+   News listing and articles
+   ===================================================== */
+.news-feed { display: grid; gap: 1rem; margin-top: 1rem; max-width: 760px; }
+.news-article-card { background: var(--white); border: 1px solid var(--border); border-left: 4px solid var(--gold); border-radius: var(--radius); padding: 1.1rem 1.25rem; }
+.news-article-card time { display: block; font-size: 0.8125rem; color: var(--text-muted); margin-bottom: 0.25rem; }
+.news-article-card h2 { font-size: 1.125rem; margin-bottom: 0.35rem; }
+.news-article-card h2 a { color: var(--blue-dark); text-decoration: none; }
+.news-article-card h2 a:hover { text-decoration: underline; }
+.news-article-card p { font-size: 0.9375rem; color: var(--text-muted); }
+
+.article-meta { color: var(--text-muted); font-size: 0.9375rem; margin-bottom: 1.25rem; }
+.article-body { max-width: 760px; }
+.article-body p { margin-bottom: 1rem; }
+.article-body h2 { font-size: 1.25rem; color: var(--blue-dark); margin: 1.75rem 0 0.6rem; }
+.article-body ul { max-width: 760px; padding-left: 1.25rem; margin-bottom: 1rem; }
+.article-body li { margin-bottom: 0.4rem; }


### PR DESCRIPTION
## Summary

New News section for both the Consolidated and Veneer sites.

- **`news.html`** — a listing page with a card feed (date, headline, one-line summary).
- **Five short, illustrative articles** — deliberately generic, no names or over-specific detail: one council goes live in 2028 (vesting day), have your say, bins & recycling, council tax, and shadow elections (May 2027).
- Article and listing components added to both stylesheets.
- All six news pages cloned to the Veneer site, with footer service links repointed to the home-page finder.
- Wired the "News" nav link to `news.html` across every page on both sites, and refreshed the home-page "Latest news" sidebars to link the real articles (dropping the stale "1 April 2027" headline).

Formatting verified in-browser; no mobile overflow at 375px.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJ29uNGieSuureHRDAyPKy)_