### PR TITLE
Make About/Contact/News breadcrumbs consistent across both sites

### DIFF
--- a/LGR/Consolidated/about.html
+++ b/LGR/Consolidated/about.html
@@ -59,7 +59,6 @@
     <div class="container">
       <ol>
         <li><a href="index.html">Home</a></li>
-        <li><a href="#">About us</a></li>
         <li aria-current="page">About the council</li>
       </ol>
     </div>

--- a/LGR/Veneer/about.html
+++ b/LGR/Veneer/about.html
@@ -54,6 +54,14 @@
     </div>
   </header>
 
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <div class="container">
+      <ol>
+        <li><a href="index.html">Home</a></li>
+        <li aria-current="page">About the council</li>
+      </ol>
+    </div>
+  </nav>
 
   <section class="page-hero" aria-label="About the council">
     <div class="container">

--- a/LGR/Veneer/contact.html
+++ b/LGR/Veneer/contact.html
@@ -54,6 +54,14 @@
     </div>
   </header>
 
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <div class="container">
+      <ol>
+        <li><a href="index.html">Home</a></li>
+        <li aria-current="page">Contact us</li>
+      </ol>
+    </div>
+  </nav>
 
   <section class="page-hero" aria-label="Contact us">
     <div class="container">

--- a/LGR/Veneer/style.css
+++ b/LGR/Veneer/style.css
@@ -804,3 +804,16 @@ details[open] summary::before { transform: rotate(90deg); }
 .article-body h2 { font-size: 1.25rem; color: var(--blue-dark); margin: 1.75rem 0 0.6rem; }
 .article-body ul { max-width: 760px; padding-left: 1.25rem; margin-bottom: 1rem; }
 .article-body li { margin-bottom: 0.4rem; }
+
+/* ---- Breadcrumb (interior pages) ---- */
+.breadcrumb {
+  background: var(--white);
+  border-bottom: 1px solid var(--border);
+  padding: 0.5rem 0;
+  font-size: 0.8125rem;
+}
+.breadcrumb ol { list-style: none; display: flex; flex-wrap: wrap; gap: 0.25rem; align-items: center; }
+.breadcrumb li + li::before { content: "›"; margin-right: 0.25rem; color: var(--text-muted); }
+.breadcrumb a { color: var(--blue-mid); text-decoration: none; }
+.breadcrumb a:hover { text-decoration: underline; }
+.breadcrumb [aria-current] { color: var(--text-muted); }


### PR DESCRIPTION
## Summary

- Consolidated About page dropped its extra "About us" crumb, so the top-level section pages are now all two-level: `Home > About the council`, `Home > Contact us`, `Home > News` (news articles remain `Home > News > [title]`).
- Veneer had no `.breadcrumb` styles, so the cloned news pages rendered as a raw numbered list. Added the breadcrumb CSS to Veneer and gave its About and Contact pages matching breadcrumbs.

Both sites now render identical, consistent trails; service pages keep their `Home > Residents > …` scheme.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJ29uNGieSuureHRDAyPKy)_