### PR TITLE
Recolour hero search button and even out popular-tasks type

### DIFF
--- a/LGR/Consolidated/style.css
+++ b/LGR/Consolidated/style.css
@@ -278,13 +278,13 @@ a:hover { color: var(--blue-dark); }
   padding: 0.75rem 1.15rem;
   font-size: 1rem;
   font-weight: 700;
-  color: var(--white);
-  background: var(--green);
-  border: 2px solid var(--green);
+  color: var(--text);
+  background: var(--gold);
+  border: 2px solid var(--gold);
   border-radius: 0 var(--radius) var(--radius) 0;
   cursor: pointer;
 }
-.hero-search__btn:hover { background: #005a30; border-color: #005a30; }
+.hero-search__btn:hover { background: #b8983f; border-color: #b8983f; }
 .hero-search__btn:focus-visible { outline: 3px solid var(--focus); outline-offset: 2px; }
 
 /* ---- Popular tasks shortcut row ---- */
@@ -298,7 +298,7 @@ a:hover { color: var(--blue-dark); }
   padding-bottom: 0.85rem;
 }
 .task-bar__title {
-  font-size: 0.9375rem;
+  font-size: 1rem;
   font-weight: 700;
   color: var(--blue-dark);
   margin: 0;
@@ -312,8 +312,8 @@ a:hover { color: var(--blue-dark); }
 }
 .task-bar__list a {
   display: inline-block;
-  padding: 0.35rem 0.75rem;
-  font-size: 0.875rem;
+  padding: 0.4rem 0.85rem;
+  font-size: 1rem;
   font-weight: 600;
   color: var(--blue-mid);
   background: var(--white);


### PR DESCRIPTION
Two small home-page polish fixes.

- **Search button** — recoloured from the off-palette green to brand gold with near-black text (AAA contrast ~8.4:1), matching the footer "Sign up" button.
- **Popular tasks** — label and chip links normalised to a consistent 1rem so the sizing reads evenly.

Consolidated-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJ29uNGieSuureHRDAyPKy)_