### PR TITLE
Style Popular tasks heading to match Services heading

### DIFF
--- a/LGR/Consolidated/index.html
+++ b/LGR/Consolidated/index.html
@@ -91,7 +91,7 @@
   <!-- Popular tasks shortcut row -->
   <section class="task-bar" aria-label="Popular tasks">
     <div class="container task-bar__inner">
-      <p class="task-bar__title" aria-hidden="true">Popular tasks</p>
+      <h2 class="section-title">Popular tasks</h2>
       <ul class="task-bar__list">
         <li><a href="waste.html">Report a missed bin</a></li>
         <li><a href="council-tax.html">Apply for a council tax discount</a></li>

--- a/LGR/Consolidated/style.css
+++ b/LGR/Consolidated/style.css
@@ -290,16 +290,8 @@ a:hover { color: var(--blue-dark); }
 /* ---- Popular tasks shortcut row ---- */
 .task-bar { background: var(--blue-xlight); border-bottom: 1px solid var(--border); }
 .task-bar__inner {
-  padding-top: 1rem;
-  padding-bottom: 1.1rem;
-}
-.task-bar__title {
-  font-size: 0.8125rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--text-muted);
-  margin: 0 0 0.6rem;
+  padding-top: 1.75rem;
+  padding-bottom: 1.25rem;
 }
 .task-bar__list {
   list-style: none;


### PR DESCRIPTION
Makes the "Popular tasks" heading identical to "Services available here" — the large blue `.section-title` `<h2>` instead of the small uppercase label — and adds a small space between the bottom of the hero panel and the heading.

Consolidated-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJ29uNGieSuureHRDAyPKy)_