### PR TITLE
Add hero search and popular-tasks row to consolidated home

### DIFF
--- a/LGR/Consolidated/index.html
+++ b/LGR/Consolidated/index.html
@@ -60,6 +60,16 @@
       <div class="hero__text">
         <h1 class="hero__title">Welcome to Newstershire Council</h1>
         <p class="hero__sub"><strong>Newstershire Council is a new unitary authority.</strong> We've replaced Gloucestershire County Council and the six district and borough councils with one council for the whole county. While we bring everything together, some services still live on the former councils' websites.</p>
+        <form class="hero-search" role="search" action="#" onsubmit="return false;">
+          <label for="site-search" class="hero-search__label">Search for a service</label>
+          <div class="hero-search__row">
+            <input type="search" id="site-search" name="q" class="hero-search__input" placeholder="e.g. council tax, bins, planning" autocomplete="off">
+            <button type="submit" class="hero-search__btn">
+              <svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.25"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+              Search
+            </button>
+          </div>
+        </form>
       </div>
       <div class="hero__stats" aria-label="Key figures">
         <div class="stat-card">
@@ -75,6 +85,21 @@
           <span class="stat-label">Council services</span>
         </div>
       </div>
+    </div>
+  </section>
+
+  <!-- Popular tasks shortcut row -->
+  <section class="task-bar" aria-label="Popular tasks">
+    <div class="container task-bar__inner">
+      <h2 class="task-bar__title">Popular tasks</h2>
+      <ul class="task-bar__list">
+        <li><a href="waste.html">Report a missed bin</a></li>
+        <li><a href="council-tax.html">Apply for a council tax discount</a></li>
+        <li><a href="planning-how-to-apply.html">Apply for planning permission</a></li>
+        <li><a href="waste-bulky.html">Book a bulky waste collection</a></li>
+        <li><a href="benefits-housing-payments.html">Claim Housing Benefit</a></li>
+        <li><a href="waste-recycling-centres.html">Find your nearest recycling centre</a></li>
+      </ul>
     </div>
   </section>
 
@@ -284,37 +309,6 @@
 
       <!-- Right: sidebar -->
       <aside class="sidebar" aria-label="Quick links and news">
-
-        <!-- Quick links -->
-        <div class="sidebar-card">
-          <h2 class="sidebar-card__title">Popular tasks</h2>
-          <ul class="quick-links">
-            <li><a href="waste.html" class="quick-link">
-              <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 9 12 2 21 9"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
-              Report a missed bin
-            </a></li>
-            <li><a href="council-tax.html" class="quick-link">
-              <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 11 12 14 22 4"/><path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11"/></svg>
-              Apply for a council tax discount
-            </a></li>
-            <li><a href="planning-how-to-apply.html" class="quick-link">
-              <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
-              Apply for planning permission
-            </a></li>
-            <li><a href="waste-bulky.html" class="quick-link">
-              <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
-              Book a bulky waste collection
-            </a></li>
-            <li><a href="benefits-housing-payments.html" class="quick-link">
-              <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/></svg>
-              Claim Housing Benefit
-            </a></li>
-            <li><a href="waste-recycling-centres.html" class="quick-link">
-              <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
-              Find your nearest recycling centre
-            </a></li>
-          </ul>
-        </div>
 
         <!-- News -->
         <div class="sidebar-card">

--- a/LGR/Consolidated/style.css
+++ b/LGR/Consolidated/style.css
@@ -243,6 +243,87 @@ a:hover { color: var(--blue-dark); }
   color: var(--blue-light);
 }
 
+/* ---- Hero search ---- */
+.hero-search { margin-top: 1.5rem; max-width: 560px; }
+.hero-search__label {
+  display: block;
+  font-size: 0.9375rem;
+  font-weight: 700;
+  color: var(--white);
+  margin-bottom: 0.4rem;
+}
+.hero-search__row { display: flex; }
+.hero-search__input {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 0.75rem 0.9rem;
+  font-size: 1rem;
+  color: var(--text);
+  background: var(--white);
+  border: 2px solid var(--white);
+  border-right: 0;
+  border-radius: var(--radius) 0 0 var(--radius);
+}
+.hero-search__input::placeholder { color: var(--text-muted); }
+.hero-search__input:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 0;
+  z-index: 1;
+}
+.hero-search__btn {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.75rem 1.15rem;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--white);
+  background: var(--green);
+  border: 2px solid var(--green);
+  border-radius: 0 var(--radius) var(--radius) 0;
+  cursor: pointer;
+}
+.hero-search__btn:hover { background: #005a30; border-color: #005a30; }
+.hero-search__btn:focus-visible { outline: 3px solid var(--focus); outline-offset: 2px; }
+
+/* ---- Popular tasks shortcut row ---- */
+.task-bar { background: var(--blue-xlight); border-bottom: 1px solid var(--border); }
+.task-bar__inner {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 1rem;
+  padding-top: 0.85rem;
+  padding-bottom: 0.85rem;
+}
+.task-bar__title {
+  font-size: 0.9375rem;
+  font-weight: 700;
+  color: var(--blue-dark);
+  margin: 0;
+  white-space: nowrap;
+}
+.task-bar__list {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.75rem;
+}
+.task-bar__list a {
+  display: inline-block;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--blue-mid);
+  background: var(--white);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  text-decoration: none;
+}
+.task-bar__list a:hover { background: var(--blue-mid); color: var(--white); border-color: var(--blue-mid); }
+.task-bar__list a:focus-visible { outline: 3px solid var(--focus); outline-offset: 2px; }
+
 /* =====================
    Main grid
    ===================== */


### PR DESCRIPTION
Aligns the Consolidated home page with the recent-unitary-council norm (based on a scan of North Yorkshire, Somerset, Cumberland, Westmorland & Furness and Buckinghamshire).

- **Hero search.** Adds a GOV.UK-style search box in the hero — white input with a green (`#00703c`) Search button (AAA contrast). It's a non-functional demo search, matching the proof-of-concept nature of the site. Every real unitary leads with a prominent search; this closes that gap.
- **Popular tasks promoted.** Moves the six task shortcuts out of the right sidebar into a horizontal chip row in a light band directly under the hero — the placement most councils use. The sidebar now carries just News and Contact.

Page flow is now hero + search → popular tasks → services index → area router → news/contact → footer. The area router remains the distinctive LGR entry point.

Consolidated-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJ29uNGieSuureHRDAyPKy)_