### PR TITLE
Make popular-tasks label a paragraph, not a heading

### DIFF
--- a/LGR/Consolidated/index.html
+++ b/LGR/Consolidated/index.html
@@ -91,7 +91,7 @@
   <!-- Popular tasks shortcut row -->
   <section class="task-bar" aria-label="Popular tasks">
     <div class="container task-bar__inner">
-      <h2 class="task-bar__title">Popular tasks</h2>
+      <p class="task-bar__title" aria-hidden="true">Popular tasks</p>
       <ul class="task-bar__list">
         <li><a href="waste.html">Report a missed bin</a></li>
         <li><a href="council-tax.html">Apply for a council tax discount</a></li>


### PR DESCRIPTION
The "Popular tasks" shortcut rail is a labelled region, not a content section, so its small uppercase label no longer needs to be an `<h2>`. Swaps it for a `<p class="task-bar__title">`, marked `aria-hidden="true"` since the `<section aria-label="Popular tasks">` already names the region for screen readers. Styling is unchanged (driven by the class). The heading outline now contains only genuine content sections.

Consolidated-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJ29uNGieSuureHRDAyPKy)_