### PR TITLE
Rebrand LGR prototypes to Gloucestershire Council and mark as test site

### DIFF
--- a/LGR/Consolidated/about.html
+++ b/LGR/Consolidated/about.html
@@ -3,13 +3,22 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>About the council – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] About the council – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
 </head>
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -19,7 +28,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -36,7 +45,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -74,7 +83,7 @@
   <main id="main-content">
     <div class="container page-body">
 
-      <p class="lead">Newstershire Council is the new unitary authority for Gloucestershire. On 1 April 2028 — vesting day — it brought together Gloucestershire County Council and the six district and borough councils into a single council responsible for every local government service across the county, from adult social care and roads to bins, planning and council tax.</p>
+      <p class="lead">Gloucestershire Council is the new unitary authority for Gloucestershire. On 1 April 2028 — vesting day — it brought together Gloucestershire County Council and the six district and borough councils into a single council responsible for every local government service across the county, from adult social care and roads to bins, planning and council tax.</p>
       <p>One council means one place to find services, one phone number to call, and one organisation accountable for getting things right — while keeping decisions as close as possible to the communities they affect.</p>
 
       <section class="section-block" aria-labelledby="why-heading">
@@ -98,7 +107,7 @@
 
       <section class="section-block" aria-labelledby="how-heading">
         <h2 id="how-heading">How the council works</h2>
-        <p>Newstershire Council is made up of elected councillors, supported by council officers. Councillors set the policies and budget; officers deliver the day-to-day services.</p>
+        <p>Gloucestershire Council is made up of elected councillors, supported by council officers. Councillors set the policies and budget; officers deliver the day-to-day services.</p>
         <div class="info-grid">
           <div class="info-card">
             <h3>Full Council</h3>
@@ -152,7 +161,7 @@
           <li class="is-done"><span class="t-date">2024–2025</span><p class="t-body">Government invited Gloucestershire's councils to propose a single unitary authority, and the proposal was agreed.</p></li>
           <li class="is-done"><span class="t-date">2026</span><p class="t-body">Transition planning began, and residents had their say on services, priorities and the new council's name.</p></li>
           <li class="is-done"><span class="t-date">May 2027</span><p class="t-body">Shadow elections — residents elected the councillors who formed the new authority and oversaw the final year of transition.</p></li>
-          <li class="is-done"><span class="t-date">1 April 2028</span><p class="t-body">Vesting day — Newstershire Council formally went live. Gloucestershire County Council and the six district and borough councils were abolished.</p></li>
+          <li class="is-done"><span class="t-date">1 April 2028</span><p class="t-body">Vesting day — Gloucestershire Council formally went live. Gloucestershire County Council and the six district and borough councils were abolished.</p></li>
           <li><span class="t-date">2028 onwards</span><p class="t-body">Services are progressively brought onto one website, one phone line and one set of systems.</p></li>
         </ol>
       </section>
@@ -179,10 +188,10 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
         </div>
       </div>
       <div class="prefooter__newsletter">
@@ -201,7 +210,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="about.html#cabinet-heading">Councillors and committees</a></li>
@@ -241,7 +250,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. Councillor names, figures and dates on this page are illustrative.</p>
       </div>
     </div>

--- a/LGR/Consolidated/benefits-cost-of-living.html
+++ b/LGR/Consolidated/benefits-cost-of-living.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Cost of living & extra support – Benefits and support – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] Cost of living & extra support – Benefits and support – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
   <link rel="stylesheet" href="topic.css">
@@ -11,6 +12,14 @@
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -20,7 +29,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -37,7 +46,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -174,16 +183,16 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg>
           </a>
         </div>
@@ -204,7 +213,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
@@ -244,7 +253,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/benefits-housing-payments.html
+++ b/LGR/Consolidated/benefits-housing-payments.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Housing payments & crisis support – Benefits and support – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] Housing payments & crisis support – Benefits and support – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
   <link rel="stylesheet" href="topic.css">
@@ -11,6 +12,14 @@
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -20,7 +29,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -37,7 +46,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -167,16 +176,16 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg>
           </a>
         </div>
@@ -197,7 +206,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
@@ -237,7 +246,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/benefits-universal-credit.html
+++ b/LGR/Consolidated/benefits-universal-credit.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Universal Credit & Housing Benefit – Benefits and support – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] Universal Credit & Housing Benefit – Benefits and support – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
   <link rel="stylesheet" href="topic.css">
@@ -11,6 +12,14 @@
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -20,7 +29,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -37,7 +46,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -168,16 +177,16 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg>
           </a>
         </div>
@@ -198,7 +207,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
@@ -238,7 +247,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/benefits.html
+++ b/LGR/Consolidated/benefits.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Benefits and support – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] Benefits and support – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
   <link rel="stylesheet" href="topic.css">
@@ -11,6 +12,14 @@
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <!-- Top utility bar -->
   <div class="utility-bar">
@@ -21,7 +30,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -38,7 +47,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -155,16 +164,16 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg>
           </a>
         </div>
@@ -185,7 +194,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
@@ -226,7 +235,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/contact.html
+++ b/LGR/Consolidated/contact.html
@@ -3,13 +3,22 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Contact us – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] Contact us – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
 </head>
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -19,7 +28,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -36,7 +45,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -87,7 +96,7 @@
           </div>
           <div class="contact-card">
             <h3>Email</h3>
-            <p><a href="mailto:info@newstershire.gov.uk">info@newstershire.gov.uk</a></p>
+            <p><a href="mailto:info@gloucestershire.gov.uk">info@gloucestershire.gov.uk</a></p>
             <p>We aim to reply within 5 working days</p>
           </div>
           <div class="contact-card">
@@ -150,7 +159,7 @@
         <p>Our main offices are open by appointment. Please book before travelling — many enquiries can be resolved by phone or online without a visit.</p>
         <div class="contact-grid">
           <div class="contact-card">
-            <h3>Newstershire House (main office)</h3>
+            <h3>Gloucestershire House (main office)</h3>
             <p>1 Shire Way, Gloucester, GL1 1AA</p>
             <p>Mon–Fri, 9am–4:30pm, by appointment</p>
           </div>
@@ -219,15 +228,15 @@
         <div class="contact-grid">
           <div class="contact-card">
             <h3>Complaints &amp; feedback</h3>
-            <p><a href="mailto:feedback@newstershire.gov.uk">feedback@newstershire.gov.uk</a></p>
+            <p><a href="mailto:feedback@gloucestershire.gov.uk">feedback@gloucestershire.gov.uk</a></p>
           </div>
           <div class="contact-card">
             <h3>Freedom of Information</h3>
-            <p><a href="mailto:foi@newstershire.gov.uk">foi@newstershire.gov.uk</a></p>
+            <p><a href="mailto:foi@gloucestershire.gov.uk">foi@gloucestershire.gov.uk</a></p>
           </div>
           <div class="contact-card">
             <h3>Data protection</h3>
-            <p><a href="mailto:dpo@newstershire.gov.uk">dpo@newstershire.gov.uk</a></p>
+            <p><a href="mailto:dpo@gloucestershire.gov.uk">dpo@gloucestershire.gov.uk</a></p>
           </div>
         </div>
       </section>
@@ -240,10 +249,10 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
         </div>
       </div>
       <div class="prefooter__newsletter">
@@ -262,7 +271,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="about.html#cabinet-heading">Councillors and committees</a></li>
@@ -302,7 +311,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. Contact details on this page are illustrative.</p>
       </div>
     </div>

--- a/LGR/Consolidated/council-tax.html
+++ b/LGR/Consolidated/council-tax.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Council tax – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] Council tax – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
   <link rel="stylesheet" href="topic.css">
@@ -11,6 +12,14 @@
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <!-- Top utility bar -->
   <div class="utility-bar">
@@ -21,7 +30,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -38,7 +47,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -491,16 +500,16 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg>
           </a>
         </div>
@@ -521,7 +530,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
@@ -562,7 +571,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/county-adult-social-care.html
+++ b/LGR/Consolidated/county-adult-social-care.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Adult social care – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] Adult social care – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
   <link rel="stylesheet" href="topic.css">
@@ -11,6 +12,14 @@
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -20,7 +29,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -37,7 +46,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -145,10 +154,10 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
         </div>
       </div>
       <div class="prefooter__newsletter">
@@ -167,7 +176,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
@@ -211,7 +220,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/county-blue-badges.html
+++ b/LGR/Consolidated/county-blue-badges.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Blue Badges and concessionary travel – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] Blue Badges and concessionary travel – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
   <link rel="stylesheet" href="topic.css">
@@ -11,6 +12,14 @@
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -20,7 +29,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -37,7 +46,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -120,10 +129,10 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
         </div>
       </div>
       <div class="prefooter__newsletter">
@@ -142,7 +151,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
@@ -186,7 +195,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/county-childrens-services.html
+++ b/LGR/Consolidated/county-childrens-services.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Children, young people and families – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] Children, young people and families – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
   <link rel="stylesheet" href="topic.css">
@@ -11,6 +12,14 @@
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -20,7 +29,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -37,7 +46,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -81,7 +90,7 @@
       </div>
 
       <div class="ct-block ct-block--common">
-        <p>Newstershire Council is the statutory children's services authority for the county — responsible for safeguarding, social care, and support for children, young people and families. Ofsted currently rates the service 'Good' with 'Outstanding' elements.</p>
+        <p>Gloucestershire Council is the statutory children's services authority for the county — responsible for safeguarding, social care, and support for children, young people and families. Ofsted currently rates the service 'Good' with 'Outstanding' elements.</p>
 
         <h3>If you're worried about a child</h3>
         <p><strong>Children and Families Front Door Service:</strong> 01452 426565, select option 2. Monday–Friday, 9am–5pm. This is the main route for reporting a welfare concern, or checking whether a child or family might be eligible for support.</p>
@@ -134,10 +143,10 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
         </div>
       </div>
       <div class="prefooter__newsletter">
@@ -156,7 +165,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
@@ -200,7 +209,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/county-highways.html
+++ b/LGR/Consolidated/county-highways.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Highways and roads – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] Highways and roads – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
   <link rel="stylesheet" href="topic.css">
@@ -11,6 +12,14 @@
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -20,7 +29,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -37,7 +46,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -81,7 +90,7 @@
       </div>
 
       <div class="ct-block ct-block--common">
-        <p>Newstershire Council is the highway authority for the whole county — one service covering all the former district and city areas the same way. Day-to-day maintenance is delivered by contractor Ringway, under a Term Maintenance Contract that began in April 2019 for an initial seven years and has since been extended for up to a further four, subject to performance targets. Average annual spend on highways maintenance runs at around £27 million; the extended contract is expected to be worth over £100 million in total.</p>
+        <p>Gloucestershire Council is the highway authority for the whole county — one service covering all the former district and city areas the same way. Day-to-day maintenance is delivered by contractor Ringway, under a Term Maintenance Contract that began in April 2019 for an initial seven years and has since been extended for up to a further four, subject to performance targets. Average annual spend on highways maintenance runs at around £27 million; the extended contract is expected to be worth over £100 million in total.</p>
 
         <h3>Reporting a problem</h3>
         <p><strong>Fix My Street</strong> is the single route for reporting potholes, damaged paving, faulty street lights, blocked drains and similar issues. It's taken over 35,000 reports since launch. You can sign up for email updates on the progress of your specific report.</p>
@@ -129,10 +138,10 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
         </div>
       </div>
       <div class="prefooter__newsletter">
@@ -151,7 +160,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
@@ -194,7 +203,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/county-libraries.html
+++ b/LGR/Consolidated/county-libraries.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Libraries – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] Libraries – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
   <link rel="stylesheet" href="topic.css">
@@ -11,6 +12,14 @@
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -20,7 +29,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -37,7 +46,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -81,7 +90,7 @@
       </div>
 
       <div class="ct-block ct-block--common">
-        <p>Newstershire Council runs 31 council libraries and a Digital Immersive Storytelling Centre, and supports a further eight volunteer-run community libraries — 32 buildings in total. In 2023/24, the service recorded around 1.5 million visits and around 1.5 million items borrowed, in person and online combined.</p>
+        <p>Gloucestershire Council runs 31 council libraries and a Digital Immersive Storytelling Centre, and supports a further eight volunteer-run community libraries — 32 buildings in total. In 2023/24, the service recorded around 1.5 million visits and around 1.5 million items borrowed, in person and online combined.</p>
 
         <h3>More than books</h3>
         <p>Libraries are treated as community spaces first, book-lending points second: accessible, safe, and offering activities, maker spaces and free digital equipment alongside the usual borrowing. Six libraries house "The Lab," high-tech spaces for digital innovation work with the public. Two libraries have recently moved into wider mixed-use developments — Stroud's is now inside the Five Valleys Shopping Centre, and Gloucester's is part of the University City Campus.</p>
@@ -130,10 +139,10 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
         </div>
       </div>
       <div class="prefooter__newsletter">
@@ -152,7 +161,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
@@ -196,7 +205,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/county-registrars.html
+++ b/LGR/Consolidated/county-registrars.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Registrars – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] Registrars – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
   <link rel="stylesheet" href="topic.css">
@@ -11,6 +12,14 @@
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -20,7 +29,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -37,7 +46,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -81,7 +90,7 @@
       </div>
 
       <div class="ct-block ct-block--common">
-        <p>Newstershire Council runs the county's statutory registration service — births, deaths, marriages, civil partnerships, citizenship ceremonies, and the historical indexes. Everything is by pre-booked appointment; there's no walk-in registration.</p>
+        <p>Gloucestershire Council runs the county's statutory registration service — births, deaths, marriages, civil partnerships, citizenship ceremonies, and the historical indexes. Everything is by pre-booked appointment; there's no walk-in registration.</p>
 
         <h3>Registering a birth</h3>
         <p>Births can only be registered in the district where they occurred, though information can be given at any register office in England or Wales and forwarded to the correct district. The baby doesn't need to attend — the hospital or health authority notifies the registrar directly.</p>
@@ -129,10 +138,10 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
         </div>
       </div>
       <div class="prefooter__newsletter">
@@ -151,7 +160,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
@@ -195,7 +204,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/county-school-admissions.html
+++ b/LGR/Consolidated/county-school-admissions.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>School admissions – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] School admissions – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
   <link rel="stylesheet" href="topic.css">
@@ -11,6 +12,14 @@
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -20,7 +29,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -37,7 +46,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -132,10 +141,10 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
         </div>
       </div>
       <div class="prefooter__newsletter">
@@ -154,7 +163,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
@@ -198,7 +207,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/housing-affordable.html
+++ b/LGR/Consolidated/housing-affordable.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Affordable housing – Housing – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] Affordable housing – Housing – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
   <link rel="stylesheet" href="topic.css">
@@ -11,6 +12,14 @@
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -20,7 +29,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -37,7 +46,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -164,16 +173,16 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg>
           </a>
         </div>
@@ -194,7 +203,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
@@ -235,7 +244,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/housing-homelessness.html
+++ b/LGR/Consolidated/housing-homelessness.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Homelessness – Housing – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] Homelessness – Housing – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
   <link rel="stylesheet" href="topic.css">
@@ -11,6 +12,14 @@
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -20,7 +29,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -37,7 +46,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -194,16 +203,16 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg>
           </a>
         </div>
@@ -224,7 +233,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
@@ -265,7 +274,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/housing-register.html
+++ b/LGR/Consolidated/housing-register.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Housing register – Housing – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] Housing register – Housing – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
   <link rel="stylesheet" href="topic.css">
@@ -11,6 +12,14 @@
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -20,7 +29,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -37,7 +46,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -180,16 +189,16 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg>
           </a>
         </div>
@@ -210,7 +219,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
@@ -251,7 +260,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/housing-supported.html
+++ b/LGR/Consolidated/housing-supported.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Supported &amp; sheltered housing – Housing – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] Supported &amp; sheltered housing – Housing – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
   <link rel="stylesheet" href="topic.css">
@@ -11,6 +12,14 @@
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -20,7 +29,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -37,7 +46,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -161,16 +170,16 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg>
           </a>
         </div>
@@ -191,7 +200,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
@@ -232,7 +241,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/housing.html
+++ b/LGR/Consolidated/housing.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Housing – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] Housing – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
   <link rel="stylesheet" href="topic.css">
@@ -11,6 +12,14 @@
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <!-- Top utility bar -->
   <div class="utility-bar">
@@ -21,7 +30,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -38,7 +47,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -161,16 +170,16 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg>
           </a>
         </div>
@@ -191,7 +200,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
@@ -232,7 +241,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/index.html
+++ b/LGR/Consolidated/index.html
@@ -3,13 +3,22 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
 </head>
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <!-- Top utility bar -->
   <div class="utility-bar">
@@ -20,7 +29,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -38,7 +47,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -61,8 +70,8 @@
   <section class="hero" aria-label="Welcome">
     <div class="container hero__inner">
       <div class="hero__text">
-        <h1 class="hero__title">Welcome to Newstershire Council</h1>
-        <p class="hero__sub"><strong>Newstershire Council is a new unitary authority.</strong> We've replaced Gloucestershire County Council and the six district and borough councils with one council for the whole county. While we bring everything together, some services still live on the former councils' websites.</p>
+        <h1 class="hero__title">Welcome to Gloucestershire Council</h1>
+        <p class="hero__sub"><strong>Gloucestershire Council is a new unitary authority.</strong> We've replaced Gloucestershire County Council and the six district and borough councils with one council for the whole county. While we bring everything together, some services still live on the former councils' websites.</p>
         <form class="hero-search" role="search" action="#services">
           <label for="site-search" class="hero-search__label">Search for a service</label>
           <div class="hero-search__row">
@@ -358,11 +367,11 @@
             </li>
             <li>
               <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-              <a href="mailto:info@newstershire.gov.uk">info@newstershire.gov.uk</a>
+              <a href="mailto:info@gloucestershire.gov.uk">info@gloucestershire.gov.uk</a>
             </li>
             <li>
               <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 10c0 7-9 13-9 13S3 17 3 10a9 9 0 0118 0z"/><circle cx="12" cy="10" r="3"/></svg>
-              <span>Newstershire House<br>1 Shire Way, Gloucester GL1 1AA</span>
+              <span>Gloucestershire House<br>1 Shire Way, Gloucester GL1 1AA</span>
             </li>
           </ul>
         </div>
@@ -378,16 +387,16 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg>
           </a>
         </div>
@@ -408,7 +417,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
@@ -449,7 +458,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/news-bins.html
+++ b/LGR/Consolidated/news-bins.html
@@ -3,13 +3,22 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Bins and recycling: what's changing – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] Bins and recycling: what's changing – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
 </head>
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -19,7 +28,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -36,7 +45,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -96,10 +105,10 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
         </div>
       </div>
       <div class="prefooter__newsletter">
@@ -118,7 +127,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="about.html#cabinet-heading">Councillors and committees</a></li>
@@ -158,7 +167,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. News articles on this page are illustrative.</p>
       </div>
     </div>

--- a/LGR/Consolidated/news-council-tax.html
+++ b/LGR/Consolidated/news-council-tax.html
@@ -3,13 +3,22 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Council tax: one bill, clearer support – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] Council tax: one bill, clearer support – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
 </head>
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -19,7 +28,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -36,7 +45,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -96,10 +105,10 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
         </div>
       </div>
       <div class="prefooter__newsletter">
@@ -118,7 +127,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="about.html#cabinet-heading">Councillors and committees</a></li>
@@ -158,7 +167,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. News articles on this page are illustrative.</p>
       </div>
     </div>

--- a/LGR/Consolidated/news-have-your-say.html
+++ b/LGR/Consolidated/news-have-your-say.html
@@ -3,13 +3,22 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Have your say on services for the new council – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] Have your say on services for the new council – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
 </head>
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -19,7 +28,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -36,7 +45,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -101,10 +110,10 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
         </div>
       </div>
       <div class="prefooter__newsletter">
@@ -123,7 +132,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="about.html#cabinet-heading">Councillors and committees</a></li>
@@ -163,7 +172,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. News articles on this page are illustrative.</p>
       </div>
     </div>

--- a/LGR/Consolidated/news-new-council.html
+++ b/LGR/Consolidated/news-new-council.html
@@ -3,13 +3,22 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>One council for Gloucestershire is now live – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] One council for Gloucestershire is now live – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
 </head>
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -19,7 +28,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -36,7 +45,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -80,7 +89,7 @@
       <p class="article-meta">Published 1 April 2028</p>
 
       <div class="article-body">
-        <p>Newstershire Council, the new single council for the whole of Gloucestershire, formally took over local services on <strong>1 April 2028</strong> — known as vesting day. From that date, one council is responsible for everything from adult social care and roads to bins, planning and council tax.</p>
+        <p>Gloucestershire Council, the new single council for the whole of Gloucestershire, formally took over local services on <strong>1 April 2028</strong> — known as vesting day. From that date, one council is responsible for everything from adult social care and roads to bins, planning and council tax.</p>
         <p>Residents don't need to do anything — bins are collected, bills are issued, and services run as usual through the changeover.</p>
         <h2>What's changing</h2>
         <p>Bringing seven councils together into one is intended to make services simpler to find and use. Over time, residents will have a single website, one phone number and one account for their council services, rather than needing to work out which organisation to contact.</p>
@@ -98,10 +107,10 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
         </div>
       </div>
       <div class="prefooter__newsletter">
@@ -120,7 +129,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="about.html#cabinet-heading">Councillors and committees</a></li>
@@ -160,7 +169,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. News articles on this page are illustrative.</p>
       </div>
     </div>

--- a/LGR/Consolidated/news-shadow-elections.html
+++ b/LGR/Consolidated/news-shadow-elections.html
@@ -3,13 +3,22 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Shadow elections: Newstershire's first councillors elected – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] Shadow elections: Gloucestershire's first councillors elected – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
 </head>
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -19,7 +28,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -36,7 +45,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -60,14 +69,14 @@
       <ol>
         <li><a href="index.html">Home</a></li>
         <li><a href="news.html">News</a></li>
-        <li aria-current="page">Shadow elections: Newstershire's first councillors elected</li>
+        <li aria-current="page">Shadow elections: Gloucestershire's first councillors elected</li>
       </ol>
     </div>
   </nav>
 
-  <section class="page-hero" aria-label="Shadow elections: Newstershire's first councillors elected">
+  <section class="page-hero" aria-label="Shadow elections: Gloucestershire's first councillors elected">
     <div class="container">
-      <h1 class="page-hero__title">Shadow elections: Newstershire's first councillors elected</h1>
+      <h1 class="page-hero__title">Shadow elections: Gloucestershire's first councillors elected</h1>
       <p class="page-hero__sub">Residents have elected the councillors who will form the new authority.</p>
     </div>
   </section>
@@ -95,10 +104,10 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
         </div>
       </div>
       <div class="prefooter__newsletter">
@@ -117,7 +126,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="about.html#cabinet-heading">Councillors and committees</a></li>
@@ -157,7 +166,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. News articles on this page are illustrative.</p>
       </div>
     </div>

--- a/LGR/Consolidated/news.html
+++ b/LGR/Consolidated/news.html
@@ -3,13 +3,22 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>News – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] News – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
 </head>
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -19,7 +28,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -36,7 +45,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -99,7 +108,7 @@
         </article>
         <article class="news-article-card">
           <time datetime="2027-05-07">7 May 2027</time>
-          <h2><a href="news-shadow-elections.html">Shadow elections: Newstershire's first councillors elected</a></h2>
+          <h2><a href="news-shadow-elections.html">Shadow elections: Gloucestershire's first councillors elected</a></h2>
           <p>Residents have elected the councillors who will form the new authority.</p>
         </article>
       </div>
@@ -113,10 +122,10 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
         </div>
       </div>
       <div class="prefooter__newsletter">
@@ -135,7 +144,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="about.html#cabinet-heading">Councillors and committees</a></li>
@@ -175,7 +184,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. News articles on this page are illustrative.</p>
       </div>
     </div>

--- a/LGR/Consolidated/planning-appeals.html
+++ b/LGR/Consolidated/planning-appeals.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Appeals – Planning – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] Appeals – Planning – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
   <link rel="stylesheet" href="topic.css">
@@ -11,6 +12,14 @@
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -20,7 +29,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -37,7 +46,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -164,16 +173,16 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg>
           </a>
         </div>
@@ -194,7 +203,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
@@ -235,7 +244,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/planning-decision.html
+++ b/LGR/Consolidated/planning-decision.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>How a decision is made – Planning – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] How a decision is made – Planning – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
   <link rel="stylesheet" href="topic.css">
@@ -11,6 +12,14 @@
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -20,7 +29,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -37,7 +46,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -172,16 +181,16 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg>
           </a>
         </div>
@@ -202,7 +211,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
@@ -243,7 +252,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/planning-fees.html
+++ b/LGR/Consolidated/planning-fees.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Fees and charges – Planning – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] Fees and charges – Planning – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
   <link rel="stylesheet" href="topic.css">
@@ -11,6 +12,14 @@
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -20,7 +29,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -37,7 +46,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -165,16 +174,16 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg>
           </a>
         </div>
@@ -195,7 +204,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
@@ -236,7 +245,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/planning-how-to-apply.html
+++ b/LGR/Consolidated/planning-how-to-apply.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>How to apply – Planning – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] How to apply – Planning – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
   <link rel="stylesheet" href="topic.css">
@@ -11,6 +12,14 @@
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -20,7 +29,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -37,7 +46,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -177,16 +186,16 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg>
           </a>
         </div>
@@ -207,7 +216,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
@@ -248,7 +257,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/planning-local-plan.html
+++ b/LGR/Consolidated/planning-local-plan.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>The Local Plan – Planning – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] The Local Plan – Planning – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
   <link rel="stylesheet" href="topic.css">
@@ -11,6 +12,14 @@
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -20,7 +29,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -37,7 +46,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -161,16 +170,16 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg>
           </a>
         </div>
@@ -191,7 +200,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
@@ -232,7 +241,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/planning.html
+++ b/LGR/Consolidated/planning.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Planning – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] Planning – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
   <link rel="stylesheet" href="topic.css">
@@ -11,6 +12,14 @@
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <!-- Top utility bar -->
   <div class="utility-bar">
@@ -21,7 +30,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -38,7 +47,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -166,16 +175,16 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg>
           </a>
         </div>
@@ -196,7 +205,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
@@ -237,7 +246,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/waste-bulky.html
+++ b/LGR/Consolidated/waste-bulky.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Bulky waste and recycling centres – Bins and recycling – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] Bulky waste and recycling centres – Bins and recycling – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
   <link rel="stylesheet" href="topic.css">
@@ -11,6 +12,14 @@
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -20,7 +29,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -37,7 +46,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -169,16 +178,16 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg>
           </a>
         </div>
@@ -199,7 +208,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
@@ -240,7 +249,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/waste-food-waste.html
+++ b/LGR/Consolidated/waste-food-waste.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Food waste – Bins and recycling – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] Food waste – Bins and recycling – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
   <link rel="stylesheet" href="topic.css">
@@ -11,6 +12,14 @@
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -20,7 +29,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -37,7 +46,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -163,16 +172,16 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg>
           </a>
         </div>
@@ -193,7 +202,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
@@ -234,7 +243,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/waste-garden-waste.html
+++ b/LGR/Consolidated/waste-garden-waste.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Garden waste – Bins and recycling – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] Garden waste – Bins and recycling – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
   <link rel="stylesheet" href="topic.css">
@@ -11,6 +12,14 @@
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -20,7 +29,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -37,7 +46,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -162,16 +171,16 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg>
           </a>
         </div>
@@ -192,7 +201,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
@@ -233,7 +242,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/waste-general-waste.html
+++ b/LGR/Consolidated/waste-general-waste.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>General waste – Bins and recycling – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] General waste – Bins and recycling – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
   <link rel="stylesheet" href="topic.css">
@@ -11,6 +12,14 @@
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -20,7 +29,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -37,7 +46,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -176,16 +185,16 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg>
           </a>
         </div>
@@ -206,7 +215,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
@@ -247,7 +256,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/waste-recycling-centres.html
+++ b/LGR/Consolidated/waste-recycling-centres.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Household Recycling Centres – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] Household Recycling Centres – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
   <link rel="stylesheet" href="topic.css">
@@ -11,6 +12,14 @@
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -20,7 +29,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -37,7 +46,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -84,7 +93,7 @@
       </div>
 
       <div class="ct-block ct-block--common">
-        <p>Newstershire Council is the Waste Disposal Authority for the county — a different role to kerbside bin collection, which is covered on the <a href="waste.html">bins and recycling</a> pages. It runs the county's Household Recycling Centres, branded Gloucestershire Recycles.</p>
+        <p>Gloucestershire Council is the Waste Disposal Authority for the county — a different role to kerbside bin collection, which is covered on the <a href="waste.html">bins and recycling</a> pages. It runs the county's Household Recycling Centres, branded Gloucestershire Recycles.</p>
 
         <h3>Book before you go</h3>
         <p>Every visit — car or van — needs a booking made in advance online. This isn't a suggestion; you can be turned away without one. It keeps queues and congestion down and makes the sites safer. With over 10,000 bookings a week across the five sites, there isn't capacity to take bookings by phone as standard. If you genuinely can't book online, and nobody can book on your behalf, there's a phone line: 01452 596 626, weekdays 9am–5pm.</p>
@@ -125,10 +134,10 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
         </div>
       </div>
       <div class="prefooter__newsletter">
@@ -147,7 +156,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
@@ -188,7 +197,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/waste-recycling.html
+++ b/LGR/Consolidated/waste-recycling.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Recycling – Bins and recycling – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] Recycling – Bins and recycling – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
   <link rel="stylesheet" href="topic.css">
@@ -11,6 +12,14 @@
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -20,7 +29,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -37,7 +46,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -168,16 +177,16 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg>
           </a>
         </div>
@@ -198,7 +207,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
@@ -239,7 +248,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Consolidated/waste.html
+++ b/LGR/Consolidated/waste.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Bins and recycling – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] Bins and recycling – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
   <link rel="stylesheet" href="topic.css">
@@ -11,6 +12,14 @@
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <!-- Top utility bar -->
   <div class="utility-bar">
@@ -21,7 +30,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -38,7 +47,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -173,16 +182,16 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg>
           </a>
         </div>
@@ -203,7 +212,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
@@ -244,7 +253,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/README.md
+++ b/LGR/README.md
@@ -1,7 +1,11 @@
 # LGR proofs of concept
 
-Two variations on a post-reorganisation website for a new unitary council
-("Newstershire Council"). They share one brand and look identical — the
+> **Test site** — these are prototypes produced for local government
+> reorganisation planning. They are **not** live Gloucestershire Council
+> websites; content, services and contact details are placeholders.
+
+Two variations on a post-reorganisation website for the new unitary council
+("Gloucestershire Council"). They share one brand and look identical — the
 difference is how much content has moved across:
 
 - **Veneer/** — a thin front door. The home page asks where you live and

--- a/LGR/Veneer/README.md
+++ b/LGR/Veneer/README.md
@@ -1,8 +1,9 @@
 # Veneer proof of concept
 
-A proof-of-concept website for a new unitary council after local government
+A proof-of-concept website for the new unitary council after local government
 reorganisation, branded to the usual local government standards — called
-Newstershire Council for now.
+Gloucestershire Council. This is a test site, not a live service; every page
+carries a test-site banner and placeholder contact details.
 
 Requirements:
 

--- a/LGR/Veneer/about.html
+++ b/LGR/Veneer/about.html
@@ -3,13 +3,22 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>About the council – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] About the council – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
 </head>
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -19,7 +28,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -36,7 +45,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -74,7 +83,7 @@
   <main id="main-content">
     <div class="container page-body">
 
-      <p class="lead">Newstershire Council is the new unitary authority for Gloucestershire. On 1 April 2028 — vesting day — it brought together Gloucestershire County Council and the six district and borough councils into a single council responsible for every local government service across the county, from adult social care and roads to bins, planning and council tax.</p>
+      <p class="lead">Gloucestershire Council is the new unitary authority for Gloucestershire. On 1 April 2028 — vesting day — it brought together Gloucestershire County Council and the six district and borough councils into a single council responsible for every local government service across the county, from adult social care and roads to bins, planning and council tax.</p>
       <p>One council means one place to find services, one phone number to call, and one organisation accountable for getting things right — while keeping decisions as close as possible to the communities they affect.</p>
       <p>We are still bringing everything together. While that happens, some services are still delivered through the former councils' websites — the tool on our <a href="index.html">home page</a> asks where you live and takes you straight to the right one.</p>
 
@@ -99,7 +108,7 @@
 
       <section class="section-block" aria-labelledby="how-heading">
         <h2 id="how-heading">How the council works</h2>
-        <p>Newstershire Council is made up of elected councillors, supported by council officers. Councillors set the policies and budget; officers deliver the day-to-day services.</p>
+        <p>Gloucestershire Council is made up of elected councillors, supported by council officers. Councillors set the policies and budget; officers deliver the day-to-day services.</p>
         <div class="info-grid">
           <div class="info-card">
             <h3>Full Council</h3>
@@ -153,7 +162,7 @@
           <li class="is-done"><span class="t-date">2024–2025</span><p class="t-body">Government invited Gloucestershire's councils to propose a single unitary authority, and the proposal was agreed.</p></li>
           <li class="is-done"><span class="t-date">2026</span><p class="t-body">Transition planning began, and residents had their say on services, priorities and the new council's name.</p></li>
           <li class="is-done"><span class="t-date">May 2027</span><p class="t-body">Shadow elections — residents elected the councillors who formed the new authority and oversaw the final year of transition.</p></li>
-          <li class="is-done"><span class="t-date">1 April 2028</span><p class="t-body">Vesting day — Newstershire Council formally went live. Gloucestershire County Council and the six district and borough councils were abolished.</p></li>
+          <li class="is-done"><span class="t-date">1 April 2028</span><p class="t-body">Vesting day — Gloucestershire Council formally went live. Gloucestershire County Council and the six district and borough councils were abolished.</p></li>
           <li><span class="t-date">2028 onwards</span><p class="t-body">Services are progressively brought onto one website, one phone line and one set of systems.</p></li>
         </ol>
       </section>
@@ -180,10 +189,10 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
         </div>
       </div>
       <div class="prefooter__newsletter">
@@ -202,7 +211,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="about.html#cabinet-heading">Councillors and committees</a></li>
@@ -242,7 +251,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. Councillor names, figures and dates on this page are illustrative.</p>
       </div>
     </div>

--- a/LGR/Veneer/contact.html
+++ b/LGR/Veneer/contact.html
@@ -3,13 +3,22 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Contact us – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] Contact us – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
 </head>
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -19,7 +28,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -36,7 +45,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -87,7 +96,7 @@
           </div>
           <div class="contact-card">
             <h3>Email</h3>
-            <p><a href="mailto:info@newstershire.gov.uk">info@newstershire.gov.uk</a></p>
+            <p><a href="mailto:info@gloucestershire.gov.uk">info@gloucestershire.gov.uk</a></p>
             <p>We aim to reply within 5 working days</p>
           </div>
           <div class="contact-card">
@@ -117,7 +126,7 @@
         <p>Our main offices are open by appointment. Please book before travelling — many enquiries can be resolved by phone or online without a visit.</p>
         <div class="contact-grid">
           <div class="contact-card">
-            <h3>Newstershire House (main office)</h3>
+            <h3>Gloucestershire House (main office)</h3>
             <p>1 Shire Way, Gloucester, GL1 1AA</p>
             <p>Mon–Fri, 9am–4:30pm, by appointment</p>
           </div>
@@ -186,15 +195,15 @@
         <div class="contact-grid">
           <div class="contact-card">
             <h3>Complaints &amp; feedback</h3>
-            <p><a href="mailto:feedback@newstershire.gov.uk">feedback@newstershire.gov.uk</a></p>
+            <p><a href="mailto:feedback@gloucestershire.gov.uk">feedback@gloucestershire.gov.uk</a></p>
           </div>
           <div class="contact-card">
             <h3>Freedom of Information</h3>
-            <p><a href="mailto:foi@newstershire.gov.uk">foi@newstershire.gov.uk</a></p>
+            <p><a href="mailto:foi@gloucestershire.gov.uk">foi@gloucestershire.gov.uk</a></p>
           </div>
           <div class="contact-card">
             <h3>Data protection</h3>
-            <p><a href="mailto:dpo@newstershire.gov.uk">dpo@newstershire.gov.uk</a></p>
+            <p><a href="mailto:dpo@gloucestershire.gov.uk">dpo@gloucestershire.gov.uk</a></p>
           </div>
         </div>
       </section>
@@ -207,10 +216,10 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
         </div>
       </div>
       <div class="prefooter__newsletter">
@@ -229,7 +238,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="about.html#cabinet-heading">Councillors and committees</a></li>
@@ -269,7 +278,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. Contact details on this page are illustrative.</p>
       </div>
     </div>

--- a/LGR/Veneer/index.html
+++ b/LGR/Veneer/index.html
@@ -3,13 +3,22 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
 </head>
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <!-- Top utility bar -->
   <div class="utility-bar">
@@ -20,7 +29,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -38,7 +47,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -61,7 +70,7 @@
   <section class="hero" aria-label="Welcome">
     <div class="container hero__inner">
       <div class="hero__text">
-        <h1 class="hero__title">Welcome to Newstershire Council</h1>
+        <h1 class="hero__title">Welcome to Gloucestershire Council</h1>
         <p class="hero__sub">The new single council for the whole of Gloucestershire. Tell us where you live and we'll point you to the right website for the service you need.</p>
       </div>
       <div class="hero__stats" aria-label="Key figures">
@@ -94,7 +103,7 @@
             <path d="M10 6v4M10 14v.5" stroke="#1d4477" stroke-width="2" stroke-linecap="round"/>
           </svg>
           <p>
-            <strong>Newstershire Council is a new unitary authority.</strong> We've replaced Gloucestershire County Council and the six district and borough councils with one council for the whole county.
+            <strong>Gloucestershire Council is a new unitary authority.</strong> We've replaced Gloucestershire County Council and the six district and borough councils with one council for the whole county.
             While we bring everything together, some services still live on the former councils' websites — the finder below points you to the right website.
           </p>
         </div>
@@ -310,11 +319,11 @@
             </li>
             <li>
               <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-              <a href="mailto:info@newstershire.gov.uk">info@newstershire.gov.uk</a>
+              <a href="mailto:info@gloucestershire.gov.uk">info@gloucestershire.gov.uk</a>
             </li>
             <li>
               <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 10c0 7-9 13-9 13S3 17 3 10a9 9 0 0118 0z"/><circle cx="12" cy="10" r="3"/></svg>
-              <span>Newstershire House<br>1 Shire Way, Gloucester GL1 1AA</span>
+              <span>Gloucestershire House<br>1 Shire Way, Gloucester GL1 1AA</span>
             </li>
           </ul>
         </div>
@@ -330,16 +339,16 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg>
           </a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube">
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube">
             <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg>
           </a>
         </div>
@@ -360,7 +369,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="#">Councillors and committees</a></li>
@@ -400,7 +409,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service.</p>
       </div>
     </div>

--- a/LGR/Veneer/news-bins.html
+++ b/LGR/Veneer/news-bins.html
@@ -3,13 +3,22 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Bins and recycling: what's changing – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] Bins and recycling: what's changing – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
 </head>
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -19,7 +28,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -36,7 +45,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -96,10 +105,10 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
         </div>
       </div>
       <div class="prefooter__newsletter">
@@ -118,7 +127,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="about.html#cabinet-heading">Councillors and committees</a></li>
@@ -158,7 +167,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. News articles on this page are illustrative.</p>
       </div>
     </div>

--- a/LGR/Veneer/news-council-tax.html
+++ b/LGR/Veneer/news-council-tax.html
@@ -3,13 +3,22 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Council tax: one bill, clearer support – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] Council tax: one bill, clearer support – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
 </head>
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -19,7 +28,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -36,7 +45,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -96,10 +105,10 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
         </div>
       </div>
       <div class="prefooter__newsletter">
@@ -118,7 +127,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="about.html#cabinet-heading">Councillors and committees</a></li>
@@ -158,7 +167,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. News articles on this page are illustrative.</p>
       </div>
     </div>

--- a/LGR/Veneer/news-have-your-say.html
+++ b/LGR/Veneer/news-have-your-say.html
@@ -3,13 +3,22 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Have your say on services for the new council – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] Have your say on services for the new council – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
 </head>
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -19,7 +28,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -36,7 +45,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -101,10 +110,10 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
         </div>
       </div>
       <div class="prefooter__newsletter">
@@ -123,7 +132,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="about.html#cabinet-heading">Councillors and committees</a></li>
@@ -163,7 +172,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. News articles on this page are illustrative.</p>
       </div>
     </div>

--- a/LGR/Veneer/news-new-council.html
+++ b/LGR/Veneer/news-new-council.html
@@ -3,13 +3,22 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>One council for Gloucestershire is now live – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] One council for Gloucestershire is now live – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
 </head>
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -19,7 +28,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -36,7 +45,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -80,7 +89,7 @@
       <p class="article-meta">Published 1 April 2028</p>
 
       <div class="article-body">
-        <p>Newstershire Council, the new single council for the whole of Gloucestershire, formally took over local services on <strong>1 April 2028</strong> — known as vesting day. From that date, one council is responsible for everything from adult social care and roads to bins, planning and council tax.</p>
+        <p>Gloucestershire Council, the new single council for the whole of Gloucestershire, formally took over local services on <strong>1 April 2028</strong> — known as vesting day. From that date, one council is responsible for everything from adult social care and roads to bins, planning and council tax.</p>
         <p>Residents don't need to do anything — bins are collected, bills are issued, and services run as usual through the changeover.</p>
         <h2>What's changing</h2>
         <p>Bringing seven councils together into one is intended to make services simpler to find and use. Over time, residents will have a single website, one phone number and one account for their council services, rather than needing to work out which organisation to contact.</p>
@@ -98,10 +107,10 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
         </div>
       </div>
       <div class="prefooter__newsletter">
@@ -120,7 +129,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="about.html#cabinet-heading">Councillors and committees</a></li>
@@ -160,7 +169,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. News articles on this page are illustrative.</p>
       </div>
     </div>

--- a/LGR/Veneer/news-shadow-elections.html
+++ b/LGR/Veneer/news-shadow-elections.html
@@ -3,13 +3,22 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Shadow elections: Newstershire's first councillors elected – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] Shadow elections: Gloucestershire's first councillors elected – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
 </head>
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -19,7 +28,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -36,7 +45,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -60,14 +69,14 @@
       <ol>
         <li><a href="index.html">Home</a></li>
         <li><a href="news.html">News</a></li>
-        <li aria-current="page">Shadow elections: Newstershire's first councillors elected</li>
+        <li aria-current="page">Shadow elections: Gloucestershire's first councillors elected</li>
       </ol>
     </div>
   </nav>
 
-  <section class="page-hero" aria-label="Shadow elections: Newstershire's first councillors elected">
+  <section class="page-hero" aria-label="Shadow elections: Gloucestershire's first councillors elected">
     <div class="container">
-      <h1 class="page-hero__title">Shadow elections: Newstershire's first councillors elected</h1>
+      <h1 class="page-hero__title">Shadow elections: Gloucestershire's first councillors elected</h1>
       <p class="page-hero__sub">Residents have elected the councillors who will form the new authority.</p>
     </div>
   </section>
@@ -95,10 +104,10 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
         </div>
       </div>
       <div class="prefooter__newsletter">
@@ -117,7 +126,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="about.html#cabinet-heading">Councillors and committees</a></li>
@@ -157,7 +166,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. News articles on this page are illustrative.</p>
       </div>
     </div>

--- a/LGR/Veneer/news.html
+++ b/LGR/Veneer/news.html
@@ -3,13 +3,22 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>News – Newstershire Council</title>
+  <meta name="robots" content="noindex, nofollow">
+  <title>[TEST] News – Gloucestershire Council</title>
   <link rel="stylesheet" href="../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'><circle cx='26' cy='26' r='26' fill='%231d4477'/><path d='M10 36 Q18 18 26 22 Q34 18 42 36 Z' fill='%23c8a951' opacity='.9'/><path d='M18 36 Q22 26 26 28 Q30 26 34 36 Z' fill='%23ffffff' opacity='.85'/></svg>">
 </head>
 <body>
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- Test-site banner: this prototype must not be mistaken for a live council website -->
+  <div class="test-banner" role="region" aria-label="Test site notice">
+    <div class="container test-banner__inner">
+      <strong class="test-banner__tag">Test site</strong>
+      <span class="test-banner__text">This is a prototype produced for local government reorganisation planning. It is <strong>not a live Gloucestershire Council website</strong> &mdash; content, services and contact details are placeholders for testing only.</span>
+    </div>
+  </div>
 
   <div class="utility-bar">
     <div class="container utility-bar__inner">
@@ -19,7 +28,7 @@
       </span>
       <span class="utility-bar__item">
         <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-        info@newstershire.gov.uk
+        info@gloucestershire.gov.uk
       </span>
       <span class="utility-bar__item">Mon–Fri 8:30am–5pm</span>
     </div>
@@ -36,7 +45,7 @@
             <rect x="23" y="36" width="6" height="5" rx="1" fill="#ffffff" opacity="0.7"/>
           </svg>
           <div>
-            <span class="org-name">Newstershire Council</span>
+            <span class="org-name">Gloucestershire Council</span>
             <span class="org-tagline">Serving Gloucestershire together</span>
           </div>
         </a>
@@ -99,7 +108,7 @@
         </article>
         <article class="news-article-card">
           <time datetime="2027-05-07">7 May 2027</time>
-          <h2><a href="news-shadow-elections.html">Shadow elections: Newstershire's first councillors elected</a></h2>
+          <h2><a href="news-shadow-elections.html">Shadow elections: Gloucestershire's first councillors elected</a></h2>
           <p>Residents have elected the councillors who will form the new authority.</p>
         </article>
       </div>
@@ -113,10 +122,10 @@
       <div class="prefooter__follow">
         <h2 class="prefooter__heading">Follow us</h2>
         <div class="follow-list">
-          <a href="#" class="follow-item" aria-label="Newstershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
-          <a href="#" class="follow-item" aria-label="Newstershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on X (Twitter)"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Facebook"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on Instagram"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
+          <a href="#" class="follow-item" aria-label="Gloucestershire Council on YouTube"><svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.495 6.205a3.007 3.007 0 00-2.088-2.088c-1.87-.501-9.396-.501-9.396-.501s-7.507-.01-9.396.501A3.007 3.007 0 00.527 6.205a31.247 31.247 0 00-.522 5.805 31.247 31.247 0 00.522 5.783 3.007 3.007 0 002.088 2.088c1.868.502 9.396.502 9.396.502s7.506 0 9.396-.502a3.007 3.007 0 002.088-2.088 31.247 31.247 0 00.5-5.783 31.247 31.247 0 00-.5-5.805zM9.609 15.601V8.408l6.264 3.602z"/></svg></a>
         </div>
       </div>
       <div class="prefooter__newsletter">
@@ -135,7 +144,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-col">
-          <h3 class="footer-col__title">About Newstershire</h3>
+          <h3 class="footer-col__title">About Gloucestershire</h3>
           <ul>
             <li><a href="about.html">About the council</a></li>
             <li><a href="about.html#cabinet-heading">Councillors and committees</a></li>
@@ -175,7 +184,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; 2028 Newstershire Council &mdash; A new unitary authority for Gloucestershire</p>
+        <p>&copy; 2028 Gloucestershire Council &mdash; A new unitary authority for Gloucestershire</p>
         <p class="footer-note">This is a proof-of-concept website produced as part of local government reorganisation planning. It is not a live service. News articles on this page are illustrative.</p>
       </div>
     </div>

--- a/LGR/style.css
+++ b/LGR/style.css
@@ -1,5 +1,6 @@
 /* =============================================
-   Newstershire Council – shared stylesheet
+   Gloucestershire Council – shared stylesheet
+   TEST SITE – proofs of concept only, not live.
    Used by both LGR proofs of concept (Veneer and
    Consolidated) so the two sites look identical.
    LGR brand palette / GOV.UK-influenced layout
@@ -80,6 +81,36 @@ a:hover { color: var(--blue-dark); }
   max-width: var(--max-w);
   margin: 0 auto;
   padding: 0 1.25rem;
+}
+
+/* =====================
+   Test-site banner
+   ===================== */
+.test-banner {
+  background: var(--gold-light);
+  border-bottom: 3px solid var(--gold);
+  color: var(--text);
+  font-size: 0.875rem;
+}
+
+.test-banner__inner {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  padding-top: 0.625rem;
+  padding-bottom: 0.625rem;
+}
+
+.test-banner__tag {
+  flex-shrink: 0;
+  background: var(--blue-dark);
+  color: var(--white);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 0.2rem 0.55rem;
+  border-radius: var(--radius);
 }
 
 /* =====================


### PR DESCRIPTION
## Summary

Rebrands the two LGR proof-of-concept sites (`LGR/Veneer` and `LGR/Consolidated`) from the fictional "Newstershire Council" to **Gloucestershire Council**, and adds clear signposting on every page that these are test prototypes, not live services.

## Changes

- **Rebrand**: "Newstershire Council" → "Gloucestershire Council" across all 48 HTML pages — titles, headers, hero copy, body content, footers and social link labels. Contact email/domain updated to `gloucestershire.gov.uk`. References to *Gloucestershire County Council* as one of the seven former councils are intentionally unchanged.
- **Test-site banner**: a persistent gold "TEST SITE" banner at the top of every page stating the prototype is not a live Gloucestershire Council website and that content and contact details are placeholders. Styled in the shared `LGR/style.css` using the existing brand palette.
- **Titles**: every page title prefixed with `[TEST]` so tabs and bookmarks flag it immediately.
- **Search engines**: `noindex, nofollow` robots meta tag added to every page so the prototypes can't be indexed if hosted publicly.
- **Docs**: `LGR/README.md` and `LGR/Veneer/README.md` updated for the new brand and test status.

## Verification

- Rendered both home pages in headless Chromium — banner, rebrand and layout confirmed visually.
- Confirmed zero remaining "Newstershire" references and full banner/robots-meta/title coverage across all 48 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZ8qBu3rZjQvxk1hD237fk

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZ8qBu3rZjQvxk1hD237fk)_