### PR TITLE
Order home services by popularity and de-duplicate sidebar

### DIFF
--- a/LGR/Consolidated/index.html
+++ b/LGR/Consolidated/index.html
@@ -89,9 +89,19 @@
         <p class="page-intro">These services are now handled right here on the new council website — no redirect needed.</p>
         <ul class="service-index" aria-label="Services available here">
           <li class="service-index__item">
-            <svg class="service-index__icon" aria-hidden="true" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z"/></svg>
-            <a href="county-adult-social-care.html" class="service-index__link">Adult social care</a>
-            <p class="service-index__desc">Assessments, paying for care, safeguarding and support for carers</p>
+            <svg class="service-index__icon" aria-hidden="true" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><rect x="2" y="5" width="20" height="14" rx="2"/><line x1="2" y1="10" x2="22" y2="10"/></svg>
+            <a href="council-tax.html" class="service-index__link">Council tax</a>
+            <p class="service-index__desc">Exemptions, discounts, empty homes, second homes and reductions</p>
+          </li>
+          <li class="service-index__item">
+            <svg class="service-index__icon" aria-hidden="true" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v6M14 11v6"/><path d="M9 6V4h6v2"/></svg>
+            <a href="waste.html" class="service-index__link">Bins &amp; recycling</a>
+            <p class="service-index__desc">Collection days, what goes in which bin and recycling centres</p>
+          </li>
+          <li class="service-index__item">
+            <svg class="service-index__icon" aria-hidden="true" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <a href="planning.html" class="service-index__link">Planning</a>
+            <p class="service-index__desc">Applying for permission, fees, decisions, appeals and the Local Plan</p>
           </li>
           <li class="service-index__item">
             <svg class="service-index__icon" aria-hidden="true" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><rect x="2" y="5" width="20" height="14" rx="2"/><circle cx="12" cy="12" r="3"/></svg>
@@ -99,9 +109,19 @@
             <p class="service-index__desc">Universal Credit, Housing Benefit, crisis payments and cost-of-living help</p>
           </li>
           <li class="service-index__item">
-            <svg class="service-index__icon" aria-hidden="true" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v6M14 11v6"/><path d="M9 6V4h6v2"/></svg>
-            <a href="waste.html" class="service-index__link">Bins &amp; recycling</a>
-            <p class="service-index__desc">Collection days, what goes in which bin and recycling centres</p>
+            <svg class="service-index__icon" aria-hidden="true" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/><path d="M9 22V12h6v10"/></svg>
+            <a href="housing.html" class="service-index__link">Housing</a>
+            <p class="service-index__desc">Homelessness help, the housing register, affordable and supported housing</p>
+          </li>
+          <li class="service-index__item">
+            <svg class="service-index__icon" aria-hidden="true" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M4 19l4-14M20 19l-4-14M12 5v3M12 12v3M12 19v1"/></svg>
+            <a href="county-highways.html" class="service-index__link">Highways &amp; roads</a>
+            <p class="service-index__desc">Report a pothole or fault, and how road repairs are prioritised</p>
+          </li>
+          <li class="service-index__item">
+            <svg class="service-index__icon" aria-hidden="true" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z"/></svg>
+            <a href="county-adult-social-care.html" class="service-index__link">Adult social care</a>
+            <p class="service-index__desc">Assessments, paying for care, safeguarding and support for carers</p>
           </li>
           <li class="service-index__item">
             <svg class="service-index__icon" aria-hidden="true" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="9" r="6"/><path d="M9.5 9l1.8 1.8L15 7"/><path d="M8 14.5V22l4-2 4 2v-7.5"/></svg>
@@ -114,29 +134,9 @@
             <p class="service-index__desc">Safeguarding, reporting a concern and support for children and young people</p>
           </li>
           <li class="service-index__item">
-            <svg class="service-index__icon" aria-hidden="true" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><rect x="2" y="5" width="20" height="14" rx="2"/><line x1="2" y1="10" x2="22" y2="10"/></svg>
-            <a href="council-tax.html" class="service-index__link">Council tax</a>
-            <p class="service-index__desc">Exemptions, discounts, empty homes, second homes and reductions</p>
-          </li>
-          <li class="service-index__item">
-            <svg class="service-index__icon" aria-hidden="true" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M4 19l4-14M20 19l-4-14M12 5v3M12 12v3M12 19v1"/></svg>
-            <a href="county-highways.html" class="service-index__link">Highways &amp; roads</a>
-            <p class="service-index__desc">Report a pothole or fault, and how road repairs are prioritised</p>
-          </li>
-          <li class="service-index__item">
-            <svg class="service-index__icon" aria-hidden="true" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/><path d="M9 22V12h6v10"/></svg>
-            <a href="housing.html" class="service-index__link">Housing</a>
-            <p class="service-index__desc">Homelessness help, the housing register, affordable and supported housing</p>
-          </li>
-          <li class="service-index__item">
             <svg class="service-index__icon" aria-hidden="true" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M4 19.5A2.5 2.5 0 016.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 014 19.5v-15A2.5 2.5 0 016.5 2z"/></svg>
             <a href="county-libraries.html" class="service-index__link">Libraries</a>
             <p class="service-index__desc">Borrowing, events, digital services and the Home Library Service</p>
-          </li>
-          <li class="service-index__item">
-            <svg class="service-index__icon" aria-hidden="true" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
-            <a href="planning.html" class="service-index__link">Planning</a>
-            <p class="service-index__desc">Applying for permission, fees, decisions, appeals and the Local Plan</p>
           </li>
           <li class="service-index__item">
             <svg class="service-index__icon" aria-hidden="true" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><circle cx="12" cy="13" r="2"/><path d="M9 18a3 3 0 016 0"/></svg>
@@ -287,15 +287,15 @@
 
         <!-- Quick links -->
         <div class="sidebar-card">
-          <h2 class="sidebar-card__title">Popular services</h2>
+          <h2 class="sidebar-card__title">Popular tasks</h2>
           <ul class="quick-links">
-            <li><a href="council-tax.html" class="quick-link">
-              <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 11 12 14 22 4"/><path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11"/></svg>
-              Council tax information
-            </a></li>
             <li><a href="waste.html" class="quick-link">
               <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 9 12 2 21 9"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
               Report a missed bin
+            </a></li>
+            <li><a href="council-tax.html" class="quick-link">
+              <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 11 12 14 22 4"/><path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11"/></svg>
+              Apply for a council tax discount
             </a></li>
             <li><a href="planning-how-to-apply.html" class="quick-link">
               <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
@@ -305,13 +305,13 @@
               <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
               Book a bulky waste collection
             </a></li>
-            <li><a href="benefits-universal-credit.html" class="quick-link">
+            <li><a href="benefits-housing-payments.html" class="quick-link">
               <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/></svg>
-              Housing benefit claim
+              Claim Housing Benefit
             </a></li>
             <li><a href="waste-recycling-centres.html" class="quick-link">
               <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
-              Find my nearest recycling centre
+              Find your nearest recycling centre
             </a></li>
           </ul>
         </div>


### PR DESCRIPTION
Two follow-ups to the Consolidated home page review.

- **Ordering.** The services index now leads with the highest-traffic services (Council tax, Bins & recycling, Planning, Benefits & support, Housing, Highways & roads), then the remaining county services alphabetically.
- **Sidebar de-duplication.** "Popular services" is now "Popular tasks" — purely task-framed shortcuts, so it no longer echoes the service index. "Council tax information" becomes "Apply for a council tax discount", and the Housing Benefit shortcut now correctly points to the Housing payments page (was pointing at the Universal Credit page).

Consolidated-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJ29uNGieSuureHRDAyPKy)_