### PR TITLE
Align public register page with GCC design principles

### DIFF
--- a/Taxi website/public-register.html
+++ b/Taxi website/public-register.html
@@ -3,23 +3,82 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Taxi &amp; Private Hire Public Register | Gloucester City Council</title>
+<title>Taxi and private hire public register | Gloucester City Council</title>
 <meta name="description" content="Search the public register of licensed hackney carriage and private hire drivers, vehicles and operators for Gloucester.">
 <style>
   :root {
-    --navy: #10263f;
-    --blue: #1d4477;
-    --blue-light: #eef3f9;
-    --gold: #c8a951;
-    --green: #1c7a4d;
-    --red: #b3261e;
-    --grey-50: #f7f8fa;
-    --grey-100: #eceef1;
-    --grey-300: #c7ccd3;
-    --grey-600: #5b6570;
-    --grey-800: #2b323a;
+    /* Standard contrast palette */
+    --color-primary: #0054A4;
+    --color-secondary: #0B2E53;
+    --color-accent: #2F80ED;
+    --color-white: #FFFFFF;
+    --color-light-grey: #F5F7FA;
+    --color-mid-grey: #C7CDD6;
+    --color-dark-grey: #4A4F55;
+    --color-near-black: #1A1D21;
+    --color-text-primary: #1A1D21;
+    --color-text-secondary: #4A4F55;
+    --color-text-muted: #6B7280;
+    --color-link: #0054A4;
+    --color-text-inverse: #FFFFFF;
+    --color-bg-default: #FFFFFF;
+    --color-bg-alt: #F5F7FA;
+    --color-bg-emphasis: #E9F1FA;
+    --color-state-default: #0054A4;
+    --color-state-hover: #003E7B;
+    --color-state-active: #0B2E53;
+    --color-state-focus: #2F80ED;
+    --color-state-disabled: #9CA3AF;
+    --color-success: #2E7D32;
+    --color-warning: #ED6C02;
+    --color-error: #C62828;
+    --color-info: #0054A4;
+    --color-border-default: #C7CDD6;
+    --color-border-active: #0054A4;
+    --color-border-focus: #2F80ED;
+    --color-border-divider: #E5E7EB;
+
+    /* Spacing scale: 4 / 8 / 16 / 24 / 32px */
+    --space-1: 0.25rem;
+    --space-2: 0.5rem;
+    --space-3: 1rem;
+    --space-4: 1.5rem;
+    --space-5: 2rem;
+
     --radius: 8px;
-    --focus: 3px solid #ffbf47;
+  }
+
+  :root[data-contrast="high"] {
+    /* High contrast palette */
+    --color-primary: #0054A4;
+    --color-secondary: #081F3A;
+    --color-accent: #1E88E5;
+    --color-white: #FFFFFF;
+    --color-light-grey: #F2F4F7;
+    --color-mid-grey: #B8BEC7;
+    --color-dark-grey: #3A3F45;
+    --color-near-black: #111418;
+    --color-text-primary: #111418;
+    --color-text-secondary: #3A3F45;
+    --color-text-muted: #525862;
+    --color-link: #003E7B;
+    --color-text-inverse: #FFFFFF;
+    --color-bg-default: #FFFFFF;
+    --color-bg-alt: #F2F4F7;
+    --color-bg-emphasis: #E3EDF9;
+    --color-state-default: #0054A4;
+    --color-state-hover: #003E7B;
+    --color-state-active: #081F3A;
+    --color-state-focus: #1E88E5;
+    --color-state-disabled: #8E959F;
+    --color-success: #1B5E20;
+    --color-warning: #B45309;
+    --color-error: #8E1B1B;
+    --color-info: #004085;
+    --color-border-default: #B8BEC7;
+    --color-border-active: #0054A4;
+    --color-border-focus: #1E88E5;
+    --color-border-divider: #D1D5DB;
   }
 
   * { box-sizing: border-box; }
@@ -27,36 +86,55 @@
   body {
     margin: 0;
     font-family: "Segoe UI", Arial, Helvetica, sans-serif;
-    color: var(--grey-800);
-    background: var(--grey-50);
+    color: var(--color-text-primary);
+    background: var(--color-bg-alt);
     line-height: 1.5;
   }
 
-  a { color: var(--blue); }
+  a {
+    color: var(--color-link);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+  a:hover { color: var(--color-state-hover); }
 
   .skip-link {
     position: absolute;
     left: -999px;
     top: 0;
-    background: #fff;
-    padding: 0.75rem 1rem;
+    background: var(--color-bg-default);
+    padding: var(--space-3) var(--space-3);
     z-index: 100;
   }
-  .skip-link:focus { left: 0.5rem; top: 0.5rem; }
+  .skip-link:focus { left: var(--space-2); top: var(--space-2); }
 
-  *:focus-visible { outline: var(--focus); outline-offset: 2px; }
+  *:focus-visible {
+    outline: 3px solid var(--color-border-focus);
+    outline-offset: 2px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    * { scroll-behavior: auto !important; transition: none !important; animation: none !important; }
+  }
 
   header.site-header {
-    background: var(--navy);
-    color: #fff;
-    padding: 1.25rem 1rem;
+    background: var(--color-secondary);
+    color: var(--color-text-inverse);
+    padding: var(--space-4) var(--space-3);
   }
   .site-header__inner {
     max-width: 1100px;
     margin: 0 auto;
     display: flex;
     align-items: center;
-    gap: 0.9rem;
+    justify-content: space-between;
+    gap: var(--space-3);
+    flex-wrap: wrap;
+  }
+  .site-header__brand {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
   }
   .site-header__inner svg { flex-shrink: 0; }
   .site-header__inner h1 {
@@ -64,91 +142,113 @@
     margin: 0;
   }
   .site-header__inner p {
-    margin: 0.15rem 0 0;
+    margin: var(--space-1) 0 0;
     font-size: 0.85rem;
-    color: #cfd9e6;
+    color: var(--color-light-grey);
   }
+
+  .contrast-toggle {
+    background: transparent;
+    border: 1px solid var(--color-text-inverse);
+    color: var(--color-text-inverse);
+    border-radius: 6px;
+    padding: 0 var(--space-3);
+    min-height: 44px;
+    font-size: 0.9rem;
+    cursor: pointer;
+    text-decoration: none;
+  }
+  .contrast-toggle:hover { background: rgba(255, 255, 255, 0.12); }
 
   .breadcrumb {
     max-width: 1100px;
     margin: 0 auto;
-    padding: 0.75rem 1rem 0;
+    padding: var(--space-3) var(--space-3) 0;
     font-size: 0.85rem;
-    color: var(--grey-600);
+    color: var(--color-text-secondary);
   }
 
   main {
     max-width: 1100px;
     margin: 0 auto;
-    padding: 1.25rem 1rem 3rem;
+    padding: var(--space-3) var(--space-3) var(--space-5);
   }
 
   .intro { max-width: 70ch; }
   .intro h2 { margin-top: 0; }
 
   details.about {
-    background: #fff;
-    border: 1px solid var(--grey-300);
+    background: var(--color-bg-default);
+    border: 1px solid var(--color-border-default);
     border-radius: var(--radius);
-    padding: 0.9rem 1.1rem;
-    margin: 1.25rem 0 1.75rem;
+    padding: var(--space-3) var(--space-4);
+    margin: var(--space-4) 0;
   }
-  details.about summary { font-weight: 600; cursor: pointer; }
-  details.about p { margin: 0.75rem 0 0.25rem; }
-  details.about ul { margin: 0.5rem 0; padding-left: 1.25rem; }
+  details.about summary { font-weight: 600; cursor: pointer; min-height: 44px; display: flex; align-items: center; }
+  details.about p { margin: var(--space-3) 0 var(--space-1); }
+  details.about ul { margin: var(--space-2) 0; padding-left: var(--space-4); }
 
   .controls {
-    background: #fff;
-    border: 1px solid var(--grey-300);
+    background: var(--color-bg-default);
+    border: 1px solid var(--color-border-default);
     border-radius: var(--radius);
-    padding: 1.1rem;
+    padding: var(--space-4);
     display: grid;
-    grid-template-columns: 2fr 1fr 1fr;
-    gap: 0.9rem;
+    grid-template-columns: repeat(12, 1fr);
+    gap: var(--space-3);
     align-items: end;
   }
+  .field--search { grid-column: span 6; }
+  .field--type { grid-column: span 3; }
+  .field--status { grid-column: span 3; }
   @media (max-width: 720px) {
-    .controls { grid-template-columns: 1fr; }
+    .field--search, .field--type, .field--status { grid-column: span 12; }
   }
   .field label {
     display: block;
     font-weight: 600;
     font-size: 0.9rem;
-    margin-bottom: 0.3rem;
+    margin-bottom: var(--space-1);
   }
   .field input,
   .field select {
     width: 100%;
-    padding: 0.55rem 0.6rem;
-    border: 1px solid var(--grey-300);
+    min-height: 44px;
+    padding: var(--space-2) var(--space-2);
+    border: 1px solid var(--color-border-default);
     border-radius: 6px;
     font-size: 1rem;
-    background: #fff;
+    background: var(--color-bg-default);
+    color: var(--color-text-primary);
   }
-  .field small { display: block; color: var(--grey-600); margin-top: 0.3rem; }
+  .field input:focus-visible,
+  .field select:focus-visible { border-color: var(--color-border-focus); }
+  .field small { display: block; color: var(--color-text-muted); margin-top: var(--space-1); }
 
   .results-bar {
     display: flex;
     justify-content: space-between;
     align-items: center;
     flex-wrap: wrap;
-    gap: 0.5rem;
-    margin: 1.1rem 0 0.6rem;
+    gap: var(--space-2);
+    margin: var(--space-4) 0 var(--space-2);
   }
-  .results-count { font-weight: 600; }
+  .results-count { font-weight: 600; margin: 0; }
   .reset-btn {
     background: none;
-    border: 1px solid var(--grey-300);
+    border: 1px solid var(--color-border-default);
     border-radius: 6px;
-    padding: 0.4rem 0.8rem;
+    padding: 0 var(--space-3);
+    min-height: 44px;
     cursor: pointer;
     font-size: 0.9rem;
+    color: var(--color-text-primary);
   }
-  .reset-btn:hover { background: var(--grey-100); }
+  .reset-btn:hover { background: var(--color-bg-alt); }
 
   .table-wrap {
-    background: #fff;
-    border: 1px solid var(--grey-300);
+    background: var(--color-bg-default);
+    border: 1px solid var(--color-border-default);
     border-radius: var(--radius);
     overflow-x: auto;
   }
@@ -157,15 +257,15 @@
     width: 100%;
     border-collapse: collapse;
     font-size: 0.92rem;
-    min-width: 780px;
+    min-width: 700px;
   }
-  caption { text-align: left; padding: 0.75rem 1rem 0; font-size: 0.85rem; color: var(--grey-600); }
+  caption { text-align: left; padding: var(--space-3) var(--space-3) 0; font-size: 0.85rem; color: var(--color-text-muted); }
 
   thead th {
     text-align: left;
-    background: var(--blue-light);
-    padding: 0.7rem 0.8rem;
-    border-bottom: 2px solid var(--grey-300);
+    background: var(--color-bg-emphasis);
+    padding: var(--space-2) var(--space-3);
+    border-bottom: 2px solid var(--color-border-default);
     white-space: nowrap;
   }
   thead th button {
@@ -175,60 +275,51 @@
     font-weight: 700;
     color: inherit;
     cursor: pointer;
-    padding: 0;
+    padding: var(--space-2) 0;
+    min-height: 44px;
     display: inline-flex;
     align-items: center;
-    gap: 0.3rem;
+    gap: var(--space-1);
   }
-  thead th button:hover { text-decoration: underline; }
+  thead th button:hover { color: var(--color-state-hover); }
   .sort-arrow { font-size: 0.7rem; opacity: 0.6; }
   .sort-arrow.active { opacity: 1; }
 
   tbody td {
-    padding: 0.65rem 0.8rem;
-    border-bottom: 1px solid var(--grey-100);
+    padding: var(--space-2) var(--space-3);
+    border-bottom: 1px solid var(--color-border-divider);
     vertical-align: top;
   }
-  tbody tr:hover { background: var(--grey-50); }
+  tbody tr:hover { background: var(--color-bg-alt); }
   tbody tr:last-child td { border-bottom: none; }
 
-  .badge {
-    display: inline-block;
-    padding: 0.15rem 0.55rem;
-    border-radius: 999px;
-    font-size: 0.78rem;
-    font-weight: 600;
-    white-space: nowrap;
-  }
-  .badge--active { background: #e4f3ea; color: var(--green); }
-  .badge--expiring { background: #fdf1dc; color: #8a5a00; }
-  .badge--expired { background: #fbe9e8; color: var(--red); }
-
   .no-results, .load-error {
-    padding: 2rem 1.2rem;
+    padding: var(--space-5) var(--space-3);
     text-align: center;
-    color: var(--grey-600);
+    color: var(--color-text-muted);
   }
-  .load-error { color: var(--red); }
+  .load-error { color: var(--color-error); }
 
   .pagination {
     display: flex;
     justify-content: center;
     align-items: center;
-    gap: 0.75rem;
-    margin: 1.1rem 0;
+    gap: var(--space-3);
+    margin: var(--space-4) 0;
     flex-wrap: wrap;
   }
   .pagination button {
-    background: #fff;
-    border: 1px solid var(--grey-300);
+    background: var(--color-bg-default);
+    border: 1px solid var(--color-border-default);
     border-radius: 6px;
-    padding: 0.4rem 0.85rem;
+    padding: 0 var(--space-3);
+    min-height: 44px;
     cursor: pointer;
     font-size: 0.9rem;
+    color: var(--color-text-primary);
   }
   .pagination button:disabled { opacity: 0.45; cursor: not-allowed; }
-  .pagination button:not(:disabled):hover { background: var(--grey-100); }
+  .pagination button:not(:disabled):hover { background: var(--color-bg-alt); }
 
   .visually-hidden {
     position: absolute;
@@ -241,11 +332,10 @@
   footer {
     max-width: 1100px;
     margin: 0 auto;
-    padding: 1.5rem 1rem 3rem;
-    color: var(--grey-600);
+    padding: var(--space-4) var(--space-3) var(--space-5);
+    color: var(--color-text-secondary);
     font-size: 0.85rem;
   }
-  footer a { color: var(--blue); }
 </style>
 </head>
 <body>
@@ -254,26 +344,29 @@
 
 <header class="site-header">
   <div class="site-header__inner">
-    <svg aria-hidden="true" width="44" height="44" viewBox="0 0 52 52">
-      <circle cx="26" cy="26" r="26" fill="#1d4477"/>
-      <path d="M10 36 Q18 18 26 22 Q34 18 42 36 Z" fill="#c8a951" opacity="0.9"/>
-      <path d="M18 36 Q22 26 26 28 Q30 26 34 36 Z" fill="#ffffff" opacity="0.85"/>
-      <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
-    </svg>
-    <div>
-      <h1>Gloucester City Council</h1>
-      <p>Taxi &amp; private hire licensing</p>
+    <div class="site-header__brand">
+      <svg aria-hidden="true" width="44" height="44" viewBox="0 0 52 52">
+        <circle cx="26" cy="26" r="26" fill="#0054A4"/>
+        <path d="M10 36 Q18 18 26 22 Q34 18 42 36 Z" fill="#2F80ED" opacity="0.9"/>
+        <path d="M18 36 Q22 26 26 28 Q30 26 34 36 Z" fill="#ffffff" opacity="0.85"/>
+        <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
+      </svg>
+      <div>
+        <h1>Gloucester City Council</h1>
+        <p>Taxi and private hire licensing</p>
+      </div>
     </div>
+    <button type="button" class="contrast-toggle" id="contrast-toggle" aria-pressed="false">Switch to high contrast</button>
   </div>
 </header>
 
 <p class="breadcrumb">
-  <a href="index.html">Taxi &amp; private hire licensing</a> &rsaquo; Public register
+  <a href="index.html">Taxi and private hire licensing</a> &rsaquo; Public register
 </p>
 
 <main id="main-content">
   <div class="intro">
-    <h2>Taxi &amp; private hire public register</h2>
+    <h2>Taxi and private hire public register</h2>
     <p>
       This register lists all currently and recently licensed hackney carriage
       and private hire drivers, vehicles and operators issued by Gloucester
@@ -287,27 +380,27 @@
     <p>Data source: <code id="source-file">LIC_Public_Register.json</code></p>
     <ul>
       <li>Records are provided for information only and may not reflect changes made since the last update.</li>
-      <li>A licence showing as "Expired" may since have been renewed &ndash; contact the licensing team to confirm current status.</li>
+      <li>A licence past its expiry date may since have been renewed &ndash; contact the licensing team to confirm current status.</li>
       <li>To report a concern about a licensed driver, vehicle or operator, contact the Licensing Team on 01452 396396 or <a href="mailto:licensing@gloucester.gov.uk">licensing@gloucester.gov.uk</a>.</li>
     </ul>
   </details>
 
   <form id="filters" class="controls" role="search" autocomplete="off">
-    <div class="field">
+    <div class="field field--search">
       <label for="search-input">Search</label>
       <input type="search" id="search-input" placeholder="Plate ref, vehicle reg, make/model or trading name">
       <small>Search updates results as you type</small>
     </div>
-    <div class="field">
+    <div class="field field--type">
       <label for="type-filter">Licence type</label>
       <select id="type-filter">
         <option value="">All types</option>
       </select>
     </div>
-    <div class="field">
-      <label for="status-filter">Status</label>
+    <div class="field field--status">
+      <label for="status-filter">Expiry status</label>
       <select id="status-filter">
-        <option value="">All statuses</option>
+        <option value="">All licences</option>
         <option value="active">Active</option>
         <option value="expiring">Expiring within 30 days</option>
         <option value="expired">Expired</option>
@@ -332,11 +425,10 @@
           <th scope="col" data-key="trading_as"><button type="button">Trading as <span class="sort-arrow" data-for="trading_as"></span></button></th>
           <th scope="col" data-key="issued_date"><button type="button">Issued <span class="sort-arrow" data-for="issued_date"></span></button></th>
           <th scope="col" data-key="expiry_date"><button type="button">Expiry <span class="sort-arrow" data-for="expiry_date"></span></button></th>
-          <th scope="col">Status</th>
         </tr>
       </thead>
       <tbody id="register-body">
-        <tr><td colspan="8" class="no-results">Loading register&hellip;</td></tr>
+        <tr><td colspan="7" class="no-results">Loading register&hellip;</td></tr>
       </tbody>
     </table>
   </div>
@@ -356,6 +448,7 @@
 (function () {
   var DATA_URL = 'PublicRegister/LIC_Public_Register.json';
   var PAGE_SIZE = 50;
+  var CONTRAST_KEY = 'gcc-contrast-mode';
 
   var state = {
     records: [],
@@ -374,8 +467,32 @@
     pagination: document.getElementById('pagination'),
     resetBtn: document.getElementById('reset-filters'),
     sourceFile: document.getElementById('source-file'),
-    table: document.getElementById('register-table')
+    table: document.getElementById('register-table'),
+    contrastToggle: document.getElementById('contrast-toggle')
   };
+
+  function initContrastToggle() {
+    var saved = null;
+    try { saved = localStorage.getItem(CONTRAST_KEY); } catch (e) { saved = null; }
+    if (saved === 'high') setContrast(true);
+
+    els.contrastToggle.addEventListener('click', function () {
+      setContrast(document.documentElement.dataset.contrast !== 'high');
+    });
+  }
+
+  function setContrast(high) {
+    if (high) {
+      document.documentElement.dataset.contrast = 'high';
+      els.contrastToggle.textContent = 'Switch to standard contrast';
+      els.contrastToggle.setAttribute('aria-pressed', 'true');
+    } else {
+      delete document.documentElement.dataset.contrast;
+      els.contrastToggle.textContent = 'Switch to high contrast';
+      els.contrastToggle.setAttribute('aria-pressed', 'false');
+    }
+    try { localStorage.setItem(CONTRAST_KEY, high ? 'high' : 'standard'); } catch (e) { /* storage unavailable */ }
+  }
 
   function formatDate(iso) {
     if (!iso) return '&ndash;';
@@ -402,11 +519,6 @@
     if (d < 0) return 'expired';
     if (d <= 30) return 'expiring';
     return 'active';
-  }
-
-  function statusBadge(status) {
-    var labels = { active: 'Active', expiring: 'Expiring soon', expired: 'Expired' };
-    return '<span class="badge badge--' + status + '">' + labels[status] + '</span>';
   }
 
   function escapeHtml(value) {
@@ -482,7 +594,7 @@
 
     if (total === 0) {
       els.resultsCount.textContent = 'No licences match your search.';
-      els.body.innerHTML = '<tr><td colspan="8" class="no-results">No matching licences found. Try clearing a filter or checking your spelling.</td></tr>';
+      els.body.innerHTML = '<tr><td colspan="7" class="no-results">No matching licences found. Try clearing a filter or checking your spelling.</td></tr>';
       els.pagination.innerHTML = '';
       return;
     }
@@ -499,7 +611,6 @@
         '<td>' + escapeHtml(r.trading_as) + '</td>' +
         '<td>' + formatDate(r.issued_date) + '</td>' +
         '<td>' + formatDate(r.expiry_date) + '</td>' +
-        '<td>' + statusBadge(statusFor(r)) + '</td>' +
         '</tr>';
     }).join('');
 
@@ -521,7 +632,8 @@
   }
 
   function scrollToTable() {
-    document.querySelector('.table-wrap').scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    var reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    document.querySelector('.table-wrap').scrollIntoView({ behavior: reduceMotion ? 'auto' : 'smooth', block: 'nearest' });
   }
 
   els.table.querySelectorAll('thead th[data-key] button').forEach(function (btn) {
@@ -558,6 +670,8 @@
     };
   }
 
+  initContrastToggle();
+
   fetch(DATA_URL)
     .then(function (res) {
       if (!res.ok) throw new Error('HTTP ' + res.status);
@@ -573,7 +687,7 @@
     })
     .catch(function (err) {
       els.resultsCount.textContent = 'Unable to load the register.';
-      els.body.innerHTML = '<tr><td colspan="8" class="load-error">' +
+      els.body.innerHTML = '<tr><td colspan="7" class="load-error">' +
         'Sorry, the public register could not be loaded (' + escapeHtml(err.message) + '). ' +
         'Please try again later or contact licensing@gloucester.gov.uk.</td></tr>';
     });


### PR DESCRIPTION
## Summary
Follow-up to #95: brings `Taxi website/public-register.html` in line with the GCC Design Principles document.

- Remove the Status column/badges from the results table (the expiry status filter is retained, driven by the visible Expiry date column)
- Apply the standard and high-contrast colour palettes from the design principles as CSS custom properties, with a persisted contrast toggle in the header
- Use the 4/8/16/24/32px spacing scale and a 12-column grid for the filter controls
- Enforce 44px minimum touch targets on all interactive controls
- Underline links with visible hover/focus states and a 3px focus ring
- Respect `prefers-reduced-motion`
- Sentence-case headings and page title

## Test plan
- [x] Served the page locally and drove it with a headless browser: search, licence-type filter, expiry-status filter, column sorting, and pagination all return correct counts/rows
- [x] Confirmed the Status column no longer renders (7 header columns, 7 cells per row)
- [x] Verified the high-contrast toggle switches the palette, sets `aria-pressed`, and persists across reload
- [x] Verified all buttons/inputs/selects meet the 44px touch-target minimum


---
_Generated by [Claude Code](https://claude.ai/code/session_0198YvztrFWvpdkCZZNC33X5)_