### PR TITLE
Reframe LGR home pages for a live unitary council; move the fiction post-vesting

### DIFF
--- a/LGR/Consolidated/about.html
+++ b/LGR/Consolidated/about.html
@@ -74,7 +74,7 @@
   <main id="main-content">
     <div class="container page-body">
 
-      <p class="lead">Newstershire Council is the new unitary authority for Gloucestershire. From 1 April 2028 — vesting day — it brings together Gloucestershire County Council and the six district and borough councils into a single council responsible for every local government service across the county, from adult social care and roads to bins, planning and council tax.</p>
+      <p class="lead">Newstershire Council is the new unitary authority for Gloucestershire. On 1 April 2028 — vesting day — it brought together Gloucestershire County Council and the six district and borough councils into a single council responsible for every local government service across the county, from adult social care and roads to bins, planning and council tax.</p>
       <p>One council means one place to find services, one phone number to call, and one organisation accountable for getting things right — while keeping decisions as close as possible to the communities they affect.</p>
 
       <section class="section-block" aria-labelledby="why-heading">
@@ -121,7 +121,7 @@
 
       <section class="section-block" aria-labelledby="cabinet-heading">
         <h2 id="cabinet-heading">Our leadership</h2>
-        <p>The council is led by a Leader and Cabinet, each member holding a portfolio for a group of services, supported by senior officers. Councillors will be elected at the shadow elections in May 2027, so the people in these roles are still to be confirmed.</p>
+        <p>The council is led by a Leader and Cabinet, each member holding a portfolio for a group of services, supported by senior officers. Councillors were elected at the shadow elections in May 2027; the names below are placeholders for this proof of concept.</p>
         <div class="people-grid">
           <div class="person-card"><div class="person-avatar" aria-hidden="true"><svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="8" r="4"/><path d="M4 21v-1a6 6 0 016-6h4a6 6 0 016 6v1"/></svg></div><h3>[Name to be confirmed]</h3><p class="person-role">Leader of the Council</p></div>
           <div class="person-card"><div class="person-avatar" aria-hidden="true"><svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="8" r="4"/><path d="M4 21v-1a6 6 0 016-6h4a6 6 0 016 6v1"/></svg></div><h3>[Name to be confirmed]</h3><p class="person-role">Deputy Leader &amp; Finance</p></div>
@@ -149,10 +149,10 @@
       <section class="section-block" aria-labelledby="timeline-heading">
         <h2 id="timeline-heading">The road to one council</h2>
         <ol class="timeline">
-          <li class="is-done"><span class="t-date">2024–2025</span><p class="t-body">Government invites Gloucestershire's councils to propose a single unitary authority, and the proposal is agreed.</p></li>
-          <li class="is-done"><span class="t-date">2026</span><p class="t-body">Transition planning begins, and residents are invited to have their say on services, priorities and the new council's name.</p></li>
-          <li><span class="t-date">May 2027</span><p class="t-body">Shadow elections — residents elect the councillors who will form the new authority and oversee the final year of transition.</p></li>
-          <li><span class="t-date">1 April 2028</span><p class="t-body">Vesting day — Newstershire Council formally goes live. Gloucestershire County Council and the six district and borough councils are abolished.</p></li>
+          <li class="is-done"><span class="t-date">2024–2025</span><p class="t-body">Government invited Gloucestershire's councils to propose a single unitary authority, and the proposal was agreed.</p></li>
+          <li class="is-done"><span class="t-date">2026</span><p class="t-body">Transition planning began, and residents had their say on services, priorities and the new council's name.</p></li>
+          <li class="is-done"><span class="t-date">May 2027</span><p class="t-body">Shadow elections — residents elected the councillors who formed the new authority and oversaw the final year of transition.</p></li>
+          <li class="is-done"><span class="t-date">1 April 2028</span><p class="t-body">Vesting day — Newstershire Council formally went live. Gloucestershire County Council and the six district and borough councils were abolished.</p></li>
           <li><span class="t-date">2028 onwards</span><p class="t-body">Services are progressively brought onto one website, one phone line and one set of systems.</p></li>
         </ol>
       </section>
@@ -241,7 +241,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. Councillor names, figures and dates on this page are illustrative.</p>
       </div>
     </div>

--- a/LGR/Consolidated/benefits-cost-of-living.html
+++ b/LGR/Consolidated/benefits-cost-of-living.html
@@ -86,7 +86,7 @@
             Select your area
           </label>
           <select id="ct-area-select" class="ct-picker__select">
-            <option value="">Choose your district or borough</option>
+            <option value="">Choose your area</option>
             <option value="cheltenham">Cheltenham</option>
             <option value="cotswold">Cotswold</option>
             <option value="forest-of-dean">Forest of Dean</option>
@@ -244,7 +244,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/benefits-housing-payments.html
+++ b/LGR/Consolidated/benefits-housing-payments.html
@@ -86,7 +86,7 @@
             Select your area
           </label>
           <select id="ct-area-select" class="ct-picker__select">
-            <option value="">Choose your district or borough</option>
+            <option value="">Choose your area</option>
             <option value="cheltenham">Cheltenham</option>
             <option value="cotswold">Cotswold</option>
             <option value="forest-of-dean">Forest of Dean</option>
@@ -237,7 +237,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/benefits-universal-credit.html
+++ b/LGR/Consolidated/benefits-universal-credit.html
@@ -86,7 +86,7 @@
             Select your area
           </label>
           <select id="ct-area-select" class="ct-picker__select">
-            <option value="">Choose your district or borough</option>
+            <option value="">Choose your area</option>
             <option value="cheltenham">Cheltenham</option>
             <option value="cotswold">Cotswold</option>
             <option value="forest-of-dean">Forest of Dean</option>
@@ -238,7 +238,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/benefits.html
+++ b/LGR/Consolidated/benefits.html
@@ -87,7 +87,7 @@
             Select your area
           </label>
           <select id="ct-area-select" class="ct-picker__select">
-            <option value="">Choose your district or borough</option>
+            <option value="">Choose your area</option>
             <option value="cheltenham">Cheltenham</option>
             <option value="cotswold">Cotswold</option>
             <option value="forest-of-dean">Forest of Dean</option>
@@ -226,7 +226,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/contact.html
+++ b/LGR/Consolidated/contact.html
@@ -302,7 +302,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. Contact details on this page are illustrative.</p>
       </div>
     </div>

--- a/LGR/Consolidated/council-tax.html
+++ b/LGR/Consolidated/council-tax.html
@@ -87,7 +87,7 @@
             Select your area
           </label>
           <select id="ct-area-select" class="ct-picker__select">
-            <option value="">Choose your district or borough</option>
+            <option value="">Choose your area</option>
             <option value="cheltenham">Cheltenham</option>
             <option value="cotswold">Cotswold</option>
             <option value="forest-of-dean">Forest of Dean</option>
@@ -562,7 +562,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/county-adult-social-care.html
+++ b/LGR/Consolidated/county-adult-social-care.html
@@ -211,7 +211,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/county-blue-badges.html
+++ b/LGR/Consolidated/county-blue-badges.html
@@ -186,7 +186,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/county-childrens-services.html
+++ b/LGR/Consolidated/county-childrens-services.html
@@ -200,7 +200,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/county-highways.html
+++ b/LGR/Consolidated/county-highways.html
@@ -194,7 +194,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/county-libraries.html
+++ b/LGR/Consolidated/county-libraries.html
@@ -196,7 +196,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/county-registrars.html
+++ b/LGR/Consolidated/county-registrars.html
@@ -195,7 +195,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/county-school-admissions.html
+++ b/LGR/Consolidated/county-school-admissions.html
@@ -198,7 +198,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/housing-affordable.html
+++ b/LGR/Consolidated/housing-affordable.html
@@ -86,7 +86,7 @@
             Select your area
           </label>
           <select id="ct-area-select" class="ct-picker__select">
-            <option value="">Choose your district or borough</option>
+            <option value="">Choose your area</option>
             <option value="cheltenham">Cheltenham</option>
             <option value="cotswold">Cotswold</option>
             <option value="forest-of-dean">Forest of Dean</option>
@@ -235,7 +235,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/housing-homelessness.html
+++ b/LGR/Consolidated/housing-homelessness.html
@@ -86,7 +86,7 @@
             Select your area
           </label>
           <select id="ct-area-select" class="ct-picker__select">
-            <option value="">Choose your district or borough</option>
+            <option value="">Choose your area</option>
             <option value="cheltenham">Cheltenham</option>
             <option value="cotswold">Cotswold</option>
             <option value="forest-of-dean">Forest of Dean</option>
@@ -265,7 +265,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/housing-register.html
+++ b/LGR/Consolidated/housing-register.html
@@ -86,7 +86,7 @@
             Select your area
           </label>
           <select id="ct-area-select" class="ct-picker__select">
-            <option value="">Choose your district or borough</option>
+            <option value="">Choose your area</option>
             <option value="cheltenham">Cheltenham</option>
             <option value="cotswold">Cotswold</option>
             <option value="forest-of-dean">Forest of Dean</option>
@@ -251,7 +251,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/housing-supported.html
+++ b/LGR/Consolidated/housing-supported.html
@@ -86,7 +86,7 @@
             Select your area
           </label>
           <select id="ct-area-select" class="ct-picker__select">
-            <option value="">Choose your district or borough</option>
+            <option value="">Choose your area</option>
             <option value="cheltenham">Cheltenham</option>
             <option value="cotswold">Cotswold</option>
             <option value="forest-of-dean">Forest of Dean</option>
@@ -232,7 +232,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/housing.html
+++ b/LGR/Consolidated/housing.html
@@ -87,7 +87,7 @@
             Select your area
           </label>
           <select id="ct-area-select" class="ct-picker__select">
-            <option value="">Choose your district or borough</option>
+            <option value="">Choose your area</option>
             <option value="cheltenham">Cheltenham</option>
             <option value="cotswold">Cotswold</option>
             <option value="forest-of-dean">Forest of Dean</option>
@@ -232,7 +232,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/index.html
+++ b/LGR/Consolidated/index.html
@@ -180,7 +180,7 @@
         </ul>
 
         <h2 class="section-title section-title--router">Looking for another service?</h2>
-        <p class="page-intro">Some services are still moving across from the former councils. Answer two quick questions and we'll point you to the right existing council website.</p>
+        <p class="page-intro">Some services are still moving across from the former councils. Answer two quick questions and we'll point you to the right former council website.</p>
 
         <!-- === STEP 1: area === -->
         <section id="step-area" class="step" aria-labelledby="step-area-heading">
@@ -189,7 +189,7 @@
             Which area do you live in?
           </h3>
           <fieldset>
-            <legend class="sr-only">Select your district or borough</legend>
+            <legend class="sr-only">Select your area</legend>
             <div class="radio-group">
               <label class="radio-card">
                 <input type="radio" name="area" value="cheltenham">
@@ -223,14 +223,14 @@
         <section id="step-tier" class="step step--hidden" aria-labelledby="step-tier-heading" aria-hidden="true">
           <h3 id="step-tier-heading" class="step-heading">
             <span class="step-number" aria-hidden="true">2</span>
-            Is it a county or district service?
+            Who provided it before councils merged?
           </h3>
 
           <div class="help-text">
             <details>
               <summary>Not sure which one?</summary>
               <div class="details-body">
-                <p><strong>County-level services</strong> (previously Gloucestershire County Council) include:</p>
+                <p><strong>Gloucestershire County Council</strong> used to run:</p>
                 <ul>
                   <li>Schools, education and libraries</li>
                   <li>Adult social care</li>
@@ -239,7 +239,7 @@
                   <li>Waste disposal (tips / recycling centres)</li>
                   <li>Fire &amp; rescue</li>
                 </ul>
-                <p><strong>District-level services</strong> (previously your district or borough council) include:</p>
+                <p><strong>Your district or borough council</strong> used to run:</p>
                 <ul>
                   <li>Bins and waste collection</li>
                   <li>Council tax and housing benefit</li>
@@ -253,18 +253,18 @@
           </div>
 
           <fieldset>
-            <legend class="sr-only">Select service type</legend>
+            <legend class="sr-only">Select who used to provide the service</legend>
             <div class="radio-group radio-group--two">
               <label class="radio-card radio-card--large">
                 <input type="radio" name="tier" value="county">
                 <span class="radio-card__icon" aria-hidden="true">🏛️</span>
-                <span class="radio-label">County service</span>
+                <span class="radio-label">Gloucestershire County Council</span>
                 <span class="radio-hint">Education, roads, social care&hellip;</span>
               </label>
               <label class="radio-card radio-card--large">
                 <input type="radio" name="tier" value="district">
                 <span class="radio-card__icon" aria-hidden="true">🏘️</span>
-                <span class="radio-label">District / borough service</span>
+                <span class="radio-label">My district or borough council</span>
                 <span class="radio-hint">Bins, planning, council tax&hellip;</span>
               </label>
             </div>
@@ -287,33 +287,33 @@
             <p>JavaScript is not available in your browser. Use the direct links below.</p>
             <h4>Cheltenham</h4>
             <ul>
-              <li><a href="https://www.gloucestershire.gov.uk/">County services (Gloucestershire County Council)</a></li>
-              <li><a href="https://www.cheltenham.gov.uk/">District services (Cheltenham Borough Council)</a></li>
+              <li><a href="https://www.gloucestershire.gov.uk/">Former county services (Gloucestershire County Council)</a></li>
+              <li><a href="https://www.cheltenham.gov.uk/">Former district services (Cheltenham Borough Council)</a></li>
             </ul>
             <h4>Cotswold</h4>
             <ul>
-              <li><a href="https://www.gloucestershire.gov.uk/">County services</a></li>
-              <li><a href="https://www.cotswold.gov.uk/">District services (Cotswold District Council)</a></li>
+              <li><a href="https://www.gloucestershire.gov.uk/">Former county services</a></li>
+              <li><a href="https://www.cotswold.gov.uk/">Former district services (Cotswold District Council)</a></li>
             </ul>
             <h4>Forest of Dean</h4>
             <ul>
-              <li><a href="https://www.gloucestershire.gov.uk/">County services</a></li>
-              <li><a href="https://www.fdean.gov.uk/">District services (Forest of Dean District Council)</a></li>
+              <li><a href="https://www.gloucestershire.gov.uk/">Former county services</a></li>
+              <li><a href="https://www.fdean.gov.uk/">Former district services (Forest of Dean District Council)</a></li>
             </ul>
             <h4>Gloucester</h4>
             <ul>
-              <li><a href="https://www.gloucestershire.gov.uk/">County services</a></li>
-              <li><a href="https://www.gloucester.gov.uk/">District services (Gloucester City Council)</a></li>
+              <li><a href="https://www.gloucestershire.gov.uk/">Former county services</a></li>
+              <li><a href="https://www.gloucester.gov.uk/">Former district services (Gloucester City Council)</a></li>
             </ul>
             <h4>Stroud</h4>
             <ul>
-              <li><a href="https://www.gloucestershire.gov.uk/">County services</a></li>
-              <li><a href="https://www.stroud.gov.uk/">District services (Stroud District Council)</a></li>
+              <li><a href="https://www.gloucestershire.gov.uk/">Former county services</a></li>
+              <li><a href="https://www.stroud.gov.uk/">Former district services (Stroud District Council)</a></li>
             </ul>
             <h4>Tewkesbury</h4>
             <ul>
-              <li><a href="https://www.gloucestershire.gov.uk/">County services</a></li>
-              <li><a href="https://www.tewkesbury.gov.uk/">District services (Tewkesbury Borough Council)</a></li>
+              <li><a href="https://www.gloucestershire.gov.uk/">Former county services</a></li>
+              <li><a href="https://www.tewkesbury.gov.uk/">Former district services (Tewkesbury Borough Council)</a></li>
             </ul>
           </section>
         </noscript>
@@ -328,20 +328,20 @@
           <h2 class="sidebar-card__title">Latest news</h2>
           <ul class="news-list">
             <li class="news-item">
-              <span class="news-date">27 Jun 2026</span>
-              <a href="news-new-council.html" class="news-title">One council for Gloucestershire goes live in 2028</a>
-            </li>
-            <li class="news-item">
-              <span class="news-date">20 Jun 2026</span>
+              <span class="news-date">20 Jun 2028</span>
               <a href="news-have-your-say.html" class="news-title">Have your say on services for the new council</a>
             </li>
             <li class="news-item">
-              <span class="news-date">12 Jun 2026</span>
+              <span class="news-date">12 Jun 2028</span>
               <a href="news-bins.html" class="news-title">Bins and recycling: what's changing</a>
             </li>
             <li class="news-item">
-              <span class="news-date">28 May 2026</span>
-              <a href="news-shadow-elections.html" class="news-title">Shadow elections planned for May 2027</a>
+              <span class="news-date">14 Apr 2028</span>
+              <a href="news-council-tax.html" class="news-title">Council tax: one bill, clearer support</a>
+            </li>
+            <li class="news-item">
+              <span class="news-date">1 Apr 2028</span>
+              <a href="news-new-council.html" class="news-title">One council for Gloucestershire is now live</a>
             </li>
           </ul>
           <a href="news.html" class="view-all-link">View all news →</a>
@@ -449,7 +449,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/news-bins.html
+++ b/LGR/Consolidated/news-bins.html
@@ -68,7 +68,7 @@
   <section class="page-hero" aria-label="Bins and recycling: what's changing">
     <div class="container">
       <h1 class="page-hero__title">Bins and recycling: what's changing</h1>
-      <p class="page-hero__sub">Why your collections carry on as normal through the transition.</p>
+      <p class="page-hero__sub">Why your collections carry on as normal while services come together.</p>
     </div>
   </section>
 
@@ -77,11 +77,11 @@
 
       <p class="back-link"><a href="news.html">&larr; All news</a></p>
 
-      <p class="article-meta">Published 12 June 2026</p>
+      <p class="article-meta">Published 12 June 2028</p>
 
       <div class="article-body">
-        <p>With one council coming for the whole county, a common question is what happens to bin collections. The short answer: nothing changes for now, and any future changes would be made carefully and communicated well in advance.</p>
-        <p>Bin colours, collection days and what goes in which container are currently set locally, so they still vary between areas. Those arrangements continue as they are through the transition.</p>
+        <p>Now one council serves the whole county, a common question is what happens to bin collections. The short answer: nothing changes for now, and any future changes will be made carefully and communicated well in advance.</p>
+        <p>Bin colours, collection days and what goes in which container are currently set locally, so they still vary between areas. Those arrangements continue as they are while services are brought together.</p>
         <h2>Looking ahead</h2>
         <p>Over time, bringing collections under one council may create opportunities to make services more consistent and efficient across the county. Any changes would be planned with residents in mind and announced clearly before they took effect.</p>
         <p>In the meantime, the simplest way to check your own collection details is to look up your area on the bins and recycling pages.</p>
@@ -158,7 +158,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. News articles on this page are illustrative.</p>
       </div>
     </div>

--- a/LGR/Consolidated/news-council-tax.html
+++ b/LGR/Consolidated/news-council-tax.html
@@ -68,7 +68,7 @@
   <section class="page-hero" aria-label="Council tax: one bill, clearer support">
     <div class="container">
       <h1 class="page-hero__title">Council tax: one bill, clearer support</h1>
-      <p class="page-hero__sub">How council tax and support for residents are affected by the change.</p>
+      <p class="page-hero__sub">How council tax and support for residents work under the new council.</p>
     </div>
   </section>
 
@@ -77,10 +77,10 @@
 
       <p class="back-link"><a href="news.html">&larr; All news</a></p>
 
-      <p class="article-meta">Published 5 June 2026</p>
+      <p class="article-meta">Published 14 April 2028</p>
 
       <div class="article-body">
-        <p>Council tax will continue to be billed as normal through the move to a single council. Residents don't need to take any action, and support for those on a low income remains available.</p>
+        <p>Council tax is billed as normal now Gloucestershire has a single council. Residents don't need to take any action, and support for those on a low income remains available.</p>
         <p>Council tax is made up of charges set by different bodies. As services come together under one council, the aim is to make bills clearer and support easier to find — without changing the help available to those who need it.</p>
         <h2>Getting help with your bill</h2>
         <p>If you're struggling to pay, or think you may be entitled to a discount, exemption or reduction, it's worth checking sooner rather than later. Support is means-tested for those on a low income, and various discounts and exemptions apply depending on circumstances.</p>
@@ -158,7 +158,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. News articles on this page are illustrative.</p>
       </div>
     </div>

--- a/LGR/Consolidated/news-have-your-say.html
+++ b/LGR/Consolidated/news-have-your-say.html
@@ -77,11 +77,11 @@
 
       <p class="back-link"><a href="news.html">&larr; All news</a></p>
 
-      <p class="article-meta">Published 20 June 2026</p>
+      <p class="article-meta">Published 20 June 2028</p>
 
       <div class="article-body">
         <p>Residents across Gloucestershire are being invited to help shape how the new council works — from the services people rely on most to how they'd prefer to get in touch.</p>
-        <p>The move to a single council is a rare chance to design services around residents rather than around existing organisational boundaries. Feedback gathered now will help set priorities for the new council ahead of vesting day.</p>
+        <p>The move to a single council is a rare chance to design services around residents rather than around existing organisational boundaries. Feedback gathered now will help set priorities as services are brought together.</p>
         <h2>How to take part</h2>
         <ul>
           <li>Share your views through the online survey while it's open</li>
@@ -163,7 +163,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. News articles on this page are illustrative.</p>
       </div>
     </div>

--- a/LGR/Consolidated/news-new-council.html
+++ b/LGR/Consolidated/news-new-council.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>One council for Gloucestershire goes live in 2028 – Newstershire Council</title>
+  <title>One council for Gloucestershire is now live – Newstershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
 </head>
@@ -60,15 +60,15 @@
       <ol>
         <li><a href="index.html">Home</a></li>
         <li><a href="news.html">News</a></li>
-        <li aria-current="page">One council for Gloucestershire goes live in 2028</li>
+        <li aria-current="page">One council for Gloucestershire is now live</li>
       </ol>
     </div>
   </nav>
 
-  <section class="page-hero" aria-label="One council for Gloucestershire goes live in 2028">
+  <section class="page-hero" aria-label="One council for Gloucestershire is now live">
     <div class="container">
-      <h1 class="page-hero__title">One council for Gloucestershire goes live in 2028</h1>
-      <p class="page-hero__sub">What vesting day means for residents — and what stays exactly the same.</p>
+      <h1 class="page-hero__title">One council for Gloucestershire is now live</h1>
+      <p class="page-hero__sub">What vesting day changed for residents — and what stays exactly the same.</p>
     </div>
   </section>
 
@@ -77,16 +77,16 @@
 
       <p class="back-link"><a href="news.html">&larr; All news</a></p>
 
-      <p class="article-meta">Published 27 June 2026</p>
+      <p class="article-meta">Published 1 April 2028</p>
 
       <div class="article-body">
-        <p>Newstershire Council, the new single council for the whole of Gloucestershire, will formally take over local services on <strong>1 April 2028</strong> — known as vesting day. From that date, one council will be responsible for everything from adult social care and roads to bins, planning and council tax.</p>
-        <p>Until then, the current county, district and borough councils continue to run services as normal. Residents don't need to do anything — bins will be collected, bills will be issued, and services will run as usual through the changeover.</p>
+        <p>Newstershire Council, the new single council for the whole of Gloucestershire, formally took over local services on <strong>1 April 2028</strong> — known as vesting day. From that date, one council is responsible for everything from adult social care and roads to bins, planning and council tax.</p>
+        <p>Residents don't need to do anything — bins are collected, bills are issued, and services run as usual through the changeover.</p>
         <h2>What's changing</h2>
         <p>Bringing seven councils together into one is intended to make services simpler to find and use. Over time, residents will have a single website, one phone number and one account for their council services, rather than needing to work out which organisation to contact.</p>
         <h2>What's staying the same</h2>
         <p>Day-to-day services continue without interruption. Where a service is delivered locally today, it will keep running — the change is about how the council is organised behind the scenes, not about stopping or reducing services.</p>
-        <p>We'll keep publishing updates here as the transition progresses.</p>
+        <p>We'll keep publishing updates here as services move across.</p>
 
       </div>
 
@@ -160,7 +160,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. News articles on this page are illustrative.</p>
       </div>
     </div>

--- a/LGR/Consolidated/news-shadow-elections.html
+++ b/LGR/Consolidated/news-shadow-elections.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Shadow elections planned for May 2027 – Newstershire Council</title>
+  <title>Shadow elections: Newstershire's first councillors elected – Newstershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
 </head>
@@ -60,15 +60,15 @@
       <ol>
         <li><a href="index.html">Home</a></li>
         <li><a href="news.html">News</a></li>
-        <li aria-current="page">Shadow elections planned for May 2027</li>
+        <li aria-current="page">Shadow elections: Newstershire's first councillors elected</li>
       </ol>
     </div>
   </nav>
 
-  <section class="page-hero" aria-label="Shadow elections planned for May 2027">
+  <section class="page-hero" aria-label="Shadow elections: Newstershire's first councillors elected">
     <div class="container">
-      <h1 class="page-hero__title">Shadow elections planned for May 2027</h1>
-      <p class="page-hero__sub">Residents will elect the councillors who form the new authority.</p>
+      <h1 class="page-hero__title">Shadow elections: Newstershire's first councillors elected</h1>
+      <p class="page-hero__sub">Residents have elected the councillors who will form the new authority.</p>
     </div>
   </section>
 
@@ -77,14 +77,13 @@
 
       <p class="back-link"><a href="news.html">&larr; All news</a></p>
 
-      <p class="article-meta">Published 28 May 2026</p>
+      <p class="article-meta">Published 7 May 2027</p>
 
       <div class="article-body">
-        <p>Ahead of the new council going live, residents will elect the councillors who will form it. These <strong>shadow elections</strong> are planned for <strong>May 2027</strong>.</p>
-        <p>The councillors elected then will oversee the final year of preparation and take up their full responsibilities on vesting day, 1 April 2028. It's an important moment: the people elected will shape the priorities and decisions of the new council from day one.</p>
-        <h2>Registering to vote</h2>
-        <p>If you're eligible and registered to vote, you'll be able to take part as usual. If you're not yet registered, it's worth doing so in good time — registration is free and can be done online through the national service.</p>
-        <p>More detail on candidates, polling arrangements and dates will be published closer to the time.</p>
+        <p>Ahead of the new council going live, residents have elected the councillors who will form it. These <strong>shadow elections</strong> took place in <strong>May 2027</strong>.</p>
+        <p>The councillors elected will oversee the final year of preparation and take up their full responsibilities on vesting day, 1 April 2028. It's an important moment: the people elected will shape the priorities and decisions of the new council from day one.</p>
+        <h2>What happens next</h2>
+        <p>The new councillors sit as a shadow authority until vesting day, agreeing the budget, senior appointments and service plans the new council will start life with.</p>
 
       </div>
 
@@ -158,7 +157,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. News articles on this page are illustrative.</p>
       </div>
     </div>

--- a/LGR/Consolidated/news.html
+++ b/LGR/Consolidated/news.html
@@ -78,29 +78,29 @@
 
       <div class="news-feed">
         <article class="news-article-card">
-          <time datetime="2026-06-27">27 June 2026</time>
-          <h2><a href="news-new-council.html">One council for Gloucestershire goes live in 2028</a></h2>
-          <p>What vesting day on 1 April 2028 means for residents — and what stays exactly the same.</p>
-        </article>
-        <article class="news-article-card">
-          <time datetime="2026-06-20">20 June 2026</time>
+          <time datetime="2028-06-20">20 June 2028</time>
           <h2><a href="news-have-your-say.html">Have your say on services for the new council</a></h2>
-          <p>Residents across the county are invited to help shape how the new council works.</p>
+          <p>Residents across the county are invited to help shape how services come together.</p>
         </article>
         <article class="news-article-card">
-          <time datetime="2026-06-12">12 June 2026</time>
+          <time datetime="2028-06-12">12 June 2028</time>
           <h2><a href="news-bins.html">Bins and recycling: what's changing</a></h2>
-          <p>Why your collections carry on as normal through the transition to one council.</p>
+          <p>Why your collections carry on as normal while services come together.</p>
         </article>
         <article class="news-article-card">
-          <time datetime="2026-06-05">5 June 2026</time>
+          <time datetime="2028-04-14">14 April 2028</time>
           <h2><a href="news-council-tax.html">Council tax: one bill, clearer support</a></h2>
-          <p>How council tax and support for residents are affected by the change.</p>
+          <p>How council tax and support for residents work under the new council.</p>
         </article>
         <article class="news-article-card">
-          <time datetime="2026-05-28">28 May 2026</time>
-          <h2><a href="news-shadow-elections.html">Shadow elections planned for May 2027</a></h2>
-          <p>Residents will elect the councillors who form the new authority.</p>
+          <time datetime="2028-04-01">1 April 2028</time>
+          <h2><a href="news-new-council.html">One council for Gloucestershire is now live</a></h2>
+          <p>What vesting day changed for residents — and what stays exactly the same.</p>
+        </article>
+        <article class="news-article-card">
+          <time datetime="2027-05-07">7 May 2027</time>
+          <h2><a href="news-shadow-elections.html">Shadow elections: Newstershire's first councillors elected</a></h2>
+          <p>Residents have elected the councillors who will form the new authority.</p>
         </article>
       </div>
 
@@ -175,7 +175,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. News articles on this page are illustrative.</p>
       </div>
     </div>

--- a/LGR/Consolidated/planning-appeals.html
+++ b/LGR/Consolidated/planning-appeals.html
@@ -86,7 +86,7 @@
             Select your area
           </label>
           <select id="ct-area-select" class="ct-picker__select">
-            <option value="">Choose your district or borough</option>
+            <option value="">Choose your area</option>
             <option value="cheltenham">Cheltenham</option>
             <option value="cotswold">Cotswold</option>
             <option value="forest-of-dean">Forest of Dean</option>
@@ -235,7 +235,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/planning-decision.html
+++ b/LGR/Consolidated/planning-decision.html
@@ -86,7 +86,7 @@
             Select your area
           </label>
           <select id="ct-area-select" class="ct-picker__select">
-            <option value="">Choose your district or borough</option>
+            <option value="">Choose your area</option>
             <option value="cheltenham">Cheltenham</option>
             <option value="cotswold">Cotswold</option>
             <option value="forest-of-dean">Forest of Dean</option>
@@ -243,7 +243,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/planning-fees.html
+++ b/LGR/Consolidated/planning-fees.html
@@ -86,7 +86,7 @@
             Select your area
           </label>
           <select id="ct-area-select" class="ct-picker__select">
-            <option value="">Choose your district or borough</option>
+            <option value="">Choose your area</option>
             <option value="cheltenham">Cheltenham</option>
             <option value="cotswold">Cotswold</option>
             <option value="forest-of-dean">Forest of Dean</option>
@@ -236,7 +236,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/planning-how-to-apply.html
+++ b/LGR/Consolidated/planning-how-to-apply.html
@@ -86,7 +86,7 @@
             Select your area
           </label>
           <select id="ct-area-select" class="ct-picker__select">
-            <option value="">Choose your district or borough</option>
+            <option value="">Choose your area</option>
             <option value="cheltenham">Cheltenham</option>
             <option value="cotswold">Cotswold</option>
             <option value="forest-of-dean">Forest of Dean</option>
@@ -248,7 +248,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/planning-local-plan.html
+++ b/LGR/Consolidated/planning-local-plan.html
@@ -86,7 +86,7 @@
             Select your area
           </label>
           <select id="ct-area-select" class="ct-picker__select">
-            <option value="">Choose your district or borough</option>
+            <option value="">Choose your area</option>
             <option value="cheltenham">Cheltenham</option>
             <option value="cotswold">Cotswold</option>
             <option value="forest-of-dean">Forest of Dean</option>
@@ -232,7 +232,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/planning.html
+++ b/LGR/Consolidated/planning.html
@@ -87,7 +87,7 @@
             Select your area
           </label>
           <select id="ct-area-select" class="ct-picker__select">
-            <option value="">Choose your district or borough</option>
+            <option value="">Choose your area</option>
             <option value="cheltenham">Cheltenham</option>
             <option value="cotswold">Cotswold</option>
             <option value="forest-of-dean">Forest of Dean</option>
@@ -237,7 +237,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/waste-bulky.html
+++ b/LGR/Consolidated/waste-bulky.html
@@ -86,7 +86,7 @@
             Select your area
           </label>
           <select id="ct-area-select" class="ct-picker__select">
-            <option value="">Choose your district or borough</option>
+            <option value="">Choose your area</option>
             <option value="cheltenham">Cheltenham</option>
             <option value="cotswold">Cotswold</option>
             <option value="forest-of-dean">Forest of Dean</option>
@@ -240,7 +240,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/waste-food-waste.html
+++ b/LGR/Consolidated/waste-food-waste.html
@@ -86,7 +86,7 @@
             Select your area
           </label>
           <select id="ct-area-select" class="ct-picker__select">
-            <option value="">Choose your district or borough</option>
+            <option value="">Choose your area</option>
             <option value="cheltenham">Cheltenham</option>
             <option value="cotswold">Cotswold</option>
             <option value="forest-of-dean">Forest of Dean</option>
@@ -234,7 +234,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/waste-garden-waste.html
+++ b/LGR/Consolidated/waste-garden-waste.html
@@ -86,7 +86,7 @@
             Select your area
           </label>
           <select id="ct-area-select" class="ct-picker__select">
-            <option value="">Choose your district or borough</option>
+            <option value="">Choose your area</option>
             <option value="cheltenham">Cheltenham</option>
             <option value="cotswold">Cotswold</option>
             <option value="forest-of-dean">Forest of Dean</option>
@@ -233,7 +233,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/waste-general-waste.html
+++ b/LGR/Consolidated/waste-general-waste.html
@@ -86,7 +86,7 @@
             Select your area
           </label>
           <select id="ct-area-select" class="ct-picker__select">
-            <option value="">Choose your district or borough</option>
+            <option value="">Choose your area</option>
             <option value="cheltenham">Cheltenham</option>
             <option value="cotswold">Cotswold</option>
             <option value="forest-of-dean">Forest of Dean</option>
@@ -247,7 +247,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/waste-recycling-centres.html
+++ b/LGR/Consolidated/waste-recycling-centres.html
@@ -188,7 +188,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/waste-recycling.html
+++ b/LGR/Consolidated/waste-recycling.html
@@ -86,7 +86,7 @@
             Select your area
           </label>
           <select id="ct-area-select" class="ct-picker__select">
-            <option value="">Choose your district or borough</option>
+            <option value="">Choose your area</option>
             <option value="cheltenham">Cheltenham</option>
             <option value="cotswold">Cotswold</option>
             <option value="forest-of-dean">Forest of Dean</option>
@@ -239,7 +239,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/waste.html
+++ b/LGR/Consolidated/waste.html
@@ -87,7 +87,7 @@
             Select your area
           </label>
           <select id="ct-area-select" class="ct-picker__select">
-            <option value="">Choose your district or borough</option>
+            <option value="">Choose your area</option>
             <option value="cheltenham">Cheltenham</option>
             <option value="cotswold">Cotswold</option>
             <option value="forest-of-dean">Forest of Dean</option>
@@ -244,7 +244,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Veneer/about.html
+++ b/LGR/Veneer/about.html
@@ -74,7 +74,7 @@
   <main id="main-content">
     <div class="container page-body">
 
-      <p class="lead">Newstershire Council is the new unitary authority for Gloucestershire. From 1 April 2028 — vesting day — it brings together Gloucestershire County Council and the six district and borough councils into a single council responsible for every local government service across the county, from adult social care and roads to bins, planning and council tax.</p>
+      <p class="lead">Newstershire Council is the new unitary authority for Gloucestershire. On 1 April 2028 — vesting day — it brought together Gloucestershire County Council and the six district and borough councils into a single council responsible for every local government service across the county, from adult social care and roads to bins, planning and council tax.</p>
       <p>One council means one place to find services, one phone number to call, and one organisation accountable for getting things right — while keeping decisions as close as possible to the communities they affect.</p>
       <p>We are still bringing everything together. While that happens, some services are still delivered through the former councils' websites — the tool on our <a href="index.html">home page</a> asks where you live and takes you straight to the right one.</p>
 
@@ -122,7 +122,7 @@
 
       <section class="section-block" aria-labelledby="cabinet-heading">
         <h2 id="cabinet-heading">Our leadership</h2>
-        <p>The council is led by a Leader and Cabinet, each member holding a portfolio for a group of services, supported by senior officers. Councillors will be elected at the shadow elections in May 2027, so the people in these roles are still to be confirmed.</p>
+        <p>The council is led by a Leader and Cabinet, each member holding a portfolio for a group of services, supported by senior officers. Councillors were elected at the shadow elections in May 2027; the names below are placeholders for this proof of concept.</p>
         <div class="people-grid">
           <div class="person-card"><div class="person-avatar" aria-hidden="true"><svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="8" r="4"/><path d="M4 21v-1a6 6 0 016-6h4a6 6 0 016 6v1"/></svg></div><h3>[Name to be confirmed]</h3><p class="person-role">Leader of the Council</p></div>
           <div class="person-card"><div class="person-avatar" aria-hidden="true"><svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="8" r="4"/><path d="M4 21v-1a6 6 0 016-6h4a6 6 0 016 6v1"/></svg></div><h3>[Name to be confirmed]</h3><p class="person-role">Deputy Leader &amp; Finance</p></div>
@@ -150,10 +150,10 @@
       <section class="section-block" aria-labelledby="timeline-heading">
         <h2 id="timeline-heading">The road to one council</h2>
         <ol class="timeline">
-          <li class="is-done"><span class="t-date">2024–2025</span><p class="t-body">Government invites Gloucestershire's councils to propose a single unitary authority, and the proposal is agreed.</p></li>
-          <li class="is-done"><span class="t-date">2026</span><p class="t-body">Transition planning begins, and residents are invited to have their say on services, priorities and the new council's name.</p></li>
-          <li><span class="t-date">May 2027</span><p class="t-body">Shadow elections — residents elect the councillors who will form the new authority and oversee the final year of transition.</p></li>
-          <li><span class="t-date">1 April 2028</span><p class="t-body">Vesting day — Newstershire Council formally goes live. Gloucestershire County Council and the six district and borough councils are abolished.</p></li>
+          <li class="is-done"><span class="t-date">2024–2025</span><p class="t-body">Government invited Gloucestershire's councils to propose a single unitary authority, and the proposal was agreed.</p></li>
+          <li class="is-done"><span class="t-date">2026</span><p class="t-body">Transition planning began, and residents had their say on services, priorities and the new council's name.</p></li>
+          <li class="is-done"><span class="t-date">May 2027</span><p class="t-body">Shadow elections — residents elected the councillors who formed the new authority and oversaw the final year of transition.</p></li>
+          <li class="is-done"><span class="t-date">1 April 2028</span><p class="t-body">Vesting day — Newstershire Council formally went live. Gloucestershire County Council and the six district and borough councils were abolished.</p></li>
           <li><span class="t-date">2028 onwards</span><p class="t-body">Services are progressively brought onto one website, one phone line and one set of systems.</p></li>
         </ol>
       </section>
@@ -242,7 +242,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. Councillor names, figures and dates on this page are illustrative.</p>
       </div>
     </div>

--- a/LGR/Veneer/contact.html
+++ b/LGR/Veneer/contact.html
@@ -100,8 +100,8 @@
 
       <section class="section-block" aria-labelledby="service-heading">
         <h2 id="service-heading">Looking for a specific service?</h2>
-        <p>We're still bringing services together under the new council. For many things — bins, council tax, planning, housing and more — you'll currently be served by one of the former district or borough councils, or by county-level teams.</p>
-        <p>The quickest way to reach the right place is the finder on our home page: tell us where you live and we'll take you straight to the correct service.</p>
+        <p>We're still bringing services together under the new council. For many things — bins, council tax, planning, housing and more — the information and forms still live on the former councils' websites.</p>
+        <p>The quickest way to reach the right place is the finder on our home page: tell us where you live and we'll point you to the right website.</p>
         <div class="cta-band">
           <div class="cta-band__text">
             <h2>Find your local service</h2>
@@ -269,7 +269,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. Contact details on this page are illustrative.</p>
       </div>
     </div>

--- a/LGR/Veneer/index.html
+++ b/LGR/Veneer/index.html
@@ -62,7 +62,7 @@
     <div class="container hero__inner">
       <div class="hero__text">
         <h1 class="hero__title">Welcome to Newstershire Council</h1>
-        <p class="hero__sub">The new single council for the whole of Gloucestershire. Tell us where you live and we'll take you straight to the service you need.</p>
+        <p class="hero__sub">The new single council for the whole of Gloucestershire. Tell us where you live and we'll point you to the right website for the service you need.</p>
       </div>
       <div class="hero__stats" aria-label="Key figures">
         <div class="stat-card">
@@ -95,12 +95,12 @@
           </svg>
           <p>
             <strong>Newstershire Council is a new unitary authority.</strong> We've replaced Gloucestershire County Council and the six district and borough councils with one council for the whole county.
-            While we bring everything together, some services still live on the former councils' websites — the tool below sends you to the right one.
+            While we bring everything together, some services still live on the former councils' websites — the finder below points you to the right website.
           </p>
         </div>
 
         <h2 class="section-title">Find your local service</h2>
-        <p class="page-intro">Answer two quick questions and we'll take you straight to the right place.</p>
+        <p class="page-intro">Answer two quick questions and we'll point you to the right place.</p>
 
         <!-- === STEP 1: area === -->
         <section id="step-area" class="step" aria-labelledby="step-area-heading">
@@ -109,7 +109,7 @@
             Which area do you live in?
           </h3>
           <fieldset>
-            <legend class="sr-only">Select your district or borough</legend>
+            <legend class="sr-only">Select your area</legend>
             <div class="radio-group">
               <label class="radio-card">
                 <input type="radio" name="area" value="cheltenham">
@@ -143,14 +143,14 @@
         <section id="step-tier" class="step step--hidden" aria-labelledby="step-tier-heading" aria-hidden="true">
           <h3 id="step-tier-heading" class="step-heading">
             <span class="step-number" aria-hidden="true">2</span>
-            Is it a county or district service?
+            Who provided it before councils merged?
           </h3>
 
           <div class="help-text">
             <details>
               <summary>Not sure which one?</summary>
               <div class="details-body">
-                <p><strong>County-level services</strong> (previously Gloucestershire County Council) include:</p>
+                <p><strong>Gloucestershire County Council</strong> used to run:</p>
                 <ul>
                   <li>Schools, education and libraries</li>
                   <li>Adult social care</li>
@@ -159,7 +159,7 @@
                   <li>Waste disposal (tips / recycling centres)</li>
                   <li>Fire &amp; rescue</li>
                 </ul>
-                <p><strong>District-level services</strong> (previously your district or borough council) include:</p>
+                <p><strong>Your district or borough council</strong> used to run:</p>
                 <ul>
                   <li>Bins and waste collection</li>
                   <li>Council tax and housing benefit</li>
@@ -173,18 +173,18 @@
           </div>
 
           <fieldset>
-            <legend class="sr-only">Select service type</legend>
+            <legend class="sr-only">Select who used to provide the service</legend>
             <div class="radio-group radio-group--two">
               <label class="radio-card radio-card--large">
                 <input type="radio" name="tier" value="county">
                 <span class="radio-card__icon" aria-hidden="true">🏛️</span>
-                <span class="radio-label">County service</span>
+                <span class="radio-label">Gloucestershire County Council</span>
                 <span class="radio-hint">Education, roads, social care&hellip;</span>
               </label>
               <label class="radio-card radio-card--large">
                 <input type="radio" name="tier" value="district">
                 <span class="radio-card__icon" aria-hidden="true">🏘️</span>
-                <span class="radio-label">District / borough service</span>
+                <span class="radio-label">My district or borough council</span>
                 <span class="radio-hint">Bins, planning, council tax&hellip;</span>
               </label>
             </div>
@@ -207,33 +207,33 @@
             <p>JavaScript is not available in your browser. Use the direct links below.</p>
             <h4>Cheltenham</h4>
             <ul>
-              <li><a href="https://www.gloucestershire.gov.uk/">County services (Gloucestershire County Council)</a></li>
-              <li><a href="https://www.cheltenham.gov.uk/">District services (Cheltenham Borough Council)</a></li>
+              <li><a href="https://www.gloucestershire.gov.uk/">Former county services (Gloucestershire County Council)</a></li>
+              <li><a href="https://www.cheltenham.gov.uk/">Former district services (Cheltenham Borough Council)</a></li>
             </ul>
             <h4>Cotswold</h4>
             <ul>
-              <li><a href="https://www.gloucestershire.gov.uk/">County services</a></li>
-              <li><a href="https://www.cotswold.gov.uk/">District services (Cotswold District Council)</a></li>
+              <li><a href="https://www.gloucestershire.gov.uk/">Former county services</a></li>
+              <li><a href="https://www.cotswold.gov.uk/">Former district services (Cotswold District Council)</a></li>
             </ul>
             <h4>Forest of Dean</h4>
             <ul>
-              <li><a href="https://www.gloucestershire.gov.uk/">County services</a></li>
-              <li><a href="https://www.fdean.gov.uk/">District services (Forest of Dean District Council)</a></li>
+              <li><a href="https://www.gloucestershire.gov.uk/">Former county services</a></li>
+              <li><a href="https://www.fdean.gov.uk/">Former district services (Forest of Dean District Council)</a></li>
             </ul>
             <h4>Gloucester</h4>
             <ul>
-              <li><a href="https://www.gloucestershire.gov.uk/">County services</a></li>
-              <li><a href="https://www.gloucester.gov.uk/">District services (Gloucester City Council)</a></li>
+              <li><a href="https://www.gloucestershire.gov.uk/">Former county services</a></li>
+              <li><a href="https://www.gloucester.gov.uk/">Former district services (Gloucester City Council)</a></li>
             </ul>
             <h4>Stroud</h4>
             <ul>
-              <li><a href="https://www.gloucestershire.gov.uk/">County services</a></li>
-              <li><a href="https://www.stroud.gov.uk/">District services (Stroud District Council)</a></li>
+              <li><a href="https://www.gloucestershire.gov.uk/">Former county services</a></li>
+              <li><a href="https://www.stroud.gov.uk/">Former district services (Stroud District Council)</a></li>
             </ul>
             <h4>Tewkesbury</h4>
             <ul>
-              <li><a href="https://www.gloucestershire.gov.uk/">County services</a></li>
-              <li><a href="https://www.tewkesbury.gov.uk/">District services (Tewkesbury Borough Council)</a></li>
+              <li><a href="https://www.gloucestershire.gov.uk/">Former county services</a></li>
+              <li><a href="https://www.tewkesbury.gov.uk/">Former district services (Tewkesbury Borough Council)</a></li>
             </ul>
           </section>
         </noscript>
@@ -246,6 +246,7 @@
         <!-- Quick links -->
         <div class="sidebar-card">
           <h2 class="sidebar-card__title">Popular services</h2>
+          <p class="sidebar-card__note">These start with the finder — tell us your area first.</p>
           <ul class="quick-links">
             <li><a href="#step-area" class="quick-link">
               <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 11 12 14 22 4"/><path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11"/></svg>
@@ -279,20 +280,20 @@
           <h2 class="sidebar-card__title">Latest news</h2>
           <ul class="news-list">
             <li class="news-item">
-              <span class="news-date">27 Jun 2026</span>
-              <a href="news-new-council.html" class="news-title">One council for Gloucestershire goes live in 2028</a>
-            </li>
-            <li class="news-item">
-              <span class="news-date">20 Jun 2026</span>
+              <span class="news-date">20 Jun 2028</span>
               <a href="news-have-your-say.html" class="news-title">Have your say on services for the new council</a>
             </li>
             <li class="news-item">
-              <span class="news-date">12 Jun 2026</span>
+              <span class="news-date">12 Jun 2028</span>
               <a href="news-bins.html" class="news-title">Bins and recycling: what's changing</a>
             </li>
             <li class="news-item">
-              <span class="news-date">28 May 2026</span>
-              <a href="news-shadow-elections.html" class="news-title">Shadow elections planned for May 2027</a>
+              <span class="news-date">14 Apr 2028</span>
+              <a href="news-council-tax.html" class="news-title">Council tax: one bill, clearer support</a>
+            </li>
+            <li class="news-item">
+              <span class="news-date">1 Apr 2028</span>
+              <a href="news-new-council.html" class="news-title">One council for Gloucestershire is now live</a>
             </li>
           </ul>
           <a href="news.html" class="view-all-link">View all news →</a>
@@ -399,7 +400,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Veneer/news-bins.html
+++ b/LGR/Veneer/news-bins.html
@@ -68,7 +68,7 @@
   <section class="page-hero" aria-label="Bins and recycling: what's changing">
     <div class="container">
       <h1 class="page-hero__title">Bins and recycling: what's changing</h1>
-      <p class="page-hero__sub">Why your collections carry on as normal through the transition.</p>
+      <p class="page-hero__sub">Why your collections carry on as normal while services come together.</p>
     </div>
   </section>
 
@@ -77,11 +77,11 @@
 
       <p class="back-link"><a href="news.html">&larr; All news</a></p>
 
-      <p class="article-meta">Published 12 June 2026</p>
+      <p class="article-meta">Published 12 June 2028</p>
 
       <div class="article-body">
-        <p>With one council coming for the whole county, a common question is what happens to bin collections. The short answer: nothing changes for now, and any future changes would be made carefully and communicated well in advance.</p>
-        <p>Bin colours, collection days and what goes in which container are currently set locally, so they still vary between areas. Those arrangements continue as they are through the transition.</p>
+        <p>Now one council serves the whole county, a common question is what happens to bin collections. The short answer: nothing changes for now, and any future changes will be made carefully and communicated well in advance.</p>
+        <p>Bin colours, collection days and what goes in which container are currently set locally, so they still vary between areas. Those arrangements continue as they are while services are brought together.</p>
         <h2>Looking ahead</h2>
         <p>Over time, bringing collections under one council may create opportunities to make services more consistent and efficient across the county. Any changes would be planned with residents in mind and announced clearly before they took effect.</p>
         <p>In the meantime, the simplest way to check your own collection details is to look up your area on the bins and recycling pages.</p>
@@ -158,7 +158,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. News articles on this page are illustrative.</p>
       </div>
     </div>

--- a/LGR/Veneer/news-council-tax.html
+++ b/LGR/Veneer/news-council-tax.html
@@ -68,7 +68,7 @@
   <section class="page-hero" aria-label="Council tax: one bill, clearer support">
     <div class="container">
       <h1 class="page-hero__title">Council tax: one bill, clearer support</h1>
-      <p class="page-hero__sub">How council tax and support for residents are affected by the change.</p>
+      <p class="page-hero__sub">How council tax and support for residents work under the new council.</p>
     </div>
   </section>
 
@@ -77,10 +77,10 @@
 
       <p class="back-link"><a href="news.html">&larr; All news</a></p>
 
-      <p class="article-meta">Published 5 June 2026</p>
+      <p class="article-meta">Published 14 April 2028</p>
 
       <div class="article-body">
-        <p>Council tax will continue to be billed as normal through the move to a single council. Residents don't need to take any action, and support for those on a low income remains available.</p>
+        <p>Council tax is billed as normal now Gloucestershire has a single council. Residents don't need to take any action, and support for those on a low income remains available.</p>
         <p>Council tax is made up of charges set by different bodies. As services come together under one council, the aim is to make bills clearer and support easier to find — without changing the help available to those who need it.</p>
         <h2>Getting help with your bill</h2>
         <p>If you're struggling to pay, or think you may be entitled to a discount, exemption or reduction, it's worth checking sooner rather than later. Support is means-tested for those on a low income, and various discounts and exemptions apply depending on circumstances.</p>
@@ -158,7 +158,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. News articles on this page are illustrative.</p>
       </div>
     </div>

--- a/LGR/Veneer/news-have-your-say.html
+++ b/LGR/Veneer/news-have-your-say.html
@@ -77,11 +77,11 @@
 
       <p class="back-link"><a href="news.html">&larr; All news</a></p>
 
-      <p class="article-meta">Published 20 June 2026</p>
+      <p class="article-meta">Published 20 June 2028</p>
 
       <div class="article-body">
         <p>Residents across Gloucestershire are being invited to help shape how the new council works — from the services people rely on most to how they'd prefer to get in touch.</p>
-        <p>The move to a single council is a rare chance to design services around residents rather than around existing organisational boundaries. Feedback gathered now will help set priorities for the new council ahead of vesting day.</p>
+        <p>The move to a single council is a rare chance to design services around residents rather than around existing organisational boundaries. Feedback gathered now will help set priorities as services are brought together.</p>
         <h2>How to take part</h2>
         <ul>
           <li>Share your views through the online survey while it's open</li>
@@ -163,7 +163,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. News articles on this page are illustrative.</p>
       </div>
     </div>

--- a/LGR/Veneer/news-new-council.html
+++ b/LGR/Veneer/news-new-council.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>One council for Gloucestershire goes live in 2028 – Newstershire Council</title>
+  <title>One council for Gloucestershire is now live – Newstershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
 </head>
@@ -60,15 +60,15 @@
       <ol>
         <li><a href="index.html">Home</a></li>
         <li><a href="news.html">News</a></li>
-        <li aria-current="page">One council for Gloucestershire goes live in 2028</li>
+        <li aria-current="page">One council for Gloucestershire is now live</li>
       </ol>
     </div>
   </nav>
 
-  <section class="page-hero" aria-label="One council for Gloucestershire goes live in 2028">
+  <section class="page-hero" aria-label="One council for Gloucestershire is now live">
     <div class="container">
-      <h1 class="page-hero__title">One council for Gloucestershire goes live in 2028</h1>
-      <p class="page-hero__sub">What vesting day means for residents — and what stays exactly the same.</p>
+      <h1 class="page-hero__title">One council for Gloucestershire is now live</h1>
+      <p class="page-hero__sub">What vesting day changed for residents — and what stays exactly the same.</p>
     </div>
   </section>
 
@@ -77,16 +77,16 @@
 
       <p class="back-link"><a href="news.html">&larr; All news</a></p>
 
-      <p class="article-meta">Published 27 June 2026</p>
+      <p class="article-meta">Published 1 April 2028</p>
 
       <div class="article-body">
-        <p>Newstershire Council, the new single council for the whole of Gloucestershire, will formally take over local services on <strong>1 April 2028</strong> — known as vesting day. From that date, one council will be responsible for everything from adult social care and roads to bins, planning and council tax.</p>
-        <p>Until then, the current county, district and borough councils continue to run services as normal. Residents don't need to do anything — bins will be collected, bills will be issued, and services will run as usual through the changeover.</p>
+        <p>Newstershire Council, the new single council for the whole of Gloucestershire, formally took over local services on <strong>1 April 2028</strong> — known as vesting day. From that date, one council is responsible for everything from adult social care and roads to bins, planning and council tax.</p>
+        <p>Residents don't need to do anything — bins are collected, bills are issued, and services run as usual through the changeover.</p>
         <h2>What's changing</h2>
         <p>Bringing seven councils together into one is intended to make services simpler to find and use. Over time, residents will have a single website, one phone number and one account for their council services, rather than needing to work out which organisation to contact.</p>
         <h2>What's staying the same</h2>
         <p>Day-to-day services continue without interruption. Where a service is delivered locally today, it will keep running — the change is about how the council is organised behind the scenes, not about stopping or reducing services.</p>
-        <p>We'll keep publishing updates here as the transition progresses.</p>
+        <p>We'll keep publishing updates here as services move across.</p>
 
       </div>
 
@@ -160,7 +160,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. News articles on this page are illustrative.</p>
       </div>
     </div>

--- a/LGR/Veneer/news-shadow-elections.html
+++ b/LGR/Veneer/news-shadow-elections.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Shadow elections planned for May 2027 – Newstershire Council</title>
+  <title>Shadow elections: Newstershire's first councillors elected – Newstershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
 </head>
@@ -60,15 +60,15 @@
       <ol>
         <li><a href="index.html">Home</a></li>
         <li><a href="news.html">News</a></li>
-        <li aria-current="page">Shadow elections planned for May 2027</li>
+        <li aria-current="page">Shadow elections: Newstershire's first councillors elected</li>
       </ol>
     </div>
   </nav>
 
-  <section class="page-hero" aria-label="Shadow elections planned for May 2027">
+  <section class="page-hero" aria-label="Shadow elections: Newstershire's first councillors elected">
     <div class="container">
-      <h1 class="page-hero__title">Shadow elections planned for May 2027</h1>
-      <p class="page-hero__sub">Residents will elect the councillors who form the new authority.</p>
+      <h1 class="page-hero__title">Shadow elections: Newstershire's first councillors elected</h1>
+      <p class="page-hero__sub">Residents have elected the councillors who will form the new authority.</p>
     </div>
   </section>
 
@@ -77,14 +77,13 @@
 
       <p class="back-link"><a href="news.html">&larr; All news</a></p>
 
-      <p class="article-meta">Published 28 May 2026</p>
+      <p class="article-meta">Published 7 May 2027</p>
 
       <div class="article-body">
-        <p>Ahead of the new council going live, residents will elect the councillors who will form it. These <strong>shadow elections</strong> are planned for <strong>May 2027</strong>.</p>
-        <p>The councillors elected then will oversee the final year of preparation and take up their full responsibilities on vesting day, 1 April 2028. It's an important moment: the people elected will shape the priorities and decisions of the new council from day one.</p>
-        <h2>Registering to vote</h2>
-        <p>If you're eligible and registered to vote, you'll be able to take part as usual. If you're not yet registered, it's worth doing so in good time — registration is free and can be done online through the national service.</p>
-        <p>More detail on candidates, polling arrangements and dates will be published closer to the time.</p>
+        <p>Ahead of the new council going live, residents have elected the councillors who will form it. These <strong>shadow elections</strong> took place in <strong>May 2027</strong>.</p>
+        <p>The councillors elected will oversee the final year of preparation and take up their full responsibilities on vesting day, 1 April 2028. It's an important moment: the people elected will shape the priorities and decisions of the new council from day one.</p>
+        <h2>What happens next</h2>
+        <p>The new councillors sit as a shadow authority until vesting day, agreeing the budget, senior appointments and service plans the new council will start life with.</p>
 
       </div>
 
@@ -158,7 +157,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. News articles on this page are illustrative.</p>
       </div>
     </div>

--- a/LGR/Veneer/news.html
+++ b/LGR/Veneer/news.html
@@ -78,29 +78,29 @@
 
       <div class="news-feed">
         <article class="news-article-card">
-          <time datetime="2026-06-27">27 June 2026</time>
-          <h2><a href="news-new-council.html">One council for Gloucestershire goes live in 2028</a></h2>
-          <p>What vesting day on 1 April 2028 means for residents — and what stays exactly the same.</p>
-        </article>
-        <article class="news-article-card">
-          <time datetime="2026-06-20">20 June 2026</time>
+          <time datetime="2028-06-20">20 June 2028</time>
           <h2><a href="news-have-your-say.html">Have your say on services for the new council</a></h2>
-          <p>Residents across the county are invited to help shape how the new council works.</p>
+          <p>Residents across the county are invited to help shape how services come together.</p>
         </article>
         <article class="news-article-card">
-          <time datetime="2026-06-12">12 June 2026</time>
+          <time datetime="2028-06-12">12 June 2028</time>
           <h2><a href="news-bins.html">Bins and recycling: what's changing</a></h2>
-          <p>Why your collections carry on as normal through the transition to one council.</p>
+          <p>Why your collections carry on as normal while services come together.</p>
         </article>
         <article class="news-article-card">
-          <time datetime="2026-06-05">5 June 2026</time>
+          <time datetime="2028-04-14">14 April 2028</time>
           <h2><a href="news-council-tax.html">Council tax: one bill, clearer support</a></h2>
-          <p>How council tax and support for residents are affected by the change.</p>
+          <p>How council tax and support for residents work under the new council.</p>
         </article>
         <article class="news-article-card">
-          <time datetime="2026-05-28">28 May 2026</time>
-          <h2><a href="news-shadow-elections.html">Shadow elections planned for May 2027</a></h2>
-          <p>Residents will elect the councillors who form the new authority.</p>
+          <time datetime="2028-04-01">1 April 2028</time>
+          <h2><a href="news-new-council.html">One council for Gloucestershire is now live</a></h2>
+          <p>What vesting day changed for residents — and what stays exactly the same.</p>
+        </article>
+        <article class="news-article-card">
+          <time datetime="2027-05-07">7 May 2027</time>
+          <h2><a href="news-shadow-elections.html">Shadow elections: Newstershire's first councillors elected</a></h2>
+          <p>Residents have elected the councillors who will form the new authority.</p>
         </article>
       </div>
 
@@ -175,7 +175,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2026 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. News articles on this page are illustrative.</p>
       </div>
     </div>

--- a/LGR/style.css
+++ b/LGR/style.css
@@ -550,6 +550,12 @@ details[open] summary::before { transform: rotate(90deg); }
   border-bottom: 2px solid var(--blue-light);
 }
 
+.sidebar-card__note {
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+  margin: -0.25rem 0 0.5rem;
+}
+
 /* Quick links */
 .quick-links { list-style: none; }
 

--- a/LGR/veneer.js
+++ b/LGR/veneer.js
@@ -54,11 +54,13 @@
 
     var service = tier === 'county' ? COUNTY : district;
     var desc    = tier === 'county' ? COUNTY.desc : DISTRICT_DESC;
-    var lead    = tier === 'county' ? 'County' : 'District';
+    var lead    = tier === 'county'
+      ? 'This service hasn’t moved to our website yet. It’s still on the former county council’s website:'
+      : 'This service hasn’t moved to our website yet. For <strong>' + district.label +
+        '</strong>, it’s still on the former district council’s website:';
 
     resultBody.innerHTML =
-      '<p class="result-card__lead">' + lead +
-      ' services for <strong>' + district.label + '</strong> are handled by:</p>' +
+      '<p class="result-card__lead">' + lead + '</p>' +
       '<p class="result-card__name">' + service.name + '</p>' +
       '<p class="result-card__desc">' + desc + '</p>' +
       '<a class="btn" href="' + service.url + '" target="_blank" rel="noopener">' +


### PR DESCRIPTION
## Summary

Follow-up to #93: reviews both LGR home pages through the lens of a unitary council that has already come together from the county council and six districts — where some content is consolidated on the new site and the rest still refers back to legacy council websites.

## Finder: former-council framing, not live two-tier

- Step 2 asked *"Is it a county or district service?"* — present tense, as if the two-tier system still existed. It now asks **"Who provided it before councils merged?"** with the former councils as the answer options ("Gloucestershire County Council" / "My district or borough council") and the helper text describing what each *used to run*. The task-first hints (bins, planning, council tax…) are kept — they're what actually helps people answer.
- Step 1's legend asked for your *"district or borough"* — a council type, and inaccurate for Gloucester (a city council). It now asks for your **area**, and the topic-page pickers say "Choose your area" to match.
- The result card said district services *"are handled by"* the legacy council — wrong claim for a unitary, which owns all services now. It now says the service **hasn't moved to this website yet** and the information still lives on the former council's website. Noscript fallbacks use the same "former county/district services" framing.

## Consistent post-vesting fiction

The hero said *"We've replaced Gloucestershire County Council and the six district and borough councils"* while the Latest news beside it led with *"One council for Gloucestershire goes live in 2028"* — the merger both done and two years away. Both sites now sit consistently after vesting day (1 April 2028):

- News re-dated and re-tensed: vesting day reported as **now live**, shadow elections as a May 2027 archive item (with a "what happens next" section replacing the stale "register to vote" call), council tax and bins articles written from under the new council. Home sidebars and the news listings reordered to match.
- About-page timeline marked complete through vesting day, with past-tense entries; leadership copy notes councillors were elected in 2027 (names remain PoC placeholders). Footer year → 2028.

## Smaller alignments

- Veneer hero/notice now *"point you to the right website"* — matching the finder's behaviour since #93 (it shows a link; it no longer auto-opens a tab), and making clear the destination is a website, not a different responsible council.
- Veneer's "Popular services" card explains those links start with the finder.
- "right existing council website" → "right former council website" on the Consolidated router intro; Veneer contact page says the information and forms still live on the former councils' websites, rather than that residents are "served by" them.

Factual service-content dates on topic pages (e.g. 2026/27 fee figures, legacy policy dates) are deliberately untouched — they're real legacy-council facts and read correctly from 2028.

## Verification

Link checker over every `href`/`src` (0 broken), `node --check` on the updated script, and the full Playwright suite re-run — 14/14 passing, no console errors — plus element screenshots of the reworded step 2 and result card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X3cU8szKqcgumnXgrT7REs

---
_Generated by [Claude Code](https://claude.ai/code/session_01X3cU8szKqcgumnXgrT7REs)_