### PR TITLE
Add HCPH taxi licensing webpages and fix HTML routing in subfolders

### DIFF
--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   build_and_deploy_job:
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
@@ -26,3 +27,14 @@ jobs:
           app_location: "/" # Your app source code
           api_location: "" # Leave blank if no API
           output_location: "" # Static site — no build step, serve from app_location
+
+  close_pull_request_job:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    name: Close Pull Request Job
+    steps:
+      - name: Close Pull Request
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
+          action: "close"

--- a/Taxi website/Webpages/gcc-approved-garages.html
+++ b/Taxi website/Webpages/gcc-approved-garages.html
@@ -1,0 +1,563 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Approved vehicle testing garages — Gloucester City Council</title>
+<style>
+/* ══════════════════════════════════════════════════════════════
+   GCC LICENSING — SHARED STYLESHEET
+   GOV.UK Done With Intention
+   All pages: landing, driver, vehicle, operator
+   ══════════════════════════════════════════════════════════════ */
+
+:root {
+  /* Brand */
+  --blue:       #0054A4;
+  --hover:      #003E7B;
+  --deep:       #0B2E53;
+  --white:      #FFFFFF;
+  --grey:       #F3F2F1;
+  --grey2:      #E8E8E8;
+  --border:     #B1B4B6;
+  --border-dk:  #0B0C0C;
+  --divider:    #D8D8D8;
+  --text:       #0B0C0C;
+  --text2:      #505A5F;
+  --muted:      #6F777B;
+  --link:       #0054A4;
+  --focus:      #FFDD00;
+
+  /* Spacing */
+  --sp1:4px; --sp2:8px; --sp3:16px; --sp4:24px;
+  --sp5:32px; --sp6:48px; --sp7:64px;
+
+  /* Type scale — GOV.UK */
+  --t-xl:      2.25rem;   /* h1 desktop */
+  --t-xl-m:    1.875rem;  /* h1 mobile */
+  --t-section: 1.75rem;   /* h2 section headings */
+  --t-lg:      1.5rem;    /* h2 base */
+  --t-md:      1.125rem;  /* h3 */
+  --t-body:    1rem;
+  --t-sm:      .875rem;
+  --t-xs:      .75rem;
+
+  /* Line heights */
+  --lh-heading: 1.1;
+  --lh-body:    1.5;
+  --lh-tight:   1.4;
+
+  /* Components */
+  --btn-pad-v: 10px;
+  --touch:     44px;
+  --max:       1200px;
+}
+
+/* ── RESET ──────────────────────────────────────────────────── */
+*,*::before,*::after { box-sizing:border-box; margin:0; padding:0 }
+html { font-size:16px; scroll-behavior:smooth }
+body {
+  font-family:"GDS Transport",Arial,sans-serif;
+  font-size:var(--t-body);
+  line-height:var(--lh-body);
+  color:var(--text);
+  background:var(--white);
+  -webkit-font-smoothing:antialiased;
+}
+@media(prefers-reduced-motion:reduce){*{transition-duration:.01ms!important}}
+
+/* ── TYPOGRAPHY ─────────────────────────────────────────────── */
+h1 { font-size:var(--t-xl); line-height:var(--lh-heading); font-weight:700; margin-bottom:var(--sp2) }
+h2 { font-size:var(--t-lg); line-height:var(--lh-heading); font-weight:700; color:var(--deep); margin:0 0 var(--sp3) }
+h3 { font-size:var(--t-md); line-height:var(--lh-heading); font-weight:700; color:var(--text); margin:0 0 var(--sp2) }
+p  { font-size:var(--t-body); line-height:var(--lh-body); margin-bottom:var(--sp3) }
+p:last-child { margin-bottom:0 }
+a  { color:var(--link); text-decoration:underline; text-underline-offset:3px }
+a:hover { color:var(--hover) }
+a:visited { color:#4c2c92 }
+
+/* ── SECTION CAPTIONS (h2 variant) ─────────────────────────── */
+h2.section-caption {
+  font-size:var(--t-section);
+  font-weight:700;
+  color:var(--deep);
+  padding-left:var(--sp3);
+  border-left:5px solid var(--blue);
+  margin-top:var(--sp6);
+  margin-bottom:var(--sp4);
+  line-height:var(--lh-heading);
+}
+.pg-hdr + section h2.section-caption { margin-top:0 }
+
+/* ── FOCUS ──────────────────────────────────────────────────── */
+:focus-visible {
+  outline:3px solid var(--focus);
+  outline-offset:0;
+  background:var(--focus);
+  color:var(--text);
+  box-shadow:0 -2px var(--focus),0 4px var(--border-dk);
+}
+a:focus-visible { color:var(--text) }
+
+/* ── SKIP ───────────────────────────────────────────────────── */
+.skip {
+  position:absolute; top:-100px; left:var(--sp3);
+  background:var(--focus); color:var(--text);
+  padding:var(--sp2) var(--sp3); font-weight:700;
+  z-index:1000; text-decoration:none;
+}
+.skip:focus { top:var(--sp2) }
+
+/* ── HEADER ─────────────────────────────────────────────────── */
+.hdr { background:var(--deep); border-bottom:4px solid var(--blue) }
+.hdr-in {
+  max-width:var(--max); margin:0 auto;
+  padding:var(--sp3) var(--sp4);
+  display:flex; align-items:center; justify-content:space-between;
+}
+.logo { display:flex; align-items:center; gap:var(--sp2); text-decoration:none; color:var(--white) }
+.logo img { height:40px; width:auto }
+.logo-txt { font-size:var(--t-md); font-weight:700 }
+.hdr-nav { display:flex; gap:var(--sp3); list-style:none }
+.hdr-nav a {
+  color:rgba(255,255,255,.85); text-decoration:none;
+  font-size:var(--t-sm); padding:var(--sp1) var(--sp2);
+  min-height:var(--touch); display:flex; align-items:center;
+}
+.hdr-nav a:hover { color:var(--white); text-decoration:underline }
+
+/* ── SERVICE BAR ────────────────────────────────────────────── */
+.svc { background:var(--blue); padding:var(--sp2) var(--sp4) }
+.svc-in { max-width:var(--max); margin:0 auto; font-size:var(--t-sm); color:var(--white) }
+
+/* ── BREADCRUMB ─────────────────────────────────────────────── */
+.bc { background:var(--grey); border-bottom:1px solid var(--divider) }
+.bc-in { max-width:var(--max); margin:0 auto; padding:var(--sp2) var(--sp4) }
+.bc-list { list-style:none; display:flex; flex-wrap:wrap; gap:var(--sp1); font-size:var(--t-sm) }
+.bc-item { display:flex; align-items:center; gap:var(--sp1) }
+.bc-item+.bc-item::before { content:"›"; color:var(--muted) }
+.bc-item a { color:var(--link) }
+.bc-cur { color:var(--text2); font-weight:700 }
+
+/* ── PAGE LAYOUT ────────────────────────────────────────────── */
+.page { max-width:var(--max); margin:0 auto; padding:var(--sp5) var(--sp4) var(--sp7) }
+
+/* ── BACK LINK ──────────────────────────────────────────────── */
+.back {
+  display:inline-flex; align-items:center; gap:var(--sp1);
+  font-size:var(--t-sm); color:var(--link);
+  text-decoration:none; margin-bottom:var(--sp5);
+  min-height:var(--touch); padding:var(--sp1) 0;
+}
+.back::before {
+  content:""; display:inline-block; width:0; height:0;
+  border-top:5px solid transparent; border-bottom:5px solid transparent;
+  border-right:6px solid var(--link); margin-top:1px;
+}
+.back:hover { color:var(--hover) }
+.back:hover::before { border-right-color:var(--hover) }
+
+/* ── PAGE HEADER ────────────────────────────────────────────── */
+.pg-hdr { margin-bottom:var(--sp4) }
+.pg-lead { font-size:var(--t-md); color:var(--text2); line-height:var(--lh-tight); margin-top:var(--sp2) }
+
+/* ── TOGGLES ────────────────────────────────────────────────── */
+.toggles { display:flex; flex-direction:column; gap:var(--sp3); margin-bottom:var(--sp5) }
+.toggle-row { display:grid; grid-template-columns:160px auto; align-items:center; gap:var(--sp3) }
+.toggle-lbl { font-size:var(--t-sm); font-weight:700; color:var(--text2) }
+.toggle { display:inline-flex; border:2px solid var(--border-dk); overflow:hidden; width:fit-content }
+.tog-btn {
+  padding:var(--btn-pad-v) var(--sp4);
+  background:var(--white); color:var(--text);
+  border:none; border-right:1px solid var(--border);
+  font-size:var(--t-sm); font-weight:700;
+  cursor:pointer; min-height:var(--touch); min-width:140px;
+  font-family:inherit; transition:background .1s; text-align:center;
+}
+.tog-btn:last-child { border-right:none }
+.tog-btn:hover { background:var(--grey) }
+.tog-btn.active { background:var(--deep); color:var(--white) }
+
+/* ── ELIGIBILITY LIST ───────────────────────────────────────── */
+.elig-list { list-style:none; border-top:1px solid var(--divider) }
+.elig-item {
+  display:grid; grid-template-columns:28px 1fr; gap:var(--sp2);
+  padding:var(--sp3) 0; border-bottom:1px solid var(--divider);
+  font-size:var(--t-body); align-items:flex-start; line-height:var(--lh-body);
+}
+.elig-mark {
+  width:22px; height:22px; border-radius:50%;
+  background:var(--blue); color:var(--white);
+  display:flex; align-items:center; justify-content:center;
+  font-size:var(--t-xs); font-weight:700; flex-shrink:0; margin-top:2px;
+}
+.elig-note {
+  font-size:var(--t-body); color:var(--text2);
+  margin-top:var(--sp1); margin-bottom:0; line-height:var(--lh-tight);
+}
+
+/* ── BOOK BEFORE YOU APPLY ──────────────────────────────────── */
+.book-list { list-style:none; border-top:1px solid var(--divider) }
+.book-item {
+  display:grid; grid-template-columns:1fr auto;
+  align-items:center; gap:var(--sp3);
+  padding:var(--sp3) 0; border-bottom:1px solid var(--divider);
+}
+.book-title { font-size:var(--t-body); font-weight:700; color:var(--text); margin-bottom:2px }
+.book-desc { font-size:var(--t-body); color:var(--text2); margin:0; line-height:var(--lh-body) }
+.book-link {
+  display:inline-flex; align-items:center; gap:var(--sp1);
+  font-size:var(--t-body); font-weight:700;
+  color:var(--link); text-decoration:none; white-space:nowrap;
+}
+.book-link:hover { color:var(--hover); text-decoration:underline }
+.book-note { font-size:var(--t-body); color:var(--text2); white-space:nowrap }
+
+/* Expandable providers */
+.book-details { width:100%;grid-column:1/-1 }
+.book-summary-inline {
+  font-size:var(--t-sm); color:var(--link); cursor:pointer;
+  list-style:none; display:inline-flex; align-items:center; gap:var(--sp1);
+  padding:var(--sp2) 0; font-weight:700; min-height:var(--touch);
+}
+.book-summary-inline::-webkit-details-marker { display:none }
+.book-details-body {
+  font-size:var(--t-sm); padding:var(--sp2) 0 var(--sp2) var(--sp4);
+  border-left:3px solid var(--divider); margin-top:var(--sp1);
+  display:flex; flex-direction:column; gap:var(--sp2);
+}
+.book-provider {
+  display:flex; align-items:center; justify-content:space-between;
+  gap:var(--sp3); font-size:var(--t-body); color:var(--text2);
+}
+
+/* ── REQUIREMENT LIST (documents) ───────────────────────────── */
+.req-list { list-style:none; border-top:1px solid var(--divider) }
+.req-item {
+  border-left:5px solid var(--blue);
+  padding:var(--sp3) 0 var(--sp3) var(--sp4);
+  margin-bottom:var(--sp1);
+  border-bottom:1px solid var(--divider);
+}
+.req-item:last-of-type { border-bottom:none }
+/* req-item--fee removed — all req-items use consistent GCC blue border */
+.req-title { font-size:var(--t-body); font-weight:700; color:var(--text); margin-bottom:var(--sp1) }
+.req-desc { font-size:var(--t-body); color:var(--text2); margin:0; line-height:var(--lh-body) }
+
+/* ── INSET ──────────────────────────────────────────────────── */
+.inset {
+  border-left:5px solid var(--border);
+  padding:var(--sp2) var(--sp3); margin-top:var(--sp2);
+}
+.inset p { font-size:var(--t-body); color:var(--text2); line-height:var(--lh-tight); margin-bottom:var(--sp1) }
+.inset p:last-child { margin-bottom:0 }
+
+/* ── FEE TAGS ───────────────────────────────────────────────── */
+.fee-tag+.fee-tag { margin-left:var(--sp2) }
+.fee-tag {
+  display:inline-block; font-size:var(--t-body); font-weight:700;
+  color:var(--deep); background:var(--grey);
+  padding:3px 10px; border:1px solid var(--border); margin-top:var(--sp2);
+}
+.fee-label {
+  display:block; font-size:var(--t-xs); font-weight:700;
+  color:var(--muted); text-transform:uppercase; letter-spacing:.05em;
+  margin-top:var(--sp2); margin-bottom:var(--sp1);
+}
+
+/* ── GOV.UK DETAILS/SUMMARY ─────────────────────────────────── */
+.govuk-details { margin-top:var(--sp2) }
+.govuk-details summary {
+  font-size:var(--t-body); color:var(--link); cursor:pointer;
+  list-style:none; display:inline-flex; align-items:center; gap:var(--sp1);
+  padding:var(--sp2) 0; min-height:var(--touch); font-weight:700;
+}
+.govuk-details summary::-webkit-details-marker { display:none }
+.govuk-details summary::before { content:"▶"; font-size:.6875rem; transition:transform .15s }
+.govuk-details[open] summary::before { transform:rotate(90deg) }
+.govuk-details-body {
+  font-size:var(--t-body); color:var(--text2);
+  padding:var(--sp2) 0 var(--sp2) var(--sp4);
+  border-left:5px solid var(--border);
+  margin-top:var(--sp1); line-height:var(--lh-body);
+}
+.govuk-details-body p { margin-bottom:var(--sp2) }
+.govuk-details-body p:last-child { margin-bottom:0 }
+
+/* ── WARNING TEXT ───────────────────────────────────────────── */
+.govuk-warning {
+  display:flex; align-items:flex-start; gap:var(--sp2); margin-bottom:var(--sp4);
+}
+.govuk-warning-icon { font-size:1.5rem; font-weight:700; color:var(--text); flex-shrink:0; line-height:1; margin-top:2px }
+.govuk-warning-text { font-weight:700; font-size:var(--t-body); color:var(--text) }
+
+/* ── PH NOTE ────────────────────────────────────────────────── */
+.ph-note {
+  font-size:var(--t-body); color:var(--text2);
+  padding:var(--sp2) var(--sp3); background:var(--grey);
+  border-left:5px solid var(--blue);
+}
+
+/* ── CTA ────────────────────────────────────────────────────── */
+.cta-wrap { margin-top:var(--sp6); padding-top:var(--sp4); border-top:1px solid var(--divider) }
+.cta {
+  display:inline-flex; align-items:center; gap:var(--sp2);
+  background:var(--blue); color:var(--white);
+  padding:var(--btn-pad-v) var(--sp5);
+  font-size:var(--t-md); font-weight:700;
+  text-decoration:none; min-height:var(--touch);
+  cursor:pointer; font-family:inherit; transition:background .1s;
+}
+.cta:hover { background:var(--hover); color:var(--white); text-decoration:none }
+.cta:visited { color:var(--white) }
+.cta:focus-visible {
+  outline:3px solid var(--focus); outline-offset:0;
+  background:var(--focus); color:var(--text);
+  box-shadow:0 -2px var(--focus),0 4px var(--border-dk);
+}
+.cta-sub { margin-top:var(--sp3); font-size:var(--t-sm); color:var(--muted) }
+
+/* ── FOOTER ─────────────────────────────────────────────────── */
+.ftr { background:var(--deep); color:var(--white); padding:var(--sp5) var(--sp4) }
+.ftr-in { max-width:var(--max); margin:0 auto; display:grid; grid-template-columns:repeat(auto-fit,minmax(180px,1fr)); gap:var(--sp5) }
+.ftr-h { font-size:var(--t-xs); font-weight:700; text-transform:uppercase; letter-spacing:.06em; margin-bottom:var(--sp3) }
+.ftr-ul { list-style:none }
+.ftr-ul li { margin-bottom:var(--sp2) }
+.ftr-ul a { color:rgba(255,255,255,.75); font-size:var(--t-sm); text-decoration:underline }
+.ftr-ul a:hover { color:var(--white) }
+.ftr-bot {
+  max-width:var(--max); margin:var(--sp4) auto 0;
+  padding-top:var(--sp3); border-top:1px solid rgba(255,255,255,.12);
+  font-size:var(--t-xs); color:rgba(255,255,255,.45);
+  display:flex; justify-content:space-between; flex-wrap:wrap; gap:var(--sp2);
+}
+
+/* ── RESPONSIVE ─────────────────────────────────────────────── */
+@media(max-width:800px) {
+  .hdr-in,.bc-in,.svc-in,.page { padding-left:var(--sp3); padding-right:var(--sp3) }
+  .hdr-nav { display:none }
+  h1 { font-size:var(--t-xl-m) }
+  h2.section-caption { font-size:var(--t-lg) }
+  .toggle-row { grid-template-columns:1fr; gap:var(--sp1) }
+  .toggle { width:100% }
+  .tog-btn { min-width:0; flex:1 }
+  .book-item { grid-template-columns:1fr; gap:var(--sp2) }
+  .book-action { justify-self:start }
+}
+@media(max-width:480px) {
+  h1 { font-size:var(--t-lg) }
+  .cta { width:100%; justify-content:center }
+}
+@media(forced-colors:active) {
+  .cta,.elig-mark { border:2px solid ButtonText }
+  .req-item { border-left-color:ButtonText }
+}
+
+
+/* GARAGE PAGE SPECIFIC */
+.garage-grid {
+  list-style:none;
+  display:grid;
+  grid-template-columns:repeat(auto-fill, minmax(280px, 1fr));
+  gap:var(--sp4);
+  margin-bottom:var(--sp6);
+}
+.garage-card {
+  border:2px solid var(--border-dk);
+  padding:var(--sp4);
+  background:var(--white);
+}
+.garage-name {
+  font-size:var(--t-md);
+  font-weight:700;
+  color:var(--deep);
+  margin-bottom:var(--sp2);
+}
+.garage-address {
+  font-size:var(--t-body);
+  color:var(--text2);
+  margin-bottom:var(--sp1);
+}
+.garage-phone {
+  font-size:var(--t-body);
+  margin-bottom:var(--sp1);
+}
+.garage-notes {
+  font-size:var(--t-sm);
+  color:var(--muted);
+  margin-bottom:var(--sp2);
+}
+.garage-map-link {
+  display:inline-flex;
+  align-items:center;
+  gap:var(--sp1);
+  font-size:var(--t-sm);
+  font-weight:700;
+  color:var(--link);
+  text-decoration:none;
+  margin-top:var(--sp2);
+}
+.garage-map-link:hover {
+  color:var(--hover);
+  text-decoration:underline;
+}
+.page-note {
+  background:var(--grey);
+  border-left:5px solid var(--blue);
+  padding:var(--sp3) var(--sp4);
+  margin-bottom:var(--sp5);
+  font-size:var(--t-body);
+  color:var(--text2);
+}
+</style>
+</head>
+<body>
+
+<a href="#main-content" class="skip">Skip to main content</a>
+
+<header class="hdr" role="banner">
+  <div class="hdr-in">
+    <a href="/" class="logo" aria-label="Gloucester City Council — home">
+      <img src="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/templates/assets/GCC_logo.svg" alt="Gloucester City Council" style="filter:brightness(0) invert(1)">
+    </a>
+  </div>
+</header>
+
+<div class="svc"><div class="svc-in">Licensing &amp; regulations</div></div>
+
+<nav class="bc" aria-label="Breadcrumb">
+  <div class="bc-in"><ol class="bc-list">
+    <li class="bc-item"><a href="#">Home</a></li>
+    <li class="bc-item"><a href="#">Licensing &amp; regulations</a></li>
+    <li class="bc-item"><a href="gcc-hcph-landing.html">Hackney carriage and private hire</a></li>
+    <li class="bc-item"><a href="gcc-vehicle-licence.html">Vehicle licence</a></li>
+    <li class="bc-item"><span class="bc-cur" aria-current="page">Approved testing garages</span></li>
+  </ol></div>
+</nav>
+
+<main id="main-content">
+<div class="page">
+
+  <a href="gcc-vehicle-licence.html" class="back">Back</a>
+
+  <header class="pg-hdr">
+    <h1>Approved vehicle testing garages</h1>
+    <p class="pg-lead">Your vehicle must be inspected at one of these approved garages before you can apply for or renew a hackney carriage or private hire vehicle licence.</p>
+  </header>
+
+  <div class="page-note">
+    <p>The inspection certificate must be no more than 2 months old at the time of application. Last updated: June 2026.</p>
+  </div>
+
+  <ul class="garage-grid" aria-label="Approved testing garages">
+        <li class="garage-card">
+          <h3 class="garage-name">Auditechnik</h3>
+          <p class="garage-address">90 Bristol Road, Gloucester, GL1 5SQ</p>
+          <p class="garage-phone"><a href="tel:01452386580">01452 386580</a></p>
+          <a href="https://maps.google.com/?q=Auditechnik+90+Bristol+Road+Gloucester+GL1+5SQ" class="garage-map-link" target="_blank" rel="noopener">View on map <span aria-hidden="true">→</span></a>
+        </li>
+        <li class="garage-card">
+          <h3 class="garage-name">Hempstead Motor Centre Ltd</h3>
+          <p class="garage-address">Unit 2E, Sudmeadow Road, Gloucester, GL1 5HD</p>
+          <p class="garage-phone"><a href="tel:01452307367">01452 307367</a></p>
+          <a href="https://maps.google.com/?q=Hempstead+Motor+Centre+Ltd+Unit+2E+Sudmeadow+Road+Gloucester+GL1+5HD" class="garage-map-link" target="_blank" rel="noopener">View on map <span aria-hidden="true">→</span></a>
+        </li>
+        <li class="garage-card">
+          <h3 class="garage-name">Express Repairs</h3>
+          <p class="garage-address">Unit 14/15 Severnside Trading Estate, Sudmeadow Road, Gloucester</p>
+          <p class="garage-phone"><a href="tel:01452505599">01452 505599</a></p>
+          <a href="https://maps.google.com/?q=Express+Repairs+Unit+14/15+Severnside+Trading+Estate+Sudmeadow+Road+Gloucester" class="garage-map-link" target="_blank" rel="noopener">View on map <span aria-hidden="true">→</span></a>
+        </li>
+        <li class="garage-card">
+          <h3 class="garage-name">Autovalue 5 Ltd</h3>
+          <p class="garage-address">151 Bristol Road, Gloucester</p>
+          <p class="garage-phone"><a href="tel:01452501723">01452 501723</a></p>
+          <a href="https://maps.google.com/?q=Autovalue+5+Ltd+151+Bristol+Road+Gloucester" class="garage-map-link" target="_blank" rel="noopener">View on map <span aria-hidden="true">→</span></a>
+        </li>
+        <li class="garage-card">
+          <h3 class="garage-name">Just MOT's</h3>
+          <p class="garage-address">Severn Road, Gloucester</p>
+          <p class="garage-phone"><a href="tel:01452303828">01452 303828</a></p>
+          <a href="https://maps.google.com/?q=Just+MOT's+Severn+Road+Gloucester" class="garage-map-link" target="_blank" rel="noopener">View on map <span aria-hidden="true">→</span></a>
+        </li>
+        <li class="garage-card">
+          <h3 class="garage-name">Cedar Motor House</h3>
+          <p class="garage-address">Grove Court, Upton Hill, Upton St Leonards, Gloucester</p>
+          <p class="garage-phone"><a href="tel:01452617240">01452 617240</a></p>
+          <a href="https://maps.google.com/?q=Cedar+Motor+House+Grove+Court+Upton+Hill+Upton+St+Leonards+Gloucester" class="garage-map-link" target="_blank" rel="noopener">View on map <span aria-hidden="true">→</span></a>
+        </li>
+        <li class="garage-card">
+          <h3 class="garage-name">Auto Mech Services</h3>
+          <p class="garage-address">Eastbrook Road, Gloucester, GL4 3DB</p>
+          <p class="garage-phone"><a href="tel:01452380955">01452 380955</a></p>
+          <a href="https://maps.google.com/?q=Auto+Mech+Services+Eastbrook+Road+Gloucester+GL4+3DB" class="garage-map-link" target="_blank" rel="noopener">View on map <span aria-hidden="true">→</span></a>
+        </li>
+        <li class="garage-card">
+          <h3 class="garage-name">Whaddon Garage</h3>
+          <p class="garage-address">Stroud Road, Brookthorpe, Gloucester, GL4 0UG</p>
+          <p class="garage-phone"><a href="tel:01452813384">01452 813384</a></p>
+          <a href="https://maps.google.com/?q=Whaddon+Garage+Stroud+Road+Brookthorpe+Gloucester+GL4+0UG" class="garage-map-link" target="_blank" rel="noopener">View on map <span aria-hidden="true">→</span></a>
+        </li>
+        <li class="garage-card">
+          <h3 class="garage-name">Pritchard Motor Services</h3>
+          <p class="garage-address">22 Hempsted Lane, Gloucester, GL2 5JA</p>
+          <p class="garage-phone"><a href="tel:01452525254">01452 525254</a></p>
+          <a href="https://maps.google.com/?q=Pritchard+Motor+Services+22+Hempsted+Lane+Gloucester+GL2+5JA" class="garage-map-link" target="_blank" rel="noopener">View on map <span aria-hidden="true">→</span></a>
+        </li>
+        <li class="garage-card">
+          <h3 class="garage-name">Motus Commercials</h3>
+          <p class="garage-address">Spinnaker Road, Gloucester, GL2 5FD</p>
+          <p class="garage-phone"><a href="tel:01452508700">01452 508700</a></p>
+          <a href="https://maps.google.com/?q=Motus+Commercials+Spinnaker+Road+Gloucester+GL2+5FD" class="garage-map-link" target="_blank" rel="noopener">View on map <span aria-hidden="true">→</span></a>
+        </li>
+        <li class="garage-card">
+          <h3 class="garage-name">PDL MOT & Repairs</h3>
+          <p class="garage-address">Unit 4, 279 Bristol Road, Gloucester, GL2 5DD</p>
+          <p class="garage-phone"><a href="tel:01452524611">01452 524611</a></p>
+          <a href="https://maps.google.com/?q=PDL+MOT+&+Repairs+Unit+4+279+Bristol+Road+Gloucester+GL2+5DD" class="garage-map-link" target="_blank" rel="noopener">View on map <span aria-hidden="true">→</span></a>
+        </li>
+        <li class="garage-card">
+          <h3 class="garage-name">Ley-Dat Services</h3>
+          <p class="garage-address">Unit G5/G6, Innsworth Technology Park, Innsworth, Gloucester</p>
+          <p class="garage-phone"><a href="tel:01452731263">01452 731263</a></p>
+          <a href="https://maps.google.com/?q=Ley-Dat+Services+Unit+G5/G6+Innsworth+Technology+Park+Innsworth+Gloucester" class="garage-map-link" target="_blank" rel="noopener">View on map <span aria-hidden="true">→</span></a>
+        </li>
+        <li class="garage-card">
+          <h3 class="garage-name">123 Car & Commercial</h3>
+          <p class="garage-address">Chase Lane, Gloucester, GL4 6PH</p>
+          <p class="garage-phone"><a href="tel:01452306306">01452 306306</a></p>
+          <a href="https://maps.google.com/?q=123+Car+&+Commercial+Chase+Lane+Gloucester+GL4+6PH" class="garage-map-link" target="_blank" rel="noopener">View on map <span aria-hidden="true">→</span></a>
+        </li>
+  </ul>
+
+</div>
+</main>
+
+<footer class="ftr" role="contentinfo">
+  <div class="ftr-in">
+    <div>
+      <div class="ftr-h">Licensing</div>
+      <ul class="ftr-ul">
+        <li><a href="gcc-hcph-landing.html">Hackney carriage and private hire</a></li>
+        <li><a href="#">Premises licences</a></li>
+        <li><a href="#">Personal licences</a></li>
+      </ul>
+    </div>
+    <div>
+      <div class="ftr-h">About GCC</div>
+      <ul class="ftr-ul">
+        <li><a href="#">Accessibility statement</a></li>
+        <li><a href="#">Privacy notice</a></li>
+        <li><a href="#">Cookies</a></li>
+        <li><a href="#">Contact us</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="ftr-bot">
+    <span>© Gloucester City Council</span>
+    <span>Last updated: July 2026</span>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/Taxi website/Webpages/gcc-driver-licence.html
+++ b/Taxi website/Webpages/gcc-driver-licence.html
@@ -1,0 +1,706 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Driver licence — Gloucester City Council</title>
+<style>
+/* ══════════════════════════════════════════════════════════════
+   GCC LICENSING — SHARED STYLESHEET
+   GOV.UK Done With Intention
+   All pages: landing, driver, vehicle, operator
+   ══════════════════════════════════════════════════════════════ */
+
+:root {
+  /* Brand */
+  --blue:       #0054A4;
+  --hover:      #003E7B;
+  --deep:       #0B2E53;
+  --white:      #FFFFFF;
+  --grey:       #F3F2F1;
+  --grey2:      #E8E8E8;
+  --border:     #B1B4B6;
+  --border-dk:  #0B0C0C;
+  --divider:    #D8D8D8;
+  --text:       #0B0C0C;
+  --text2:      #505A5F;
+  --muted:      #6F777B;
+  --link:       #0054A4;
+  --focus:      #FFDD00;
+
+  /* Spacing */
+  --sp1:4px; --sp2:8px; --sp3:16px; --sp4:24px;
+  --sp5:32px; --sp6:48px; --sp7:64px;
+
+  /* Type scale — GOV.UK */
+  --t-xl:      2.25rem;   /* h1 desktop */
+  --t-xl-m:    1.875rem;  /* h1 mobile */
+  --t-section: 1.75rem;   /* h2 section headings */
+  --t-lg:      1.5rem;    /* h2 base */
+  --t-md:      1.125rem;  /* h3 */
+  --t-body:    1rem;
+  --t-sm:      .875rem;
+  --t-xs:      .75rem;
+
+  /* Line heights */
+  --lh-heading: 1.1;
+  --lh-body:    1.5;
+  --lh-tight:   1.4;
+
+  /* Components */
+  --btn-pad-v: 10px;
+  --touch:     44px;
+  --max:       1200px;
+}
+
+/* ── RESET ──────────────────────────────────────────────────── */
+*,*::before,*::after { box-sizing:border-box; margin:0; padding:0 }
+html { font-size:16px; scroll-behavior:smooth }
+body {
+  font-family:"GDS Transport",Arial,sans-serif;
+  font-size:var(--t-body);
+  line-height:var(--lh-body);
+  color:var(--text);
+  background:var(--white);
+  -webkit-font-smoothing:antialiased;
+}
+@media(prefers-reduced-motion:reduce){*{transition-duration:.01ms!important}}
+
+/* ── TYPOGRAPHY ─────────────────────────────────────────────── */
+h1 { font-size:var(--t-xl); line-height:var(--lh-heading); font-weight:700; margin-bottom:var(--sp2) }
+h2 { font-size:var(--t-lg); line-height:var(--lh-heading); font-weight:700; color:var(--deep); margin:0 0 var(--sp3) }
+h3 { font-size:var(--t-md); line-height:var(--lh-heading); font-weight:700; color:var(--text); margin:0 0 var(--sp2) }
+p  { font-size:var(--t-body); line-height:var(--lh-body); margin-bottom:var(--sp3) }
+p:last-child { margin-bottom:0 }
+a  { color:var(--link); text-decoration:underline; text-underline-offset:3px }
+a:hover { color:var(--hover) }
+a:visited { color:#4c2c92 }
+
+/* ── SECTION CAPTIONS (h2 variant) ─────────────────────────── */
+h2.section-caption {
+  font-size:var(--t-section);
+  font-weight:700;
+  color:var(--deep);
+  padding-left:var(--sp3);
+  border-left:5px solid var(--blue);
+  margin-top:var(--sp6);
+  margin-bottom:var(--sp4);
+  line-height:var(--lh-heading);
+}
+.pg-hdr + section h2.section-caption { margin-top:0 }
+
+/* ── FOCUS ──────────────────────────────────────────────────── */
+:focus-visible {
+  outline:3px solid var(--focus);
+  outline-offset:0;
+  background:var(--focus);
+  color:var(--text);
+  box-shadow:0 -2px var(--focus),0 4px var(--border-dk);
+}
+a:focus-visible { color:var(--text) }
+
+/* ── SKIP ───────────────────────────────────────────────────── */
+.skip {
+  position:absolute; top:-100px; left:var(--sp3);
+  background:var(--focus); color:var(--text);
+  padding:var(--sp2) var(--sp3); font-weight:700;
+  z-index:1000; text-decoration:none;
+}
+.skip:focus { top:var(--sp2) }
+
+/* ── HEADER ─────────────────────────────────────────────────── */
+.hdr { background:var(--deep); border-bottom:4px solid var(--blue) }
+.hdr-in {
+  max-width:var(--max); margin:0 auto;
+  padding:var(--sp3) var(--sp4);
+  display:flex; align-items:center; justify-content:space-between;
+}
+.logo { display:flex; align-items:center; gap:var(--sp2); text-decoration:none; color:var(--white) }
+.logo img { height:40px; width:auto }
+.logo-txt { font-size:var(--t-md); font-weight:700 }
+.hdr-nav { display:flex; gap:var(--sp3); list-style:none }
+.hdr-nav a {
+  color:rgba(255,255,255,.85); text-decoration:none;
+  font-size:var(--t-sm); padding:var(--sp1) var(--sp2);
+  min-height:var(--touch); display:flex; align-items:center;
+}
+.hdr-nav a:hover { color:var(--white); text-decoration:underline }
+
+/* ── SERVICE BAR ────────────────────────────────────────────── */
+.svc { background:var(--blue); padding:var(--sp2) var(--sp4) }
+.svc-in { max-width:var(--max); margin:0 auto; font-size:var(--t-sm); color:var(--white) }
+
+/* ── BREADCRUMB ─────────────────────────────────────────────── */
+.bc { background:var(--grey); border-bottom:1px solid var(--divider) }
+.bc-in { max-width:var(--max); margin:0 auto; padding:var(--sp2) var(--sp4) }
+.bc-list { list-style:none; display:flex; flex-wrap:wrap; gap:var(--sp1); font-size:var(--t-sm) }
+.bc-item { display:flex; align-items:center; gap:var(--sp1) }
+.bc-item+.bc-item::before { content:"›"; color:var(--muted) }
+.bc-item a { color:var(--link) }
+.bc-cur { color:var(--text2); font-weight:700 }
+
+/* ── PAGE LAYOUT ────────────────────────────────────────────── */
+.page { max-width:var(--max); margin:0 auto; padding:var(--sp5) var(--sp4) var(--sp7) }
+
+/* ── BACK LINK ──────────────────────────────────────────────── */
+.back {
+  display:inline-flex; align-items:center; gap:var(--sp1);
+  font-size:var(--t-sm); color:var(--link);
+  text-decoration:none; margin-bottom:var(--sp5);
+  min-height:var(--touch); padding:var(--sp1) 0;
+}
+.back::before {
+  content:""; display:inline-block; width:0; height:0;
+  border-top:5px solid transparent; border-bottom:5px solid transparent;
+  border-right:6px solid var(--link); margin-top:1px;
+}
+.back:hover { color:var(--hover) }
+.back:hover::before { border-right-color:var(--hover) }
+
+/* ── PAGE HEADER ────────────────────────────────────────────── */
+.pg-hdr { margin-bottom:var(--sp4) }
+.pg-lead { font-size:var(--t-md); color:var(--text2); line-height:var(--lh-tight); margin-top:var(--sp2) }
+
+/* ── TOGGLES ────────────────────────────────────────────────── */
+.toggles { display:flex; flex-direction:column; gap:var(--sp3); margin-bottom:var(--sp5) }
+.toggle-row { display:grid; grid-template-columns:160px auto; align-items:center; gap:var(--sp3) }
+.toggle-lbl { font-size:var(--t-sm); font-weight:700; color:var(--text2) }
+.toggle { display:inline-flex; border:2px solid var(--border-dk); overflow:hidden; width:fit-content }
+.tog-btn {
+  padding:var(--btn-pad-v) var(--sp4);
+  background:var(--white); color:var(--text);
+  border:none; border-right:1px solid var(--border);
+  font-size:var(--t-sm); font-weight:700;
+  cursor:pointer; min-height:var(--touch); min-width:140px;
+  font-family:inherit; transition:background .1s; text-align:center;
+}
+.tog-btn:last-child { border-right:none }
+.tog-btn:hover { background:var(--grey) }
+.tog-btn.active { background:var(--deep); color:var(--white) }
+
+/* ── ELIGIBILITY LIST ───────────────────────────────────────── */
+.elig-list { list-style:none }
+.elig-item {
+  display:grid; grid-template-columns:28px 1fr; gap:var(--sp2);
+  padding:var(--sp3) 0; border-bottom:1px solid var(--divider);
+  border-top:1px solid var(--divider); margin-top:-1px;
+  font-size:var(--t-body); align-items:flex-start; line-height:var(--lh-body);
+}
+.elig-mark {
+  width:22px; height:22px; border-radius:50%;
+  background:var(--blue); color:var(--white);
+  display:flex; align-items:center; justify-content:center;
+  font-size:var(--t-xs); font-weight:700; flex-shrink:0; margin-top:2px;
+}
+.elig-note {
+  font-size:var(--t-body); color:var(--text2);
+  margin-top:var(--sp1); margin-bottom:0; line-height:var(--lh-tight);
+}
+
+/* ── BOOK BEFORE YOU APPLY ──────────────────────────────────── */
+.book-list { list-style:none; border-top:1px solid var(--divider) }
+.book-item {
+  display:grid; grid-template-columns:1fr auto;
+  align-items:center; gap:var(--sp3);
+  padding:var(--sp3) 0; border-bottom:1px solid var(--divider);
+}
+.book-title { font-size:var(--t-body); font-weight:700; color:var(--text); margin-bottom:2px }
+.book-desc { font-size:var(--t-body); color:var(--text2); margin:0; line-height:var(--lh-body) }
+.book-link {
+  display:inline-flex; align-items:center; gap:var(--sp1);
+  font-size:var(--t-body); font-weight:700;
+  color:var(--link); text-decoration:none; white-space:nowrap;
+}
+.book-link:hover { color:var(--hover); text-decoration:underline }
+.book-note { font-size:var(--t-body); color:var(--text2); white-space:nowrap }
+
+/* Expandable providers */
+.book-details { width:100%;grid-column:1/-1 }
+.book-summary-inline {
+  font-size:var(--t-sm); color:var(--link); cursor:pointer;
+  list-style:none; display:inline-flex; align-items:center; gap:var(--sp1);
+  padding:var(--sp2) 0; font-weight:700; min-height:var(--touch);
+}
+.book-summary-inline::-webkit-details-marker { display:none }
+.book-details-body {
+  font-size:var(--t-sm); padding:var(--sp2) 0 var(--sp2) var(--sp4);
+  border-left:3px solid var(--divider); margin-top:var(--sp1);
+  display:flex; flex-direction:column; gap:var(--sp2);
+}
+.book-provider {
+  display:flex; align-items:center; justify-content:space-between;
+  gap:var(--sp3); font-size:var(--t-body); color:var(--text2);
+}
+
+/* ── REQUIREMENT LIST (documents) ───────────────────────────── */
+.req-list { list-style:none; border-top:1px solid var(--divider) }
+.req-item {
+  border-left:5px solid var(--blue);
+  padding:var(--sp3) 0 var(--sp3) var(--sp4);
+  margin-bottom:var(--sp1);
+  border-bottom:1px solid var(--divider);
+}
+.req-item:last-of-type { border-bottom:none }
+/* req-item--fee removed */
+.req-title { font-size:var(--t-body); font-weight:700; color:var(--text); margin-bottom:var(--sp1) }
+.req-desc { font-size:var(--t-body); color:var(--text2); margin:0; line-height:var(--lh-body) }
+
+/* ── INSET ──────────────────────────────────────────────────── */
+.inset {
+  border-left:5px solid var(--border);
+  padding:var(--sp2) var(--sp3); margin-top:var(--sp2);
+}
+.inset p { font-size:var(--t-body); color:var(--text2); line-height:var(--lh-tight); margin-bottom:var(--sp1) }
+.inset p:last-child { margin-bottom:0 }
+
+/* ── FEE TAGS ───────────────────────────────────────────────── */
+.fee-tag+.fee-tag { margin-left:var(--sp2) }
+.fee-tag {
+  display:inline-block; font-size:var(--t-body); font-weight:700;
+  color:var(--deep); background:var(--grey);
+  padding:3px 10px; border:1px solid var(--border); margin-top:var(--sp2);
+}
+.fee-label {
+  display:block; font-size:var(--t-xs); font-weight:700;
+  color:var(--muted); text-transform:uppercase; letter-spacing:.05em;
+  margin-top:var(--sp2); margin-bottom:var(--sp1);
+}
+
+/* ── GOV.UK DETAILS/SUMMARY ─────────────────────────────────── */
+.govuk-details { margin-top:var(--sp2) }
+.govuk-details summary {
+  font-size:var(--t-body); color:var(--link); cursor:pointer;
+  list-style:none; display:inline-flex; align-items:center; gap:var(--sp1);
+  padding:var(--sp2) 0; min-height:var(--touch); font-weight:700;
+}
+.govuk-details summary::-webkit-details-marker { display:none }
+.govuk-details summary::before { content:"▶"; font-size:.6875rem; transition:transform .15s }
+.govuk-details[open] summary::before { transform:rotate(90deg) }
+.govuk-details-body {
+  font-size:var(--t-body); color:var(--text2);
+  padding:var(--sp2) 0 var(--sp2) var(--sp4);
+  border-left:5px solid var(--border);
+  margin-top:var(--sp1); line-height:var(--lh-body);
+}
+.govuk-details-body p { margin-bottom:var(--sp2) }
+.govuk-details-body p:last-child { margin-bottom:0 }
+
+/* ── WARNING TEXT ───────────────────────────────────────────── */
+.govuk-warning {
+  display:flex; align-items:flex-start; gap:var(--sp2); margin-bottom:var(--sp4);
+}
+.govuk-warning-icon { font-size:1.5rem; font-weight:700; color:var(--text); flex-shrink:0; line-height:1; margin-top:2px }
+.govuk-warning-text { font-weight:700; font-size:var(--t-body); color:var(--text) }
+
+/* ── PH NOTE ────────────────────────────────────────────────── */
+.ph-note {
+  font-size:var(--t-body); color:var(--text2);
+  padding:var(--sp2) var(--sp3); background:var(--grey);
+  border-left:5px solid var(--blue);
+}
+
+/* ── CTA ────────────────────────────────────────────────────── */
+.cta-wrap { margin-top:var(--sp6); padding-top:var(--sp4) }
+.cta {
+  display:inline-flex; align-items:center; gap:var(--sp2);
+  background:var(--blue); color:var(--white);
+  padding:var(--btn-pad-v) var(--sp5);
+  font-size:var(--t-md); font-weight:700;
+  text-decoration:none; min-height:var(--touch);
+  cursor:pointer; font-family:inherit; transition:background .1s;
+}
+.cta:hover { background:var(--hover); color:var(--white); text-decoration:none }
+.cta:visited { color:var(--white) }
+.cta:focus-visible {
+  outline:3px solid var(--focus); outline-offset:0;
+  background:var(--focus); color:var(--text);
+  box-shadow:0 -2px var(--focus),0 4px var(--border-dk);
+}
+.cta-sub { margin-top:var(--sp3); font-size:var(--t-sm); color:var(--muted) }
+
+/* ── FOOTER ─────────────────────────────────────────────────── */
+.ftr { background:var(--deep); color:var(--white); padding:var(--sp5) var(--sp4) }
+.ftr-in { max-width:var(--max); margin:0 auto; display:grid; grid-template-columns:repeat(auto-fit,minmax(180px,1fr)); gap:var(--sp5) }
+.ftr-h { font-size:var(--t-xs); font-weight:700; text-transform:uppercase; letter-spacing:.06em; margin-bottom:var(--sp3) }
+.ftr-ul { list-style:none }
+.ftr-ul li { margin-bottom:var(--sp2) }
+.ftr-ul a { color:rgba(255,255,255,.75); font-size:var(--t-sm); text-decoration:underline }
+.ftr-ul a:hover { color:var(--white) }
+.ftr-bot {
+  max-width:var(--max); margin:var(--sp4) auto 0;
+  padding-top:var(--sp3); border-top:1px solid rgba(255,255,255,.12);
+  font-size:var(--t-xs); color:rgba(255,255,255,.45);
+  display:flex; justify-content:space-between; flex-wrap:wrap; gap:var(--sp2);
+}
+
+/* ── RESPONSIVE ─────────────────────────────────────────────── */
+@media(max-width:800px) {
+  .hdr-in,.bc-in,.svc-in,.page { padding-left:var(--sp3); padding-right:var(--sp3) }
+  .hdr-nav { display:none }
+  h1 { font-size:var(--t-xl-m) }
+  h2.section-caption { font-size:var(--t-lg) }
+  .toggle-row { grid-template-columns:1fr; gap:var(--sp1) }
+  .toggle { width:100% }
+  .tog-btn { min-width:0; flex:1 }
+  .book-item { grid-template-columns:1fr; gap:var(--sp2) }
+  .book-action { justify-self:start }
+}
+@media(max-width:480px) {
+  h1 { font-size:var(--t-lg) }
+  .cta { width:100%; justify-content:center }
+}
+@media(forced-colors:active) {
+  .cta,.elig-mark { border:2px solid ButtonText }
+  .req-item { border-left-color:ButtonText }
+}
+
+</style>
+</head>
+<body>
+
+<a href="#main-content" class="skip">Skip to main content</a>
+
+<header class="hdr" role="banner">
+  <div class="hdr-in">
+    <a href="/" class="logo" aria-label="Gloucester City Council — home">
+      <img src="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/templates/assets/GCC_logo.svg" alt="Gloucester City Council" style="filter:brightness(0) invert(1)">
+    </a>
+  </div>
+</header>
+
+<div class="svc"><div class="svc-in">Licensing &amp; regulations</div></div>
+
+<nav class="bc" aria-label="Breadcrumb">
+  <div class="bc-in"><ol class="bc-list">
+    <li class="bc-item"><a href="#">Home</a></li>
+    <li class="bc-item"><a href="#">Licensing &amp; regulations</a></li>
+    <li class="bc-item"><a href="gcc-hcph-landing.html">Hackney carriage and private hire</a></li>
+    <li class="bc-item"><span class="bc-cur" aria-current="page">Driver licence</span></li>
+  </ol></div>
+</nav>
+
+<main id="main-content">
+<div class="page">
+
+  <a href="gcc-hcph-landing.html" class="back">Back</a>
+
+  <header class="pg-hdr">
+    <h1>Driver licence</h1>
+    <p class="pg-lead">Apply for a new licence or renew an existing one. This page covers both hackney carriage and private hire driver licences.</p>
+  </header>
+
+  <!-- TOGGLES -->
+  <div class="toggles">
+    <div class="toggle-row" role="group" aria-label="New licence or renewal?">
+      <span class="toggle-lbl">What do you need?</span>
+      <div class="toggle">
+        <button class="tog-btn active" id="btn-new"   onclick="setMode('new')"   aria-pressed="true">New licence</button>
+        <button class="tog-btn"        id="btn-renew" onclick="setMode('renew')" aria-pressed="false">Renew my licence</button>
+      </div>
+    </div>
+    <div class="toggle-row" role="group" aria-label="Hackney carriage or private hire?">
+      <span class="toggle-lbl">Type of licence</span>
+      <div class="toggle">
+        <button class="tog-btn active" id="btn-hc" onclick="setType('hc')" aria-pressed="true">Hackney carriage</button>
+        <button class="tog-btn"        id="btn-ph" onclick="setType('ph')" aria-pressed="false">Private hire</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- ══ NEW APPLICATION ══════════════════════════════════════ -->
+  <div id="view-new">
+
+    <!-- 1. ELIGIBILITY -->
+    <section aria-labelledby="h-elig">
+      <h2 class="section-caption" id="h-elig">Check you are eligible</h2>
+      <ul class="elig-list">
+
+        <li class="elig-item">
+          <span class="elig-mark" aria-hidden="true">✓</span>
+          <span>Hold a full UK driving licence (not provisional) for at least 12 continuous months</span>
+        </li>
+
+        <li class="elig-item">
+          <span class="elig-mark" aria-hidden="true">✓</span>
+          <span>Be aged 21 or over</span>
+        </li>
+
+        <li class="elig-item">
+          <span class="elig-mark" aria-hidden="true">✓</span>
+          <span>Have no more than 3 penalty points on your DVLA licence</span>
+        </li>
+
+        <li class="elig-item">
+          <span class="elig-mark" aria-hidden="true">✓</span>
+          <div>
+            <span>Be a fit and proper person</span>
+            <p class="elig-note">A licence will not be granted unless the Licensing Authority is satisfied that you are a fit and proper person.</p>
+            <p class="elig-note">You must declare any convictions, cautions, fixed penalties or pending court cases that arise between submitting your application and your licence being issued.</p>
+          </div>
+        </li>
+
+        <li class="elig-item">
+          <span class="elig-mark" aria-hidden="true">✓</span>
+          <div>
+            <span>Be eligible to work in the UK</span>
+            <p class="elig-note">A right to work check will be carried out automatically before your licence is issued.</p>
+            <details class="govuk-details">
+              <summary>Nationality and visa requirements</summary>
+              <div class="govuk-details-body">
+                <div id="visa-hc"><p><strong>Student visas</strong></p><p>Applications will not be accepted from people who hold a student visa.</p></div>
+                <div id="visa-ph" style="display:none"><p><strong>Student visas</strong></p><p>Foreign nationals that hold a Student Visa are only permitted to work for up to 20 hours during term time (depending on the course studied). The private hire operator may be liable if the driver breaches the limitations of the student visa. Information may be shared with the Border Agency.</p></div>
+                <p style="margin-top:var(--sp3)"><strong>Lived outside the UK</strong></p>
+                <p>If you have lived outside the UK since the age of 18, you must provide a Certificate of Good Conduct, a Criminal Record Check or similar document from each country where you have been resident for more than 6 months in a calendar year. If the certificate is not in English, provide a translation from the Embassy or Consulate of that country.</p>
+                <p style="margin-top:var(--sp3)"><strong>Non-EU or EEA driving licence</strong></p>
+                <p>If your driving licence was issued outside the EU or EEA, you must convert it to a GB DVLA licence before applying. The convertible licence can be used to demonstrate 12 months of driving experience.</p>
+              </div>
+            </details>
+          </div>
+        </li>
+
+      </ul>
+    </section>
+
+    <!-- 2. BOOK BEFORE YOU APPLY — PLACEHOLDER -->
+    <section aria-labelledby="h-book">
+      <h2 class="section-caption" id="h-book">Book these before you apply</h2>
+      <p style="font-size:var(--t-body);color:var(--text2)">This section is being finalised — content to follow.</p>
+    </section>
+
+    <!-- 3. DOCUMENTS -->
+    <section aria-labelledby="h-docs-new">
+      <h2 class="section-caption" id="h-docs-new">Gather your documents and apply</h2>
+      <p style="font-size:var(--t-body);color:var(--text2);margin-bottom:var(--sp4)">Have everything below ready before you start. You will not be able to save and return to your application.</p>
+
+      <ul class="req-list">
+
+        <li class="req-item" id="ph-operator-item" style="display:none">
+          <div class="req-title">Operator confirmation</div>
+          <p class="req-desc">You must have confirmation from the private hire operator you will be working for.</p>
+        </li>
+
+        <li class="req-item">
+          <div class="req-title">Photograph</div>
+          <p class="req-desc">Must meet the <a href="https://www.gov.uk/photos-for-passports">gov.uk passport photo requirements</a>.</p>
+        </li>
+
+        <li class="req-item">
+          <div class="req-title">DVLA driving licence</div>
+          <p class="req-desc">Your current valid DVLA photocard licence — both the front and back. If your licence was issued before 1998, provide the paper licence showing your current home address.</p>
+        </li>
+
+        <li class="req-item">
+          <div class="req-title">DVLA check code</div>
+          <p class="req-desc">Generate a check code at <a href="https://www.gov.uk/view-driving-licence">gov.uk/view-driving-licence</a>. Codes are valid for 21 days, can only be used once, and are case sensitive.</p>
+        </li>
+
+        <li class="req-item">
+          <div class="req-title">DBS certificate</div>
+          <p class="req-desc">An enhanced DBS certificate registered with the DBS Online Update Service. <a href="https://taxiplus.co.uk">Apply via TaxiPlus</a>.</p>
+        </li>
+
+        <li class="req-item">
+          <div class="req-title">Pass certificates from all tests and assessments</div>
+          <p class="req-desc">Knowledge test, safeguarding, English proficiency and driving assessment. <a href="https://gloucester-self.achieveservice.com/service/Book_your_taxi_driver_tests">Book online</a>.</p>
+        </li>
+
+        <li class="req-item">
+          <div class="req-title">Driving medical certificate</div>
+          <p class="req-desc">Your GP must complete this to the standard required for professional drivers. No more than 3 months old, on the <a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/medical-examination-report.pdf" target="_blank" rel="noopener">approved medical form</a>.</p>
+        </li>
+
+        <li class="req-item">
+          <div class="req-title">Application fee</div>
+          <p class="req-desc">Paid when you submit your application online.</p>
+          <span class="fee-tag">1 year — £132.00</span>
+          <span class="fee-tag">3 years — £289.00</span>
+        </li>
+
+      </ul>
+
+      <div class="cta-wrap">
+        <a href="https://gloucester-self.achieveservice.com/service/Taxi___Apply_for_a_new_Hackney_Carriage_or_Private_Hire_driver_licence" class="cta" role="button">Apply now <span aria-hidden="true">→</span></a>
+
+      </div>
+    </section>
+  </div><!-- /view-new -->
+
+  <!-- ══ RENEWAL ═══════════════════════════════════════════════ -->
+  <div id="view-renew" style="display:none">
+
+    <!-- EXPIRY WARNING -->
+    <div class="inset" role="note" style="margin-bottom:var(--sp4);border-left-color:var(--blue)">
+      <p style="font-weight:700;margin-bottom:var(--sp2)">Renew before your licence expires</p>
+      <p>A licence renewed after the expiry date is not valid — you cannot drive until a new licence is issued. There is no period of grace and you will need to make a full new application, including a new criminal record check and medical report.</p>
+    </div>
+
+    <!-- RIGHT TO WORK NOTE -->
+    <ul class="elig-list" style="margin-bottom:var(--sp5)">
+      <li class="elig-item">
+        <span class="elig-mark" aria-hidden="true">✓</span>
+        <span>You must remain eligible to work in the UK. If your circumstances have changed since your last licence was issued you may need to provide evidence.</span>
+      </li>
+    </ul>
+
+    <!-- PH OPERATOR NOTE -->
+
+    <!-- DOCUMENTS -->
+    <section aria-labelledby="h-docs-renew">
+      <h2 class="section-caption" id="h-docs-renew">Gather your documents and renew</h2>
+
+      <ul class="req-list">
+
+
+
+        <li class="req-item" id="renew-ph-operator" style="display:none">
+          <div class="req-title">Operator confirmation</div>
+          <p class="req-desc">You must have confirmation from the private hire operator you will be working for.</p>
+        </li>
+
+        <li class="req-item">
+          <div class="req-title">Photograph</div>
+          <p class="req-desc">Must meet the <a href="https://www.gov.uk/photos-for-passports">gov.uk passport photo requirements</a>.</p>
+        </li>
+
+        <li class="req-item">
+          <div class="req-title">DVLA driving licence</div>
+          <p class="req-desc">Your current valid DVLA photocard licence — both the front and back. If your licence was issued before 1998, provide the paper licence showing your current home address.</p>
+        </li>
+
+        <li class="req-item">
+          <div class="req-title">DVLA check code</div>
+          <p class="req-desc">Generate a check code at <a href="https://www.gov.uk/view-driving-licence">gov.uk/view-driving-licence</a>. Codes are valid for 21 days, can only be used once, and are case sensitive.</p>
+        </li>
+
+        <li class="req-item">
+          <div class="req-title">DBS certificate</div>
+          <p class="req-desc">Your DBS subscription must remain active. We conduct 6-monthly checks automatically. If your subscription has lapsed you will need a new certificate. <a href="https://taxiplus.co.uk">Apply via TaxiPlus</a>.</p>
+        </li>
+
+        <li class="req-item">
+          <div class="req-title">Driving medical certificate</div>
+          <p class="req-desc">Your GP must complete this to the standard required for professional drivers. No more than 3 months old, on the <a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/medical-examination-report.pdf" target="_blank" rel="noopener">approved medical form</a>.</p>
+          <div class="inset">
+            <p>If you are aged 45 or over: required every 5 years.</p>
+            <p>If you are aged 65 or over: required every year.</p>
+          </div>
+        </li>
+
+        <li class="req-item">
+          <div class="req-title">Safeguarding refresher certificate</div>
+          <p class="req-desc">Required every 3 years. Your licence will be suspended if training is overdue. <a href="https://gloucester-self.achieveservice.com/service/Book_your_taxi_driver_tests">Book online</a>.</p>
+        </li>
+
+        <li class="req-item">
+          <div class="req-title">Renewal fee</div>
+          <p class="req-desc">Paid when you submit your renewal online.</p>
+          <span class="fee-tag">1 year — £93.00</span>
+          <span class="fee-tag">3 years — £241.00</span>
+        </li>
+
+      </ul>
+      <div class="cta-wrap">
+        <a href="https://gloucester-self.achieveservice.com/service/Taxi___Renew_a_Hackney_Carriage_or_Private_Hire_driver_licence" class="cta" role="button">Renew now <span aria-hidden="true">→</span></a>
+      </div>
+    </section>
+
+  </div><!-- /view-renew -->
+
+
+  <!-- RELATED INFORMATION -->
+  <aside aria-label="Related information" style="margin-top:var(--sp7)">
+    <h2 class="section-caption">Related information</h2>
+    <ul style="list-style:none;border-top:1px solid var(--divider)">
+      <li style="padding:var(--sp3) 0;border-bottom:1px solid var(--divider)">
+        <a href="gcc-hcph-documents.html" style="font-weight:700;font-size:var(--t-body)">Licensing information</a>
+        <p style="font-size:var(--t-body);color:var(--text2);margin-top:var(--sp1)">Rule books, policies, forms and reference documents</p>
+      </li>
+      <li style="padding:var(--sp3) 0;border-bottom:1px solid var(--divider)">
+        <a href="gcc-hcph-wav.html" style="font-weight:700;font-size:var(--t-body)">Wheelchair accessible vehicles</a>
+        <p style="font-size:var(--t-body);color:var(--text2);margin-top:var(--sp1)">Guidance and register of designated WAVs</p>
+      </li>
+      <li style="padding:var(--sp3) 0;border-bottom:1px solid var(--divider)">
+        <a href="gcc-hcph-fees.html" style="font-weight:700;font-size:var(--t-body)">Fees and charges</a>
+        <p style="font-size:var(--t-body);color:var(--text2);margin-top:var(--sp1)">Full fee schedule for 2026 to 2027</p>
+      </li>
+    </ul>
+  </aside>
+
+</div>
+</main>
+
+<footer class="ftr" role="contentinfo">
+  <div class="ftr-in">
+    <div>
+      <div class="ftr-h">Licensing</div>
+      <ul class="ftr-ul">
+        <li><a href="gcc-hcph-landing.html">Hackney carriage and private hire</a></li>
+        <li><a href="#">Premises licences</a></li>
+        <li><a href="#">Personal licences</a></li>
+      </ul>
+    </div>
+    <div>
+      <div class="ftr-h">About GCC</div>
+      <ul class="ftr-ul">
+        <li><a href="#">Accessibility statement</a></li>
+        <li><a href="#">Privacy notice</a></li>
+        <li><a href="#">Cookies</a></li>
+        <li><a href="#">Contact us</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="ftr-bot">
+    <span>© Gloucester City Council</span>
+    <span>Last updated: July 2026</span>
+  </div>
+</footer>
+
+<script>
+let mode='new', type='hc';
+
+function show(id){const el=document.getElementById(id);if(el)el.style.display='block'}
+function hide(id){const el=document.getElementById(id);if(el)el.style.display='none'}
+
+function render(){
+  // Mode
+  if(mode==='new'){ show('view-new'); hide('view-renew'); }
+  else { hide('view-new'); show('view-renew'); }
+
+  // Type
+  if(type==='hc'){
+    show('know-fee-hc');  hide('know-fee-ph');
+    hide('ph-operator-item');
+    hide('renew-ph-operator');
+    show('visa-hc');      hide('visa-ph');
+  } else {
+    hide('know-fee-hc');  show('know-fee-ph');
+    show('ph-operator-item');
+    show('renew-ph-operator');
+    hide('visa-hc');      show('visa-ph');
+  }
+}
+
+function setMode(m){
+  mode=m;
+  ['new','renew'].forEach(v=>{
+    const b=document.getElementById('btn-'+v);
+    b.classList.toggle('active',v===m);
+    b.setAttribute('aria-pressed',v===m?'true':'false');
+  });
+  render();
+}
+
+function setType(t){
+  type=t;
+  ['hc','ph'].forEach(v=>{
+    const b=document.getElementById('btn-'+v);
+    b.classList.toggle('active',v===t);
+    b.setAttribute('aria-pressed',v===t?'true':'false');
+  });
+  render();
+}
+
+render();
+</script>
+</body>
+</html>

--- a/Taxi website/Webpages/gcc-hcph-changes.html
+++ b/Taxi website/Webpages/gcc-hcph-changes.html
@@ -1,0 +1,562 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Something has changed — Gloucester City Council</title>
+<style>
+/* ══════════════════════════════════════════════════════════════
+   GCC LICENSING — SHARED STYLESHEET
+   GOV.UK Done With Intention
+   All pages: landing, driver, vehicle, operator
+   ══════════════════════════════════════════════════════════════ */
+
+:root {
+  /* Brand */
+  --blue:       #0054A4;
+  --hover:      #003E7B;
+  --deep:       #0B2E53;
+  --white:      #FFFFFF;
+  --grey:       #F3F2F1;
+  --grey2:      #E8E8E8;
+  --border:     #B1B4B6;
+  --border-dk:  #0B0C0C;
+  --divider:    #D8D8D8;
+  --text:       #0B0C0C;
+  --text2:      #505A5F;
+  --muted:      #6F777B;
+  --link:       #0054A4;
+  --focus:      #FFDD00;
+
+  /* Spacing */
+  --sp1:4px; --sp2:8px; --sp3:16px; --sp4:24px;
+  --sp5:32px; --sp6:48px; --sp7:64px;
+
+  /* Type scale — GOV.UK */
+  --t-xl:      2.25rem;   /* h1 desktop */
+  --t-xl-m:    1.875rem;  /* h1 mobile */
+  --t-section: 1.75rem;   /* h2 section headings */
+  --t-lg:      1.5rem;    /* h2 base */
+  --t-md:      1.125rem;  /* h3 */
+  --t-body:    1rem;
+  --t-sm:      .875rem;
+  --t-xs:      .75rem;
+
+  /* Line heights */
+  --lh-heading: 1.1;
+  --lh-body:    1.5;
+  --lh-tight:   1.4;
+
+  /* Components */
+  --btn-pad-v: 10px;
+  --touch:     44px;
+  --max:       1200px;
+}
+
+/* ── RESET ──────────────────────────────────────────────────── */
+*,*::before,*::after { box-sizing:border-box; margin:0; padding:0 }
+html { font-size:16px; scroll-behavior:smooth }
+body {
+  font-family:"GDS Transport",Arial,sans-serif;
+  font-size:var(--t-body);
+  line-height:var(--lh-body);
+  color:var(--text);
+  background:var(--white);
+  -webkit-font-smoothing:antialiased;
+}
+@media(prefers-reduced-motion:reduce){*{transition-duration:.01ms!important}}
+
+/* ── TYPOGRAPHY ─────────────────────────────────────────────── */
+h1 { font-size:var(--t-xl); line-height:var(--lh-heading); font-weight:700; margin-bottom:var(--sp2) }
+h2 { font-size:var(--t-lg); line-height:var(--lh-heading); font-weight:700; color:var(--deep); margin:0 0 var(--sp3) }
+h3 { font-size:var(--t-md); line-height:var(--lh-heading); font-weight:700; color:var(--text); margin:0 0 var(--sp2) }
+p  { font-size:var(--t-body); line-height:var(--lh-body); margin-bottom:var(--sp3) }
+p:last-child { margin-bottom:0 }
+a  { color:var(--link); text-decoration:underline; text-underline-offset:3px }
+a:hover { color:var(--hover) }
+a:visited { color:#4c2c92 }
+
+/* ── SECTION CAPTIONS (h2 variant) ─────────────────────────── */
+h2.section-caption {
+  font-size:var(--t-section);
+  font-weight:700;
+  color:var(--deep);
+  padding-left:var(--sp3);
+  border-left:5px solid var(--blue);
+  margin-top:var(--sp6);
+  margin-bottom:var(--sp4);
+  line-height:var(--lh-heading);
+}
+.pg-hdr + section h2.section-caption { margin-top:0 }
+
+/* ── FOCUS ──────────────────────────────────────────────────── */
+:focus-visible {
+  outline:3px solid var(--focus);
+  outline-offset:0;
+  background:var(--focus);
+  color:var(--text);
+  box-shadow:0 -2px var(--focus),0 4px var(--border-dk);
+}
+a:focus-visible { color:var(--text) }
+
+/* ── SKIP ───────────────────────────────────────────────────── */
+.skip {
+  position:absolute; top:-100px; left:var(--sp3);
+  background:var(--focus); color:var(--text);
+  padding:var(--sp2) var(--sp3); font-weight:700;
+  z-index:1000; text-decoration:none;
+}
+.skip:focus { top:var(--sp2) }
+
+/* ── HEADER ─────────────────────────────────────────────────── */
+.hdr { background:var(--deep); border-bottom:4px solid var(--blue) }
+.hdr-in {
+  max-width:var(--max); margin:0 auto;
+  padding:var(--sp3) var(--sp4);
+  display:flex; align-items:center; justify-content:space-between;
+}
+.logo { display:flex; align-items:center; gap:var(--sp2); text-decoration:none; color:var(--white) }
+.logo img { height:40px; width:auto }
+.logo-txt { font-size:var(--t-md); font-weight:700 }
+.hdr-nav { display:flex; gap:var(--sp3); list-style:none }
+.hdr-nav a {
+  color:rgba(255,255,255,.85); text-decoration:none;
+  font-size:var(--t-sm); padding:var(--sp1) var(--sp2);
+  min-height:var(--touch); display:flex; align-items:center;
+}
+.hdr-nav a:hover { color:var(--white); text-decoration:underline }
+
+/* ── SERVICE BAR ────────────────────────────────────────────── */
+.svc { background:var(--blue); padding:var(--sp2) var(--sp4) }
+.svc-in { max-width:var(--max); margin:0 auto; font-size:var(--t-sm); color:var(--white) }
+
+/* ── BREADCRUMB ─────────────────────────────────────────────── */
+.bc { background:var(--grey); border-bottom:1px solid var(--divider) }
+.bc-in { max-width:var(--max); margin:0 auto; padding:var(--sp2) var(--sp4) }
+.bc-list { list-style:none; display:flex; flex-wrap:wrap; gap:var(--sp1); font-size:var(--t-sm) }
+.bc-item { display:flex; align-items:center; gap:var(--sp1) }
+.bc-item+.bc-item::before { content:"›"; color:var(--muted) }
+.bc-item a { color:var(--link) }
+.bc-cur { color:var(--text2); font-weight:700 }
+
+/* ── PAGE LAYOUT ────────────────────────────────────────────── */
+.page { max-width:var(--max); margin:0 auto; padding:var(--sp5) var(--sp4) var(--sp7) }
+
+/* ── BACK LINK ──────────────────────────────────────────────── */
+.back {
+  display:inline-flex; align-items:center; gap:var(--sp1);
+  font-size:var(--t-sm); color:var(--link);
+  text-decoration:none; margin-bottom:var(--sp5);
+  min-height:var(--touch); padding:var(--sp1) 0;
+}
+.back::before {
+  content:""; display:inline-block; width:0; height:0;
+  border-top:5px solid transparent; border-bottom:5px solid transparent;
+  border-right:6px solid var(--link); margin-top:1px;
+}
+.back:hover { color:var(--hover) }
+.back:hover::before { border-right-color:var(--hover) }
+
+/* ── PAGE HEADER ────────────────────────────────────────────── */
+.pg-hdr { margin-bottom:var(--sp4) }
+.pg-lead { font-size:var(--t-md); color:var(--text2); line-height:var(--lh-tight); margin-top:var(--sp2) }
+
+/* ── TOGGLES ────────────────────────────────────────────────── */
+.toggles { display:flex; flex-direction:column; gap:var(--sp3); margin-bottom:var(--sp5) }
+.toggle-row { display:grid; grid-template-columns:160px auto; align-items:center; gap:var(--sp3) }
+.toggle-lbl { font-size:var(--t-sm); font-weight:700; color:var(--text2) }
+.toggle { display:inline-flex; border:2px solid var(--border-dk); overflow:hidden; width:fit-content }
+.tog-btn {
+  padding:var(--btn-pad-v) var(--sp4);
+  background:var(--white); color:var(--text);
+  border:none; border-right:1px solid var(--border);
+  font-size:var(--t-sm); font-weight:700;
+  cursor:pointer; min-height:var(--touch); min-width:140px;
+  font-family:inherit; transition:background .1s; text-align:center;
+}
+.tog-btn:last-child { border-right:none }
+.tog-btn:hover { background:var(--grey) }
+.tog-btn.active { background:var(--deep); color:var(--white) }
+
+/* ── ELIGIBILITY LIST ───────────────────────────────────────── */
+.elig-list { list-style:none; border-top:1px solid var(--divider) }
+.elig-item {
+  display:grid; grid-template-columns:28px 1fr; gap:var(--sp2);
+  padding:var(--sp3) 0; border-bottom:1px solid var(--divider);
+  font-size:var(--t-body); align-items:flex-start; line-height:var(--lh-body);
+}
+.elig-mark {
+  width:22px; height:22px; border-radius:50%;
+  background:var(--blue); color:var(--white);
+  display:flex; align-items:center; justify-content:center;
+  font-size:var(--t-xs); font-weight:700; flex-shrink:0; margin-top:2px;
+}
+.elig-note {
+  font-size:var(--t-body); color:var(--text2);
+  margin-top:var(--sp1); margin-bottom:0; line-height:var(--lh-tight);
+}
+
+/* ── BOOK BEFORE YOU APPLY ──────────────────────────────────── */
+.book-list { list-style:none; border-top:1px solid var(--divider) }
+.book-item {
+  display:grid; grid-template-columns:1fr auto;
+  align-items:center; gap:var(--sp3);
+  padding:var(--sp3) 0; border-bottom:1px solid var(--divider);
+}
+.book-title { font-size:var(--t-body); font-weight:700; color:var(--text); margin-bottom:2px }
+.book-desc { font-size:var(--t-body); color:var(--text2); margin:0; line-height:var(--lh-body) }
+.book-link {
+  display:inline-flex; align-items:center; gap:var(--sp1);
+  font-size:var(--t-body); font-weight:700;
+  color:var(--link); text-decoration:none; white-space:nowrap;
+}
+.book-link:hover { color:var(--hover); text-decoration:underline }
+.book-note { font-size:var(--t-body); color:var(--text2); white-space:nowrap }
+
+/* Expandable providers */
+.book-details { width:100%;grid-column:1/-1 }
+.book-summary-inline {
+  font-size:var(--t-sm); color:var(--link); cursor:pointer;
+  list-style:none; display:inline-flex; align-items:center; gap:var(--sp1);
+  padding:var(--sp2) 0; font-weight:700; min-height:var(--touch);
+}
+.book-summary-inline::-webkit-details-marker { display:none }
+.book-details-body {
+  font-size:var(--t-sm); padding:var(--sp2) 0 var(--sp2) var(--sp4);
+  border-left:3px solid var(--divider); margin-top:var(--sp1);
+  display:flex; flex-direction:column; gap:var(--sp2);
+}
+.book-provider {
+  display:flex; align-items:center; justify-content:space-between;
+  gap:var(--sp3); font-size:var(--t-body); color:var(--text2);
+}
+
+/* ── REQUIREMENT LIST (documents) ───────────────────────────── */
+.req-list { list-style:none; border-top:1px solid var(--divider) }
+.req-item {
+  border-left:5px solid var(--blue);
+  padding:var(--sp3) 0 var(--sp3) var(--sp4);
+  margin-bottom:var(--sp1);
+  border-bottom:1px solid var(--divider);
+}
+.req-item:last-of-type { border-bottom:none }
+/* req-item--fee removed — all req-items use consistent GCC blue border */
+.req-title { font-size:var(--t-body); font-weight:700; color:var(--text); margin-bottom:var(--sp1) }
+.req-desc { font-size:var(--t-body); color:var(--text2); margin:0; line-height:var(--lh-body) }
+
+/* ── INSET ──────────────────────────────────────────────────── */
+.inset {
+  border-left:5px solid var(--border);
+  padding:var(--sp2) var(--sp3); margin-top:var(--sp2);
+}
+.inset p { font-size:var(--t-body); color:var(--text2); line-height:var(--lh-tight); margin-bottom:var(--sp1) }
+.inset p:last-child { margin-bottom:0 }
+
+/* ── FEE TAGS ───────────────────────────────────────────────── */
+.fee-tag+.fee-tag { margin-left:var(--sp2) }
+.fee-tag {
+  display:inline-block; font-size:var(--t-body); font-weight:700;
+  color:var(--deep); background:var(--grey);
+  padding:3px 10px; border:1px solid var(--border); margin-top:var(--sp2);
+}
+.fee-label {
+  display:block; font-size:var(--t-xs); font-weight:700;
+  color:var(--muted); text-transform:uppercase; letter-spacing:.05em;
+  margin-top:var(--sp2); margin-bottom:var(--sp1);
+}
+
+/* ── GOV.UK DETAILS/SUMMARY ─────────────────────────────────── */
+.govuk-details { margin-top:var(--sp2) }
+.govuk-details summary {
+  font-size:var(--t-body); color:var(--link); cursor:pointer;
+  list-style:none; display:inline-flex; align-items:center; gap:var(--sp1);
+  padding:var(--sp2) 0; min-height:var(--touch); font-weight:700;
+}
+.govuk-details summary::-webkit-details-marker { display:none }
+.govuk-details summary::before { content:"▶"; font-size:.6875rem; transition:transform .15s }
+.govuk-details[open] summary::before { transform:rotate(90deg) }
+.govuk-details-body {
+  font-size:var(--t-body); color:var(--text2);
+  padding:var(--sp2) 0 var(--sp2) var(--sp4);
+  border-left:5px solid var(--border);
+  margin-top:var(--sp1); line-height:var(--lh-body);
+}
+.govuk-details-body p { margin-bottom:var(--sp2) }
+.govuk-details-body p:last-child { margin-bottom:0 }
+
+/* ── WARNING TEXT ───────────────────────────────────────────── */
+.govuk-warning {
+  display:flex; align-items:flex-start; gap:var(--sp2); margin-bottom:var(--sp4);
+}
+.govuk-warning-icon { font-size:1.5rem; font-weight:700; color:var(--text); flex-shrink:0; line-height:1; margin-top:2px }
+.govuk-warning-text { font-weight:700; font-size:var(--t-body); color:var(--text) }
+
+/* ── PH NOTE ────────────────────────────────────────────────── */
+.ph-note {
+  font-size:var(--t-body); color:var(--text2);
+  padding:var(--sp2) var(--sp3); background:var(--grey);
+  border-left:5px solid var(--blue);
+}
+
+/* ── CTA ────────────────────────────────────────────────────── */
+.cta-wrap { margin-top:var(--sp6); padding-top:var(--sp4); border-top:1px solid var(--divider) }
+.cta {
+  display:inline-flex; align-items:center; gap:var(--sp2);
+  background:var(--blue); color:var(--white);
+  padding:var(--btn-pad-v) var(--sp5);
+  font-size:var(--t-md); font-weight:700;
+  text-decoration:none; min-height:var(--touch);
+  cursor:pointer; font-family:inherit; transition:background .1s;
+}
+.cta:hover { background:var(--hover); color:var(--white); text-decoration:none }
+.cta:visited { color:var(--white) }
+.cta:focus-visible {
+  outline:3px solid var(--focus); outline-offset:0;
+  background:var(--focus); color:var(--text);
+  box-shadow:0 -2px var(--focus),0 4px var(--border-dk);
+}
+.cta-sub { margin-top:var(--sp3); font-size:var(--t-sm); color:var(--muted) }
+
+/* ── FOOTER ─────────────────────────────────────────────────── */
+.ftr { background:var(--deep); color:var(--white); padding:var(--sp5) var(--sp4) }
+.ftr-in { max-width:var(--max); margin:0 auto; display:grid; grid-template-columns:repeat(auto-fit,minmax(180px,1fr)); gap:var(--sp5) }
+.ftr-h { font-size:var(--t-xs); font-weight:700; text-transform:uppercase; letter-spacing:.06em; margin-bottom:var(--sp3) }
+.ftr-ul { list-style:none }
+.ftr-ul li { margin-bottom:var(--sp2) }
+.ftr-ul a { color:rgba(255,255,255,.75); font-size:var(--t-sm); text-decoration:underline }
+.ftr-ul a:hover { color:var(--white) }
+.ftr-bot {
+  max-width:var(--max); margin:var(--sp4) auto 0;
+  padding-top:var(--sp3); border-top:1px solid rgba(255,255,255,.12);
+  font-size:var(--t-xs); color:rgba(255,255,255,.45);
+  display:flex; justify-content:space-between; flex-wrap:wrap; gap:var(--sp2);
+}
+
+/* ── RESPONSIVE ─────────────────────────────────────────────── */
+@media(max-width:800px) {
+  .hdr-in,.bc-in,.svc-in,.page { padding-left:var(--sp3); padding-right:var(--sp3) }
+  .hdr-nav { display:none }
+  h1 { font-size:var(--t-xl-m) }
+  h2.section-caption { font-size:var(--t-lg) }
+  .toggle-row { grid-template-columns:1fr; gap:var(--sp1) }
+  .toggle { width:100% }
+  .tog-btn { min-width:0; flex:1 }
+  .book-item { grid-template-columns:1fr; gap:var(--sp2) }
+  .book-action { justify-self:start }
+}
+@media(max-width:480px) {
+  h1 { font-size:var(--t-lg) }
+  .cta { width:100%; justify-content:center }
+}
+@media(forced-colors:active) {
+  .cta,.elig-mark { border:2px solid ButtonText }
+  .req-item { border-left-color:ButtonText }
+}
+
+.change-section { margin-bottom:var(--sp6); }
+.change-section h2 {
+  font-size:var(--t-section); font-weight:700; color:var(--deep);
+  border-left:5px solid var(--blue); padding-left:var(--sp3); margin-bottom:var(--sp4);
+}
+.change-list { list-style:none; border-top:1px solid var(--divider); }
+.change-item {
+  padding:var(--sp4) 0; border-bottom:1px solid var(--divider);
+  display:grid; grid-template-columns:1fr auto; gap:var(--sp4); align-items:start;
+}
+.change-title { font-size:var(--t-body); font-weight:700; color:var(--text); margin-bottom:var(--sp1); }
+.change-desc { font-size:var(--t-body); color:var(--text2); }
+.change-action {
+  font-size:var(--t-body); font-weight:700; color:var(--link);
+  white-space:nowrap; text-decoration:none; padding-top:2px;
+}
+.change-action:hover { color:var(--hover); text-decoration:underline; }
+.driver-note {
+  font-size:var(--t-body); color:var(--text2); font-style:italic;
+  margin-top:var(--sp2); padding:var(--sp2) var(--sp3);
+  border-left:3px solid var(--border); background:var(--grey);
+}
+</style>
+</head>
+<body>
+
+<a href="#main-content" class="skip">Skip to main content</a>
+
+<header class="hdr" role="banner">
+  <div class="hdr-in">
+    <a href="/" class="logo" aria-label="Gloucester City Council — home">
+      <img src="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/templates/assets/GCC_logo.svg" alt="Gloucester City Council" style="filter:brightness(0) invert(1)">
+    </a>
+  </div>
+</header>
+
+<div class="svc"><div class="svc-in">Licensing &amp; regulations</div></div>
+
+<nav class="bc" aria-label="Breadcrumb">
+  <div class="bc-in"><ol class="bc-list">
+    <li class="bc-item"><a href="#">Home</a></li>
+    <li class="bc-item"><a href="#">Licensing &amp; regulations</a></li>
+    <li class="bc-item"><a href="gcc-hcph-landing.html">Hackney carriage and private hire</a></li>
+    <li class="bc-item"><span class="bc-cur" aria-current="page">Something has changed</span></li>
+  </ol></div>
+</nav>
+
+<main id="main-content">
+<div class="page">
+
+  <a href="gcc-hcph-landing.html" class="back">Back</a>
+
+  <header class="pg-hdr" style="margin-bottom:var(--sp6)">
+    <h1>Something has changed</h1>
+    <p class="pg-lead">Notify us of a change to your licence, vehicle or personal circumstances.</p>
+  </header>
+
+  <!-- DRIVER AND VEHICLE -->
+  <div class="change-section">
+    <h2>Driver and vehicle licence changes</h2>
+    <ul class="change-list">
+
+      <li class="change-item">
+        <div>
+          <div class="change-title">Change of address</div>
+          <p class="change-desc">You must notify us of any change to your home address. Applies to both driver and vehicle licences. A fee applies.</p>
+        </div>
+        <a href="https://gloucester-self.achieveservice.com/service/Taxi___Apply_to_change_address_on_licence" class="change-action">Apply online →</a>
+      </li>
+
+      <li class="change-item">
+        <div>
+          <div class="change-title">Replacement badge or plate</div>
+          <p class="change-desc">Apply for a replacement driver badge or vehicle licence plate. Applies to both driver and vehicle licences. A fee applies.</p>
+        </div>
+        <a href="https://gloucester-self.achieveservice.com/service/Taxi___Apply_for_a_replacement_badge_or_plate" class="change-action">Apply online →</a>
+      </li>
+
+      <li class="change-item">
+        <div>
+          <div class="change-title">Notify us of a conviction, caution or fixed penalty</div>
+          <p class="change-desc">You must notify us within 48 hours of any conviction, caution, fixed penalty or pending court case.</p>
+        </div>
+        <a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/notification-of-conviction.pdf" target="_blank" rel="noopener" class="change-action">Download form →</a>
+      </li>
+
+    </ul>
+  </div>
+
+  <!-- VEHICLES -->
+  <div class="change-section">
+    <h2>Vehicle licence changes</h2>
+    <ul class="change-list">
+
+      <li class="change-item">
+        <div>
+          <div class="change-title">Transfer of ownership</div>
+          <p class="change-desc">If you are taking over a licensed vehicle from another proprietor. A fee applies.</p>
+        </div>
+        <a href="https://gloucester-self.achieveservice.com/service/Taxi___Apply_to_transfer_the_ownership_of_a_vehicle" class="change-action">Apply online →</a>
+      </li>
+
+      <li class="change-item">
+        <div>
+          <div class="change-title">Change of vehicle</div>
+          <p class="change-desc">If you want to swap your licensed vehicle for a different one. New plates will be issued. A fee applies.</p>
+        </div>
+        <a href="https://gloucester-self.achieveservice.com/service/Taxi___Apply_for_a_change_of_vehicle" class="change-action">Apply online →</a>
+      </li>
+
+      <li class="change-item">
+        <div>
+          <div class="change-title">Change of vehicle registration</div>
+          <p class="change-desc">If the registration number of your licensed vehicle has changed. You must provide confirmation from DVLA.</p>
+        </div>
+        <a href="https://gloucester-self.achieveservice.com/service/Taxi___Apply_to_change_your_vehicle_registration_number" class="change-action">Apply online →</a>
+      </li>
+
+      <li class="change-item">
+        <div>
+          <div class="change-title">Private hire vehicle plate exemption</div>
+          <p class="change-desc">Apply to exempt your private hire vehicle from displaying licence plates and signage. Each application is assessed on its own merits. Fleet exemptions are not permitted.</p>
+        </div>
+        <a href="https://gloucester-self.achieveservice.com/service/Taxi___Apply_for_a_Private_Hire_vehicle_plate_exemption" class="change-action">Apply online →</a>
+      </li>
+
+    </ul>
+  </div>
+
+  <!-- REPORT AN ACCIDENT -->
+  <div class="change-section">
+    <h2>Report an accident</h2>
+    <ul class="change-list">
+
+      <li class="change-item">
+        <div>
+          <div class="change-title">Report a hackney carriage or private hire accident</div>
+          <p class="change-desc">If you are involved in an accident while driving a licensed vehicle you must report it to us.</p>
+          <details class="govuk-details" style="margin-top:var(--sp3)">
+            <summary>Are you a passenger wanting to make a complaint?</summary>
+            <div class="govuk-details-body">
+              <p>This form is for licensed drivers to report their own accident — it is not for passenger complaints. If you wish to report an issue about a taxi or private hire driver or vehicle, please provide as much detail as possible.</p>
+              <p style="font-weight:700;margin-top:var(--sp3)">Information we need:</p>
+              <ul style="margin-top:var(--sp2);padding-left:var(--sp4)">
+                <li>Your name, address, email and a daytime telephone number</li>
+                <li>The plate number or vehicle registration</li>
+                <li>A full description of the issue or incident and any witnesses</li>
+                <li>The date, time and location where the incident happened or your journey details</li>
+                <li>A description of the driver and the driver's badge number if known</li>
+                <li>As much detail as you can about the vehicle type, colour and any distinguishing features</li>
+              </ul>
+              <p style="margin-top:var(--sp3)">Email <a href="mailto:licensing@gloucester.gov.uk">licensing@gloucester.gov.uk</a> or call the Licensing Team on <a href="tel:01452396396">01452 396396</a>.</p>
+            </div>
+          </details>
+        </div>
+        <a href="https://gloucester-self.achieveservice.com/service/Taxi___Report_a_Hackney_Carriage_or_Private_Hire_accident?accept=yes&consentMessageIds[]=55" class="change-action">Report online →</a>
+      </li>
+
+    </ul>
+  </div>
+
+  <!-- RELATED -->
+  <aside aria-label="Related information" style="margin-top:var(--sp7)">
+    <h2 class="section-caption">Related information</h2>
+    <ul style="list-style:none;border-top:1px solid var(--divider)">
+      <li style="padding:var(--sp3) 0;border-bottom:1px solid var(--divider)">
+        <a href="gcc-hcph-documents.html" style="font-weight:700;font-size:var(--t-body)">Licensing information</a>
+        <p style="font-size:var(--t-body);color:var(--text2);margin-top:var(--sp1)">Rule books, policies, forms and reference documents</p>
+      </li>
+      <li style="padding:var(--sp3) 0;border-bottom:1px solid var(--divider)">
+        <a href="gcc-hcph-fees.html" style="font-weight:700;font-size:var(--t-body)">Fees and charges</a>
+        <p style="font-size:var(--t-body);color:var(--text2);margin-top:var(--sp1)">Full fee schedule for 2026 to 2027</p>
+      </li>
+    </ul>
+  </aside>
+
+</div>
+</main>
+
+<footer class="ftr" role="contentinfo">
+  <div class="ftr-in">
+    <div>
+      <div class="ftr-h">Licensing</div>
+      <ul class="ftr-ul">
+        <li><a href="gcc-hcph-landing.html">Hackney carriage and private hire</a></li>
+        <li><a href="#">Premises licences</a></li>
+        <li><a href="#">Personal licences</a></li>
+      </ul>
+    </div>
+    <div>
+      <div class="ftr-h">About GCC</div>
+      <ul class="ftr-ul">
+        <li><a href="#">Accessibility statement</a></li>
+        <li><a href="#">Privacy notice</a></li>
+        <li><a href="#">Cookies</a></li>
+        <li><a href="#">Contact us</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="ftr-bot">
+    <span>© Gloucester City Council</span>
+    <span>Last updated: July 2026</span>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/Taxi website/Webpages/gcc-hcph-documents.html
+++ b/Taxi website/Webpages/gcc-hcph-documents.html
@@ -1,0 +1,559 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Licensing information — Gloucester City Council</title>
+<style>
+/* ══════════════════════════════════════════════════════════════
+   GCC LICENSING — SHARED STYLESHEET
+   GOV.UK Done With Intention
+   All pages: landing, driver, vehicle, operator
+   ══════════════════════════════════════════════════════════════ */
+
+:root {
+  /* Brand */
+  --blue:       #0054A4;
+  --hover:      #003E7B;
+  --deep:       #0B2E53;
+  --white:      #FFFFFF;
+  --grey:       #F3F2F1;
+  --grey2:      #E8E8E8;
+  --border:     #B1B4B6;
+  --border-dk:  #0B0C0C;
+  --divider:    #D8D8D8;
+  --text:       #0B0C0C;
+  --text2:      #505A5F;
+  --muted:      #6F777B;
+  --link:       #0054A4;
+  --focus:      #FFDD00;
+
+  /* Spacing */
+  --sp1:4px; --sp2:8px; --sp3:16px; --sp4:24px;
+  --sp5:32px; --sp6:48px; --sp7:64px;
+
+  /* Type scale — GOV.UK */
+  --t-xl:      2.25rem;   /* h1 desktop */
+  --t-xl-m:    1.875rem;  /* h1 mobile */
+  --t-section: 1.75rem;   /* h2 section headings */
+  --t-lg:      1.5rem;    /* h2 base */
+  --t-md:      1.125rem;  /* h3 */
+  --t-body:    1rem;
+  --t-sm:      .875rem;
+  --t-xs:      .75rem;
+
+  /* Line heights */
+  --lh-heading: 1.1;
+  --lh-body:    1.5;
+  --lh-tight:   1.4;
+
+  /* Components */
+  --btn-pad-v: 10px;
+  --touch:     44px;
+  --max:       1200px;
+}
+
+/* ── RESET ──────────────────────────────────────────────────── */
+*,*::before,*::after { box-sizing:border-box; margin:0; padding:0 }
+html { font-size:16px; scroll-behavior:smooth }
+body {
+  font-family:"GDS Transport",Arial,sans-serif;
+  font-size:var(--t-body);
+  line-height:var(--lh-body);
+  color:var(--text);
+  background:var(--white);
+  -webkit-font-smoothing:antialiased;
+}
+@media(prefers-reduced-motion:reduce){*{transition-duration:.01ms!important}}
+
+/* ── TYPOGRAPHY ─────────────────────────────────────────────── */
+h1 { font-size:var(--t-xl); line-height:var(--lh-heading); font-weight:700; margin-bottom:var(--sp2) }
+h2 { font-size:var(--t-lg); line-height:var(--lh-heading); font-weight:700; color:var(--deep); margin:0 0 var(--sp3) }
+h3 { font-size:var(--t-md); line-height:var(--lh-heading); font-weight:700; color:var(--text); margin:0 0 var(--sp2) }
+p  { font-size:var(--t-body); line-height:var(--lh-body); margin-bottom:var(--sp3) }
+p:last-child { margin-bottom:0 }
+a  { color:var(--link); text-decoration:underline; text-underline-offset:3px }
+a:hover { color:var(--hover) }
+a:visited { color:#4c2c92 }
+
+/* ── SECTION CAPTIONS (h2 variant) ─────────────────────────── */
+h2.section-caption {
+  font-size:var(--t-section);
+  font-weight:700;
+  color:var(--deep);
+  padding-left:var(--sp3);
+  border-left:5px solid var(--blue);
+  margin-top:var(--sp6);
+  margin-bottom:var(--sp4);
+  line-height:var(--lh-heading);
+}
+.pg-hdr + section h2.section-caption { margin-top:0 }
+
+/* ── FOCUS ──────────────────────────────────────────────────── */
+:focus-visible {
+  outline:3px solid var(--focus);
+  outline-offset:0;
+  background:var(--focus);
+  color:var(--text);
+  box-shadow:0 -2px var(--focus),0 4px var(--border-dk);
+}
+a:focus-visible { color:var(--text) }
+
+/* ── SKIP ───────────────────────────────────────────────────── */
+.skip {
+  position:absolute; top:-100px; left:var(--sp3);
+  background:var(--focus); color:var(--text);
+  padding:var(--sp2) var(--sp3); font-weight:700;
+  z-index:1000; text-decoration:none;
+}
+.skip:focus { top:var(--sp2) }
+
+/* ── HEADER ─────────────────────────────────────────────────── */
+.hdr { background:var(--deep); border-bottom:4px solid var(--blue) }
+.hdr-in {
+  max-width:var(--max); margin:0 auto;
+  padding:var(--sp3) var(--sp4);
+  display:flex; align-items:center; justify-content:space-between;
+}
+.logo { display:flex; align-items:center; gap:var(--sp2); text-decoration:none; color:var(--white) }
+.logo img { height:40px; width:auto }
+.logo-txt { font-size:var(--t-md); font-weight:700 }
+.hdr-nav { display:flex; gap:var(--sp3); list-style:none }
+.hdr-nav a {
+  color:rgba(255,255,255,.85); text-decoration:none;
+  font-size:var(--t-sm); padding:var(--sp1) var(--sp2);
+  min-height:var(--touch); display:flex; align-items:center;
+}
+.hdr-nav a:hover { color:var(--white); text-decoration:underline }
+
+/* ── SERVICE BAR ────────────────────────────────────────────── */
+.svc { background:var(--blue); padding:var(--sp2) var(--sp4) }
+.svc-in { max-width:var(--max); margin:0 auto; font-size:var(--t-sm); color:var(--white) }
+
+/* ── BREADCRUMB ─────────────────────────────────────────────── */
+.bc { background:var(--grey); border-bottom:1px solid var(--divider) }
+.bc-in { max-width:var(--max); margin:0 auto; padding:var(--sp2) var(--sp4) }
+.bc-list { list-style:none; display:flex; flex-wrap:wrap; gap:var(--sp1); font-size:var(--t-sm) }
+.bc-item { display:flex; align-items:center; gap:var(--sp1) }
+.bc-item+.bc-item::before { content:"›"; color:var(--muted) }
+.bc-item a { color:var(--link) }
+.bc-cur { color:var(--text2); font-weight:700 }
+
+/* ── PAGE LAYOUT ────────────────────────────────────────────── */
+.page { max-width:var(--max); margin:0 auto; padding:var(--sp5) var(--sp4) var(--sp7) }
+
+/* ── BACK LINK ──────────────────────────────────────────────── */
+.back {
+  display:inline-flex; align-items:center; gap:var(--sp1);
+  font-size:var(--t-sm); color:var(--link);
+  text-decoration:none; margin-bottom:var(--sp5);
+  min-height:var(--touch); padding:var(--sp1) 0;
+}
+.back::before {
+  content:""; display:inline-block; width:0; height:0;
+  border-top:5px solid transparent; border-bottom:5px solid transparent;
+  border-right:6px solid var(--link); margin-top:1px;
+}
+.back:hover { color:var(--hover) }
+.back:hover::before { border-right-color:var(--hover) }
+
+/* ── PAGE HEADER ────────────────────────────────────────────── */
+.pg-hdr { margin-bottom:var(--sp6) }
+.pg-lead { font-size:var(--t-md); color:var(--text2); line-height:var(--lh-tight); margin-top:var(--sp2) }
+
+/* ── TOGGLES ────────────────────────────────────────────────── */
+.toggles { display:flex; flex-direction:column; gap:var(--sp3); margin-bottom:var(--sp5) }
+.toggle-row { display:grid; grid-template-columns:160px auto; align-items:center; gap:var(--sp3) }
+.toggle-lbl { font-size:var(--t-sm); font-weight:700; color:var(--text2) }
+.toggle { display:inline-flex; border:2px solid var(--border-dk); overflow:hidden; width:fit-content }
+.tog-btn {
+  padding:var(--btn-pad-v) var(--sp4);
+  background:var(--white); color:var(--text);
+  border:none; border-right:1px solid var(--border);
+  font-size:var(--t-sm); font-weight:700;
+  cursor:pointer; min-height:var(--touch); min-width:140px;
+  font-family:inherit; transition:background .1s; text-align:center;
+}
+.tog-btn:last-child { border-right:none }
+.tog-btn:hover { background:var(--grey) }
+.tog-btn.active { background:var(--deep); color:var(--white) }
+
+/* ── ELIGIBILITY LIST ───────────────────────────────────────── */
+.elig-list { list-style:none; border-top:1px solid var(--divider) }
+.elig-item {
+  display:grid; grid-template-columns:28px 1fr; gap:var(--sp2);
+  padding:var(--sp3) 0; border-bottom:1px solid var(--divider);
+  font-size:var(--t-body); align-items:flex-start; line-height:var(--lh-body);
+}
+.elig-mark {
+  width:22px; height:22px; border-radius:50%;
+  background:var(--blue); color:var(--white);
+  display:flex; align-items:center; justify-content:center;
+  font-size:var(--t-xs); font-weight:700; flex-shrink:0; margin-top:2px;
+}
+.elig-note {
+  font-size:var(--t-body); color:var(--text2);
+  margin-top:var(--sp1); margin-bottom:0; line-height:var(--lh-tight);
+}
+
+/* ── BOOK BEFORE YOU APPLY ──────────────────────────────────── */
+.book-list { list-style:none; border-top:1px solid var(--divider) }
+.book-item {
+  display:grid; grid-template-columns:1fr auto;
+  align-items:center; gap:var(--sp3);
+  padding:var(--sp3) 0; border-bottom:1px solid var(--divider);
+}
+.book-title { font-size:var(--t-body); font-weight:700; color:var(--text); margin-bottom:2px }
+.book-desc { font-size:var(--t-body); color:var(--text2); margin:0; line-height:var(--lh-body) }
+.book-link {
+  display:inline-flex; align-items:center; gap:var(--sp1);
+  font-size:var(--t-body); font-weight:700;
+  color:var(--link); text-decoration:none; white-space:nowrap;
+}
+.book-link:hover { color:var(--hover); text-decoration:underline }
+.book-note { font-size:var(--t-body); color:var(--text2); white-space:nowrap }
+
+/* Expandable providers */
+.book-details { width:100%;grid-column:1/-1 }
+.book-summary-inline {
+  font-size:var(--t-sm); color:var(--link); cursor:pointer;
+  list-style:none; display:inline-flex; align-items:center; gap:var(--sp1);
+  padding:var(--sp2) 0; font-weight:700; min-height:var(--touch);
+}
+.book-summary-inline::-webkit-details-marker { display:none }
+.book-details-body {
+  font-size:var(--t-sm); padding:var(--sp2) 0 var(--sp2) var(--sp4);
+  border-left:3px solid var(--divider); margin-top:var(--sp1);
+  display:flex; flex-direction:column; gap:var(--sp2);
+}
+.book-provider {
+  display:flex; align-items:center; justify-content:space-between;
+  gap:var(--sp3); font-size:var(--t-body); color:var(--text2);
+}
+
+/* ── REQUIREMENT LIST (documents) ───────────────────────────── */
+.req-list { list-style:none; border-top:1px solid var(--divider) }
+.req-item {
+  border-left:5px solid var(--blue);
+  padding:var(--sp3) 0 var(--sp3) var(--sp4);
+  margin-bottom:var(--sp1);
+  border-bottom:1px solid var(--divider);
+}
+.req-item:last-of-type { border-bottom:none }
+/* req-item--fee removed — all req-items use consistent GCC blue border */
+.req-title { font-size:var(--t-body); font-weight:700; color:var(--text); margin-bottom:var(--sp1) }
+.req-desc { font-size:var(--t-body); color:var(--text2); margin:0; line-height:var(--lh-body) }
+
+/* ── INSET ──────────────────────────────────────────────────── */
+.inset {
+  border-left:5px solid var(--border);
+  padding:var(--sp2) var(--sp3); margin-top:var(--sp2);
+}
+.inset p { font-size:var(--t-body); color:var(--text2); line-height:var(--lh-tight); margin-bottom:var(--sp1) }
+.inset p:last-child { margin-bottom:0 }
+
+/* ── FEE TAGS ───────────────────────────────────────────────── */
+.fee-tag+.fee-tag { margin-left:var(--sp2) }
+.fee-tag {
+  display:inline-block; font-size:var(--t-body); font-weight:700;
+  color:var(--deep); background:var(--grey);
+  padding:3px 10px; border:1px solid var(--border); margin-top:var(--sp2);
+}
+.fee-label {
+  display:block; font-size:var(--t-xs); font-weight:700;
+  color:var(--muted); text-transform:uppercase; letter-spacing:.05em;
+  margin-top:var(--sp2); margin-bottom:var(--sp1);
+}
+
+/* ── GOV.UK DETAILS/SUMMARY ─────────────────────────────────── */
+.govuk-details { margin-top:var(--sp2) }
+.govuk-details summary {
+  font-size:var(--t-body); color:var(--link); cursor:pointer;
+  list-style:none; display:inline-flex; align-items:center; gap:var(--sp1);
+  padding:var(--sp2) 0; min-height:var(--touch); font-weight:700;
+}
+.govuk-details summary::-webkit-details-marker { display:none }
+.govuk-details summary::before { content:"▶"; font-size:.6875rem; transition:transform .15s }
+.govuk-details[open] summary::before { transform:rotate(90deg) }
+.govuk-details-body {
+  font-size:var(--t-body); color:var(--text2);
+  padding:var(--sp2) 0 var(--sp2) var(--sp4);
+  border-left:5px solid var(--border);
+  margin-top:var(--sp1); line-height:var(--lh-body);
+}
+.govuk-details-body p { margin-bottom:var(--sp2) }
+.govuk-details-body p:last-child { margin-bottom:0 }
+
+/* ── WARNING TEXT ───────────────────────────────────────────── */
+.govuk-warning {
+  display:flex; align-items:flex-start; gap:var(--sp2); margin-bottom:var(--sp4);
+}
+.govuk-warning-icon { font-size:1.5rem; font-weight:700; color:var(--text); flex-shrink:0; line-height:1; margin-top:2px }
+.govuk-warning-text { font-weight:700; font-size:var(--t-body); color:var(--text) }
+
+/* ── PH NOTE ────────────────────────────────────────────────── */
+.ph-note {
+  font-size:var(--t-body); color:var(--text2);
+  padding:var(--sp2) var(--sp3); background:var(--grey);
+  border-left:5px solid var(--blue);
+}
+
+/* ── CTA ────────────────────────────────────────────────────── */
+.cta-wrap { margin-top:var(--sp6); padding-top:var(--sp4); border-top:1px solid var(--divider) }
+.cta {
+  display:inline-flex; align-items:center; gap:var(--sp2);
+  background:var(--blue); color:var(--white);
+  padding:var(--btn-pad-v) var(--sp5);
+  font-size:var(--t-md); font-weight:700;
+  text-decoration:none; min-height:var(--touch);
+  cursor:pointer; font-family:inherit; transition:background .1s;
+}
+.cta:hover { background:var(--hover); color:var(--white); text-decoration:none }
+.cta:visited { color:var(--white) }
+.cta:focus-visible {
+  outline:3px solid var(--focus); outline-offset:0;
+  background:var(--focus); color:var(--text);
+  box-shadow:0 -2px var(--focus),0 4px var(--border-dk);
+}
+.cta-sub { margin-top:var(--sp3); font-size:var(--t-sm); color:var(--muted) }
+
+/* ── FOOTER ─────────────────────────────────────────────────── */
+.ftr { background:var(--deep); color:var(--white); padding:var(--sp5) var(--sp4) }
+.ftr-in { max-width:var(--max); margin:0 auto; display:grid; grid-template-columns:repeat(auto-fit,minmax(180px,1fr)); gap:var(--sp5) }
+.ftr-h { font-size:var(--t-xs); font-weight:700; text-transform:uppercase; letter-spacing:.06em; margin-bottom:var(--sp3) }
+.ftr-ul { list-style:none }
+.ftr-ul li { margin-bottom:var(--sp2) }
+.ftr-ul a { color:rgba(255,255,255,.75); font-size:var(--t-sm); text-decoration:underline }
+.ftr-ul a:hover { color:var(--white) }
+.ftr-bot {
+  max-width:var(--max); margin:var(--sp4) auto 0;
+  padding-top:var(--sp3); border-top:1px solid rgba(255,255,255,.12);
+  font-size:var(--t-xs); color:rgba(255,255,255,.45);
+  display:flex; justify-content:space-between; flex-wrap:wrap; gap:var(--sp2);
+}
+
+/* ── RESPONSIVE ─────────────────────────────────────────────── */
+@media(max-width:800px) {
+  .hdr-in,.bc-in,.svc-in,.page { padding-left:var(--sp3); padding-right:var(--sp3) }
+  .hdr-nav { display:none }
+  h1 { font-size:var(--t-xl-m) }
+  h2.section-caption { font-size:var(--t-lg) }
+  .toggle-row { grid-template-columns:1fr; gap:var(--sp1) }
+  .toggle { width:100% }
+  .tog-btn { min-width:0; flex:1 }
+  .book-item { grid-template-columns:1fr; gap:var(--sp2) }
+  .book-action { justify-self:start }
+}
+@media(max-width:480px) {
+  h1 { font-size:var(--t-lg) }
+  .cta { width:100%; justify-content:center }
+}
+@media(forced-colors:active) {
+  .cta,.elig-mark { border:2px solid ButtonText }
+  .req-item { border-left-color:ButtonText }
+}
+
+
+/* PAGE SPECIFIC */
+.doc-section {
+  margin-bottom:var(--sp6);
+}
+.doc-section h2 {
+  font-size:var(--t-section);
+  font-weight:700;
+  color:var(--deep);
+  border-left:5px solid var(--blue);
+  padding-left:var(--sp3);
+  margin-bottom:var(--sp4);
+}
+.doc-list {
+  list-style:none;
+}
+.doc-item {
+  padding:var(--sp4) 0;
+  border-bottom:1px solid var(--divider);
+}
+.doc-item:first-child {
+  border-top:1px solid var(--divider);
+}
+.doc-title {
+  font-size:var(--t-body);
+  font-weight:700;
+  color:var(--text);
+  margin-bottom:var(--sp1);
+}
+.doc-desc {
+  font-size:var(--t-body);
+  color:var(--text2);
+  margin-bottom:var(--sp2);
+}
+.doc-meta {
+  font-size:var(--t-sm);
+  color:var(--muted);
+}
+.doc-badge {
+  display:inline-block;
+  font-size:var(--t-sm);
+  font-weight:700;
+  padding:2px 8px;
+  margin-right:var(--sp2);
+  background:var(--grey);
+  color:var(--text2);
+  border:1px solid var(--border);
+}
+.doc-badge--pdf { background:#fff3cd; color:#856404; border-color:#ffc107; }
+.doc-badge--doc { background:#cce5ff; color:#004085; border-color:#b8daff; }
+.doc-badge--html { background:#d4edda; color:#155724; border-color:#c3e6cb; }
+.page-intro {
+  font-size:var(--t-body);
+  color:var(--text2);
+  margin-bottom:var(--sp6);
+}
+</style>
+</head>
+<body>
+
+<a href="#main-content" class="skip">Skip to main content</a>
+
+<header class="hdr" role="banner">
+  <div class="hdr-in">
+    <a href="/" class="logo" aria-label="Gloucester City Council — home">
+      <img src="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/templates/assets/GCC_logo.svg" alt="Gloucester City Council" style="filter:brightness(0) invert(1)">
+    </a>
+  </div>
+</header>
+
+<div class="svc"><div class="svc-in">Licensing &amp; regulations</div></div>
+
+<nav class="bc" aria-label="Breadcrumb">
+  <div class="bc-in"><ol class="bc-list">
+    <li class="bc-item"><a href="#">Home</a></li>
+    <li class="bc-item"><a href="#">Licensing &amp; regulations</a></li>
+    <li class="bc-item"><a href="gcc-hcph-landing.html">Hackney carriage and private hire</a></li>
+    <li class="bc-item"><span class="bc-cur" aria-current="page">Policies and documents</span></li>
+  </ol></div>
+</nav>
+
+<main id="main-content">
+<div class="page">
+
+  <a href="gcc-hcph-landing.html" class="back">Back</a>
+
+  <header class="pg-hdr">
+    <h1>Licensing information</h1>
+    <p class="pg-lead">Rule books, policies, forms and reference documents for hackney carriage and private hire licensing in Gloucester City.</p>
+
+  <!-- POLICY DOCUMENTS -->
+  <div class="doc-section" style="padding-top:var(--sp5);border-top:1px solid var(--divider)">
+    <h2>Licensing policies</h2>
+    <ul class="doc-list">
+
+      <li class="doc-item">
+        <div class="doc-title"><a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/taxi-tariff-november-24.pdf" target="_blank" rel="noopener">Taxi tariff</a></div>
+        <span class="doc-meta">Approved November 2024</span>
+      </li>
+
+      <li class="doc-item">
+        <div class="doc-title"><a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/hc-driver-and-vehicle-rule-books-june-2025.pdf" target="_blank" rel="noopener">Hackney Carriage Driver and Vehicle Rule Book</a></div>
+        <span class="doc-meta">Approved June 2025</span>
+      </li>
+
+      <li class="doc-item">
+        <div class="doc-title"><a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/ph-driver-and-vehicle-rule-book-june-2025.pdf" target="_blank" rel="noopener">Private Hire Driver and Vehicle Rule Book</a></div>
+        <span class="doc-meta">Approved June 2025</span>
+      </li>
+
+      <li class="doc-item">
+        <div class="doc-title"><a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/pho-rule-book-june-2025.pdf" target="_blank" rel="noopener">Private Hire Operators Rule Book</a></div>
+        <span class="doc-meta">Approved June 2025</span>
+      </li>
+
+      <li class="doc-item">
+        <div class="doc-title"><a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/hc-ph-regulatory-guidelines-approved-september-21.pdf" target="_blank" rel="noopener">Hackney Carriage and Private Hire Regulatory Guidelines</a></div>
+        <span class="doc-meta">Approved September 2021</span>
+      </li>
+
+      <li class="doc-item">
+        <div class="doc-title"><a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/common-standards-for-licensing-hackney-carriage-and-private-hire-drivers-app.pdf" target="_blank" rel="noopener">Common Standards for Licensing Drivers in Gloucestershire</a></div>
+        <span class="doc-meta">Approved September 2021</span>
+      </li>
+
+    </ul>
+  </div>
+
+  <!-- FORMS AND SCHEDULES -->
+  <div class="doc-section">
+    <h2>Forms and documents</h2>
+    <ul class="doc-list">
+
+      <li class="doc-item">
+        <div class="doc-title"><a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/medical-examination-report.pdf" target="_blank" rel="noopener">Medical examination form</a></div>
+        <p class="doc-desc">A standard DVLA medical form is not accepted — your GP must use this form.</p>
+      </li>
+
+      <li class="doc-item">
+        <div class="doc-title"><a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/notification-of-conviction.pdf" target="_blank" rel="noopener">Notification of conviction form</a></div>
+        <p class="doc-desc">Licence holders must notify us within 48 hours of any conviction, caution, fixed penalty or pending court case.</p>
+      </li>
+
+    </ul>
+  </div>
+
+  <!-- REFERENCE -->
+  <div class="doc-section">
+    <h2>Reference</h2>
+    <ul class="doc-list">
+
+      <li class="doc-item">
+        <div class="doc-title"><a href="gcc-hcph-register.html">Public register</a></div>
+        <p class="doc-desc">All currently licensed hackney carriage and private hire drivers, vehicles and operators.</p>
+      </li>
+
+      <li class="doc-item">
+        <div class="doc-title"><a href="gcc-hcph-wav.html">Wheelchair accessible vehicles</a></div>
+        <p class="doc-desc">Guidance for drivers, proprietors and operators of designated WAVs, including the vehicle register.</p>
+      </li>
+
+      <li class="doc-item">
+        <div class="doc-title"><a href="gcc-hcph-fees.html">Fees and charges</a></div>
+        <span class="doc-meta">2026 to 2027</span>
+      </li>
+
+      <li class="doc-item">
+        <div class="doc-title"><a href="gcc-approved-garages.html">Approved testing garages</a></div>
+      </li>
+
+    </ul>
+  </div>
+
+</div>
+</main>
+
+<footer class="ftr" role="contentinfo">
+  <div class="ftr-in">
+    <div>
+      <div class="ftr-h">Licensing</div>
+      <ul class="ftr-ul">
+        <li><a href="gcc-hcph-landing.html">Hackney carriage and private hire</a></li>
+        <li><a href="#">Premises licences</a></li>
+        <li><a href="#">Personal licences</a></li>
+      </ul>
+    </div>
+    <div>
+      <div class="ftr-h">About GCC</div>
+      <ul class="ftr-ul">
+        <li><a href="#">Accessibility statement</a></li>
+        <li><a href="#">Privacy notice</a></li>
+        <li><a href="#">Cookies</a></li>
+        <li><a href="#">Contact us</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="ftr-bot">
+    <span>© Gloucester City Council</span>
+    <span>Last updated: July 2026</span>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/Taxi website/Webpages/gcc-hcph-fees.html
+++ b/Taxi website/Webpages/gcc-hcph-fees.html
@@ -1,0 +1,547 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Fees and charges — Gloucester City Council</title>
+<style>
+/* ══════════════════════════════════════════════════════════════
+   GCC LICENSING — SHARED STYLESHEET
+   GOV.UK Done With Intention
+   All pages: landing, driver, vehicle, operator
+   ══════════════════════════════════════════════════════════════ */
+
+:root {
+  /* Brand */
+  --blue:       #0054A4;
+  --hover:      #003E7B;
+  --deep:       #0B2E53;
+  --white:      #FFFFFF;
+  --grey:       #F3F2F1;
+  --grey2:      #E8E8E8;
+  --border:     #B1B4B6;
+  --border-dk:  #0B0C0C;
+  --divider:    #D8D8D8;
+  --text:       #0B0C0C;
+  --text2:      #505A5F;
+  --muted:      #6F777B;
+  --link:       #0054A4;
+  --focus:      #FFDD00;
+
+  /* Spacing */
+  --sp1:4px; --sp2:8px; --sp3:16px; --sp4:24px;
+  --sp5:32px; --sp6:48px; --sp7:64px;
+
+  /* Type scale — GOV.UK */
+  --t-xl:      2.25rem;   /* h1 desktop */
+  --t-xl-m:    1.875rem;  /* h1 mobile */
+  --t-section: 1.75rem;   /* h2 section headings */
+  --t-lg:      1.5rem;    /* h2 base */
+  --t-md:      1.125rem;  /* h3 */
+  --t-body:    1rem;
+  --t-sm:      .875rem;
+  --t-xs:      .75rem;
+
+  /* Line heights */
+  --lh-heading: 1.1;
+  --lh-body:    1.5;
+  --lh-tight:   1.4;
+
+  /* Components */
+  --btn-pad-v: 10px;
+  --touch:     44px;
+  --max:       1200px;
+}
+
+/* ── RESET ──────────────────────────────────────────────────── */
+*,*::before,*::after { box-sizing:border-box; margin:0; padding:0 }
+html { font-size:16px; scroll-behavior:smooth }
+body {
+  font-family:"GDS Transport",Arial,sans-serif;
+  font-size:var(--t-body);
+  line-height:var(--lh-body);
+  color:var(--text);
+  background:var(--white);
+  -webkit-font-smoothing:antialiased;
+}
+@media(prefers-reduced-motion:reduce){*{transition-duration:.01ms!important}}
+
+/* ── TYPOGRAPHY ─────────────────────────────────────────────── */
+h1 { font-size:var(--t-xl); line-height:var(--lh-heading); font-weight:700; margin-bottom:var(--sp2) }
+h2 { font-size:var(--t-lg); line-height:var(--lh-heading); font-weight:700; color:var(--deep); margin:0 0 var(--sp3) }
+h3 { font-size:var(--t-md); line-height:var(--lh-heading); font-weight:700; color:var(--text); margin:0 0 var(--sp2) }
+p  { font-size:var(--t-body); line-height:var(--lh-body); margin-bottom:var(--sp3) }
+p:last-child { margin-bottom:0 }
+a  { color:var(--link); text-decoration:underline; text-underline-offset:3px }
+a:hover { color:var(--hover) }
+a:visited { color:#4c2c92 }
+
+/* ── SECTION CAPTIONS (h2 variant) ─────────────────────────── */
+h2.section-caption {
+  font-size:var(--t-section);
+  font-weight:700;
+  color:var(--deep);
+  padding-left:var(--sp3);
+  border-left:5px solid var(--blue);
+  margin-top:var(--sp6);
+  margin-bottom:var(--sp4);
+  line-height:var(--lh-heading);
+}
+.pg-hdr + section h2.section-caption { margin-top:0 }
+
+/* ── FOCUS ──────────────────────────────────────────────────── */
+:focus-visible {
+  outline:3px solid var(--focus);
+  outline-offset:0;
+  background:var(--focus);
+  color:var(--text);
+  box-shadow:0 -2px var(--focus),0 4px var(--border-dk);
+}
+a:focus-visible { color:var(--text) }
+
+/* ── SKIP ───────────────────────────────────────────────────── */
+.skip {
+  position:absolute; top:-100px; left:var(--sp3);
+  background:var(--focus); color:var(--text);
+  padding:var(--sp2) var(--sp3); font-weight:700;
+  z-index:1000; text-decoration:none;
+}
+.skip:focus { top:var(--sp2) }
+
+/* ── HEADER ─────────────────────────────────────────────────── */
+.hdr { background:var(--deep); border-bottom:4px solid var(--blue) }
+.hdr-in {
+  max-width:var(--max); margin:0 auto;
+  padding:var(--sp3) var(--sp4);
+  display:flex; align-items:center; justify-content:space-between;
+}
+.logo { display:flex; align-items:center; gap:var(--sp2); text-decoration:none; color:var(--white) }
+.logo img { height:40px; width:auto }
+.logo-txt { font-size:var(--t-md); font-weight:700 }
+.hdr-nav { display:flex; gap:var(--sp3); list-style:none }
+.hdr-nav a {
+  color:rgba(255,255,255,.85); text-decoration:none;
+  font-size:var(--t-sm); padding:var(--sp1) var(--sp2);
+  min-height:var(--touch); display:flex; align-items:center;
+}
+.hdr-nav a:hover { color:var(--white); text-decoration:underline }
+
+/* ── SERVICE BAR ────────────────────────────────────────────── */
+.svc { background:var(--blue); padding:var(--sp2) var(--sp4) }
+.svc-in { max-width:var(--max); margin:0 auto; font-size:var(--t-sm); color:var(--white) }
+
+/* ── BREADCRUMB ─────────────────────────────────────────────── */
+.bc { background:var(--grey); border-bottom:1px solid var(--divider) }
+.bc-in { max-width:var(--max); margin:0 auto; padding:var(--sp2) var(--sp4) }
+.bc-list { list-style:none; display:flex; flex-wrap:wrap; gap:var(--sp1); font-size:var(--t-sm) }
+.bc-item { display:flex; align-items:center; gap:var(--sp1) }
+.bc-item+.bc-item::before { content:"›"; color:var(--muted) }
+.bc-item a { color:var(--link) }
+.bc-cur { color:var(--text2); font-weight:700 }
+
+/* ── PAGE LAYOUT ────────────────────────────────────────────── */
+.page { max-width:var(--max); margin:0 auto; padding:var(--sp5) var(--sp4) var(--sp7) }
+
+/* ── BACK LINK ──────────────────────────────────────────────── */
+.back {
+  display:inline-flex; align-items:center; gap:var(--sp1);
+  font-size:var(--t-sm); color:var(--link);
+  text-decoration:none; margin-bottom:var(--sp5);
+  min-height:var(--touch); padding:var(--sp1) 0;
+}
+.back::before {
+  content:""; display:inline-block; width:0; height:0;
+  border-top:5px solid transparent; border-bottom:5px solid transparent;
+  border-right:6px solid var(--link); margin-top:1px;
+}
+.back:hover { color:var(--hover) }
+.back:hover::before { border-right-color:var(--hover) }
+
+/* ── PAGE HEADER ────────────────────────────────────────────── */
+.pg-hdr { margin-bottom:var(--sp4) }
+.pg-lead { font-size:var(--t-md); color:var(--text2); line-height:var(--lh-tight); margin-top:var(--sp2) }
+
+/* ── TOGGLES ────────────────────────────────────────────────── */
+.toggles { display:flex; flex-direction:column; gap:var(--sp3); margin-bottom:var(--sp5) }
+.toggle-row { display:grid; grid-template-columns:160px auto; align-items:center; gap:var(--sp3) }
+.toggle-lbl { font-size:var(--t-sm); font-weight:700; color:var(--text2) }
+.toggle { display:inline-flex; border:2px solid var(--border-dk); overflow:hidden; width:fit-content }
+.tog-btn {
+  padding:var(--btn-pad-v) var(--sp4);
+  background:var(--white); color:var(--text);
+  border:none; border-right:1px solid var(--border);
+  font-size:var(--t-sm); font-weight:700;
+  cursor:pointer; min-height:var(--touch); min-width:140px;
+  font-family:inherit; transition:background .1s; text-align:center;
+}
+.tog-btn:last-child { border-right:none }
+.tog-btn:hover { background:var(--grey) }
+.tog-btn.active { background:var(--deep); color:var(--white) }
+
+/* ── ELIGIBILITY LIST ───────────────────────────────────────── */
+.elig-list { list-style:none; border-top:1px solid var(--divider) }
+.elig-item {
+  display:grid; grid-template-columns:28px 1fr; gap:var(--sp2);
+  padding:var(--sp3) 0; border-bottom:1px solid var(--divider);
+  font-size:var(--t-body); align-items:flex-start; line-height:var(--lh-body);
+}
+.elig-mark {
+  width:22px; height:22px; border-radius:50%;
+  background:var(--blue); color:var(--white);
+  display:flex; align-items:center; justify-content:center;
+  font-size:var(--t-xs); font-weight:700; flex-shrink:0; margin-top:2px;
+}
+.elig-note {
+  font-size:var(--t-body); color:var(--text2);
+  margin-top:var(--sp1); margin-bottom:0; line-height:var(--lh-tight);
+}
+
+/* ── BOOK BEFORE YOU APPLY ──────────────────────────────────── */
+.book-list { list-style:none; border-top:1px solid var(--divider) }
+.book-item {
+  display:grid; grid-template-columns:1fr auto;
+  align-items:center; gap:var(--sp3);
+  padding:var(--sp3) 0; border-bottom:1px solid var(--divider);
+}
+.book-title { font-size:var(--t-body); font-weight:700; color:var(--text); margin-bottom:2px }
+.book-desc { font-size:var(--t-body); color:var(--text2); margin:0; line-height:var(--lh-body) }
+.book-link {
+  display:inline-flex; align-items:center; gap:var(--sp1);
+  font-size:var(--t-body); font-weight:700;
+  color:var(--link); text-decoration:none; white-space:nowrap;
+}
+.book-link:hover { color:var(--hover); text-decoration:underline }
+.book-note { font-size:var(--t-body); color:var(--text2); white-space:nowrap }
+
+/* Expandable providers */
+.book-details { width:100%;grid-column:1/-1 }
+.book-summary-inline {
+  font-size:var(--t-sm); color:var(--link); cursor:pointer;
+  list-style:none; display:inline-flex; align-items:center; gap:var(--sp1);
+  padding:var(--sp2) 0; font-weight:700; min-height:var(--touch);
+}
+.book-summary-inline::-webkit-details-marker { display:none }
+.book-details-body {
+  font-size:var(--t-sm); padding:var(--sp2) 0 var(--sp2) var(--sp4);
+  border-left:3px solid var(--divider); margin-top:var(--sp1);
+  display:flex; flex-direction:column; gap:var(--sp2);
+}
+.book-provider {
+  display:flex; align-items:center; justify-content:space-between;
+  gap:var(--sp3); font-size:var(--t-body); color:var(--text2);
+}
+
+/* ── REQUIREMENT LIST (documents) ───────────────────────────── */
+.req-list { list-style:none; border-top:1px solid var(--divider) }
+.req-item {
+  border-left:5px solid var(--blue);
+  padding:var(--sp3) 0 var(--sp3) var(--sp4);
+  margin-bottom:var(--sp1);
+  border-bottom:1px solid var(--divider);
+}
+.req-item:last-of-type { border-bottom:none }
+/* req-item--fee removed — all req-items use consistent GCC blue border */
+.req-title { font-size:var(--t-body); font-weight:700; color:var(--text); margin-bottom:var(--sp1) }
+.req-desc { font-size:var(--t-body); color:var(--text2); margin:0; line-height:var(--lh-body) }
+
+/* ── INSET ──────────────────────────────────────────────────── */
+.inset {
+  border-left:5px solid var(--border);
+  padding:var(--sp2) var(--sp3); margin-top:var(--sp2);
+}
+.inset p { font-size:var(--t-body); color:var(--text2); line-height:var(--lh-tight); margin-bottom:var(--sp1) }
+.inset p:last-child { margin-bottom:0 }
+
+/* ── FEE TAGS ───────────────────────────────────────────────── */
+.fee-tag+.fee-tag { margin-left:var(--sp2) }
+.fee-tag {
+  display:inline-block; font-size:var(--t-body); font-weight:700;
+  color:var(--deep); background:var(--grey);
+  padding:3px 10px; border:1px solid var(--border); margin-top:var(--sp2);
+}
+.fee-label {
+  display:block; font-size:var(--t-xs); font-weight:700;
+  color:var(--muted); text-transform:uppercase; letter-spacing:.05em;
+  margin-top:var(--sp2); margin-bottom:var(--sp1);
+}
+
+/* ── GOV.UK DETAILS/SUMMARY ─────────────────────────────────── */
+.govuk-details { margin-top:var(--sp2) }
+.govuk-details summary {
+  font-size:var(--t-body); color:var(--link); cursor:pointer;
+  list-style:none; display:inline-flex; align-items:center; gap:var(--sp1);
+  padding:var(--sp2) 0; min-height:var(--touch); font-weight:700;
+}
+.govuk-details summary::-webkit-details-marker { display:none }
+.govuk-details summary::before { content:"▶"; font-size:.6875rem; transition:transform .15s }
+.govuk-details[open] summary::before { transform:rotate(90deg) }
+.govuk-details-body {
+  font-size:var(--t-body); color:var(--text2);
+  padding:var(--sp2) 0 var(--sp2) var(--sp4);
+  border-left:5px solid var(--border);
+  margin-top:var(--sp1); line-height:var(--lh-body);
+}
+.govuk-details-body p { margin-bottom:var(--sp2) }
+.govuk-details-body p:last-child { margin-bottom:0 }
+
+/* ── WARNING TEXT ───────────────────────────────────────────── */
+.govuk-warning {
+  display:flex; align-items:flex-start; gap:var(--sp2); margin-bottom:var(--sp4);
+}
+.govuk-warning-icon { font-size:1.5rem; font-weight:700; color:var(--text); flex-shrink:0; line-height:1; margin-top:2px }
+.govuk-warning-text { font-weight:700; font-size:var(--t-body); color:var(--text) }
+
+/* ── PH NOTE ────────────────────────────────────────────────── */
+.ph-note {
+  font-size:var(--t-body); color:var(--text2);
+  padding:var(--sp2) var(--sp3); background:var(--grey);
+  border-left:5px solid var(--blue);
+}
+
+/* ── CTA ────────────────────────────────────────────────────── */
+.cta-wrap { margin-top:var(--sp6); padding-top:var(--sp4); border-top:1px solid var(--divider) }
+.cta {
+  display:inline-flex; align-items:center; gap:var(--sp2);
+  background:var(--blue); color:var(--white);
+  padding:var(--btn-pad-v) var(--sp5);
+  font-size:var(--t-md); font-weight:700;
+  text-decoration:none; min-height:var(--touch);
+  cursor:pointer; font-family:inherit; transition:background .1s;
+}
+.cta:hover { background:var(--hover); color:var(--white); text-decoration:none }
+.cta:visited { color:var(--white) }
+.cta:focus-visible {
+  outline:3px solid var(--focus); outline-offset:0;
+  background:var(--focus); color:var(--text);
+  box-shadow:0 -2px var(--focus),0 4px var(--border-dk);
+}
+.cta-sub { margin-top:var(--sp3); font-size:var(--t-sm); color:var(--muted) }
+
+/* ── FOOTER ─────────────────────────────────────────────────── */
+.ftr { background:var(--deep); color:var(--white); padding:var(--sp5) var(--sp4) }
+.ftr-in { max-width:var(--max); margin:0 auto; display:grid; grid-template-columns:repeat(auto-fit,minmax(180px,1fr)); gap:var(--sp5) }
+.ftr-h { font-size:var(--t-xs); font-weight:700; text-transform:uppercase; letter-spacing:.06em; margin-bottom:var(--sp3) }
+.ftr-ul { list-style:none }
+.ftr-ul li { margin-bottom:var(--sp2) }
+.ftr-ul a { color:rgba(255,255,255,.75); font-size:var(--t-sm); text-decoration:underline }
+.ftr-ul a:hover { color:var(--white) }
+.ftr-bot {
+  max-width:var(--max); margin:var(--sp4) auto 0;
+  padding-top:var(--sp3); border-top:1px solid rgba(255,255,255,.12);
+  font-size:var(--t-xs); color:rgba(255,255,255,.45);
+  display:flex; justify-content:space-between; flex-wrap:wrap; gap:var(--sp2);
+}
+
+/* ── RESPONSIVE ─────────────────────────────────────────────── */
+@media(max-width:800px) {
+  .hdr-in,.bc-in,.svc-in,.page { padding-left:var(--sp3); padding-right:var(--sp3) }
+  .hdr-nav { display:none }
+  h1 { font-size:var(--t-xl-m) }
+  h2.section-caption { font-size:var(--t-lg) }
+  .toggle-row { grid-template-columns:1fr; gap:var(--sp1) }
+  .toggle { width:100% }
+  .tog-btn { min-width:0; flex:1 }
+  .book-item { grid-template-columns:1fr; gap:var(--sp2) }
+  .book-action { justify-self:start }
+}
+@media(max-width:480px) {
+  h1 { font-size:var(--t-lg) }
+  .cta { width:100%; justify-content:center }
+}
+@media(forced-colors:active) {
+  .cta,.elig-mark { border:2px solid ButtonText }
+  .req-item { border-left-color:ButtonText }
+}
+
+
+.fee-section {
+  margin-bottom:var(--sp6);
+}
+.fee-section h2 {
+  font-size:var(--t-section);
+  font-weight:700;
+  color:var(--deep);
+  border-left:5px solid var(--blue);
+  padding-left:var(--sp3);
+  margin-bottom:var(--sp4);
+}
+.fee-table {
+  width:100%;
+  border-collapse:collapse;
+  margin-bottom:var(--sp4);
+  font-size:var(--t-body);
+}
+.fee-table th {
+  text-align:left;
+  padding:var(--sp2) var(--sp3);
+  background:var(--deep);
+  color:var(--white);
+  font-weight:700;
+}
+.fee-table td {
+  padding:var(--sp2) var(--sp3);
+  border-bottom:1px solid var(--divider);
+  vertical-align:top;
+}
+.fee-table tr:last-child td {
+  border-bottom:none;
+}
+.fee-table td:last-child {
+  text-align:right;
+  font-weight:700;
+  white-space:nowrap;
+  color:var(--deep);
+}
+.fee-note {
+  font-size:var(--t-body);
+  color:var(--text2);
+  margin-bottom:var(--sp4);
+}
+.fee-link {
+  display:inline-block;
+  margin-top:var(--sp3);
+  font-size:var(--t-body);
+  font-weight:700;
+  color:var(--link);
+}
+</style>
+</head>
+<body>
+
+<a href="#main-content" class="skip">Skip to main content</a>
+
+<header class="hdr" role="banner">
+  <div class="hdr-in">
+    <a href="/" class="logo" aria-label="Gloucester City Council — home">
+      <img src="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/templates/assets/GCC_logo.svg" alt="Gloucester City Council" style="filter:brightness(0) invert(1)">
+    </a>
+  </div>
+</header>
+
+<div class="svc"><div class="svc-in">Licensing &amp; regulations</div></div>
+
+<nav class="bc" aria-label="Breadcrumb">
+  <div class="bc-in"><ol class="bc-list">
+    <li class="bc-item"><a href="#">Home</a></li>
+    <li class="bc-item"><a href="#">Licensing &amp; regulations</a></li>
+    <li class="bc-item"><a href="gcc-hcph-landing.html">Hackney carriage and private hire</a></li>
+    <li class="bc-item"><span class="bc-cur" aria-current="page">Fees and charges</span></li>
+  </ol></div>
+</nav>
+
+<main id="main-content">
+<div class="page">
+
+  <a href="gcc-hcph-landing.html" class="back">Back</a>
+
+  <header class="pg-hdr">
+    <h1>Fees and charges</h1>
+    <p class="pg-lead">Current fees for hackney carriage and private hire licences, tests and amendments. Fees are set annually and reviewed by Full Council.</p>
+    <p style="font-size:var(--t-body);color:var(--text2);margin-top:var(--sp2)">Fee schedule: 2026 to 2027</p>
+  </header>
+
+  <!-- DRIVER LICENCES -->
+  <div class="fee-section">
+    <h2>Driver licences</h2>
+    <table class="fee-table" aria-label="Driver licence fees">
+      <thead>
+        <tr><th scope="col">Licence</th><th scope="col" style="text-align:right">Fee</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>New driver licence — 1 year</td><td>£132.00</td></tr>
+        <tr><td>New driver licence — 3 years</td><td>£289.00</td></tr>
+        <tr><td>Renewal — 1 year</td><td>£93.00</td></tr>
+        <tr><td>Renewal — 3 years</td><td>£241.00</td></tr>
+        <tr><td>Replacement driver badge</td><td>£10.00</td></tr>
+      </tbody>
+    </table>
+    <p class="fee-note">Fees apply to both hackney carriage and private hire driver licences.</p>
+  </div>
+
+  <!-- DRIVER TESTS -->
+  <div class="fee-section">
+    <h2>Driver tests and training</h2>
+    <table class="fee-table" aria-label="Driver test and training fees">
+      <thead>
+        <tr><th scope="col">Test or training</th><th scope="col" style="text-align:right">Fee</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>Hackney carriage knowledge test</td><td>£149.00</td></tr>
+        <tr><td>Hackney carriage knowledge test retake</td><td>£149.00</td></tr>
+        <tr><td>Private hire knowledge test</td><td>£67.00</td></tr>
+        <tr><td>English proficiency test</td><td>£45.00</td></tr>
+        <tr><td>Safeguarding awareness training</td><td>£40.00</td></tr>
+      </tbody>
+    </table>
+    <p class="fee-note">Driving assessment fees are set by the approved provider — contact them directly.</p>
+  </div>
+
+  <!-- VEHICLE LICENCES -->
+  <div class="fee-section">
+    <h2>Vehicle licences</h2>
+    <table class="fee-table" aria-label="Vehicle licence fees">
+      <thead>
+        <tr><th scope="col">Licence or service</th><th scope="col" style="text-align:right">Fee</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>Vehicle licence — annual (new and renewal)</td><td>£222.00</td></tr>
+        <tr><td>Transfer of ownership</td><td>£59.00</td></tr>
+        <tr><td>Change of vehicle including new plates</td><td>£78.00</td></tr>
+        <tr><td>Licensing Officer vehicle inspection (cosmetic check)</td><td>£23.00</td></tr>
+        <tr><td>Replacement rear exterior plate</td><td>£20.00</td></tr>
+        <tr><td>Replacement interior plate or front exterior plate</td><td>£15.00</td></tr>
+        <tr><td>Copy or replacement licence certificate</td><td>£12.00</td></tr>
+        <tr><td>Change of address notification</td><td>£12.00</td></tr>
+      </tbody>
+    </table>
+    <p class="fee-note">Vehicle licence fees apply to both hackney carriage and private hire vehicles.</p>
+  </div>
+
+  <!-- OPERATOR LICENCES -->
+  <div class="fee-section">
+    <h2>Private hire operator licences</h2>
+    <table class="fee-table" aria-label="Operator licence fees">
+      <thead>
+        <tr><th scope="col">Fleet size</th><th scope="col" style="text-align:right">1 year</th><th scope="col" style="text-align:right">5 years</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>Micro — up to 3 vehicles</td><td style="text-align:right;font-weight:700;color:var(--deep)">£352.00</td><td style="text-align:right;font-weight:700;color:var(--deep)">£1,407.00</td></tr>
+        <tr><td>Small — 4 to 10 vehicles</td><td style="text-align:right;font-weight:700;color:var(--deep)">£727.00</td><td style="text-align:right;font-weight:700;color:var(--deep)">£2,909.00</td></tr>
+        <tr><td>Medium — 11 to 30 vehicles</td><td style="text-align:right;font-weight:700;color:var(--deep)">£1,173.00</td><td style="text-align:right;font-weight:700;color:var(--deep)">£4,692.00</td></tr>
+        <tr><td>Large — 31 or more vehicles</td><td style="text-align:right;font-weight:700;color:var(--deep)">£1,759.00</td><td style="text-align:right;font-weight:700;color:var(--deep)">£7,038.00</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+
+</div>
+</main>
+
+<footer class="ftr" role="contentinfo">
+  <div class="ftr-in">
+    <div>
+      <div class="ftr-h">Licensing</div>
+      <ul class="ftr-ul">
+        <li><a href="gcc-hcph-landing.html">Hackney carriage and private hire</a></li>
+        <li><a href="#">Premises licences</a></li>
+        <li><a href="#">Personal licences</a></li>
+      </ul>
+    </div>
+    <div>
+      <div class="ftr-h">About GCC</div>
+      <ul class="ftr-ul">
+        <li><a href="#">Accessibility statement</a></li>
+        <li><a href="#">Privacy notice</a></li>
+        <li><a href="#">Cookies</a></li>
+        <li><a href="#">Contact us</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="ftr-bot">
+    <span>© Gloucester City Council</span>
+    <span>Last updated: July 2026</span>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/Taxi website/Webpages/gcc-hcph-landing.html
+++ b/Taxi website/Webpages/gcc-hcph-landing.html
@@ -1,0 +1,373 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Hackney carriage and private hire — Gloucester City Council</title>
+<style>
+:root {
+  --blue:      #0054A4;
+  --hover:     #003E7B;
+  --deep:      #0B2E53;
+  --white:     #FFFFFF;
+  --grey:      #F3F2F1;
+  --border:    #B1B4B6;
+  --border-dk: #0B0C0C;
+  --divider:   #D8D8D8;
+  --text:      #0B0C0C;
+  --text2:     #505A5F;
+  --muted:     #6F777B;
+  --link:      #0054A4;
+  --focus:     #FFDD00;
+  --sp1:4px;--sp2:8px;--sp3:16px;--sp4:24px;--sp5:32px;--sp6:48px;--sp7:64px;
+  --t-xl:2.25rem;--t-xl-m:1.875rem;--t-lg:1.5rem;--t-md:1.125rem;
+  --t-body:1rem;--t-sm:.875rem;--t-xs:.75rem;
+  --lh-heading:1.1;--lh-body:1.5;--lh-tight:1.4;
+  --max:1200px;--touch:44px;--r:4px;
+}
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+html{font-size:16px;scroll-behavior:smooth}
+body{font-family:"GDS Transport",Arial,sans-serif;font-size:var(--t-body);line-height:var(--lh-body);color:var(--text);background:var(--white);-webkit-font-smoothing:antialiased}
+@media(prefers-reduced-motion:reduce){*{transition-duration:.01ms!important}}
+
+h1{font-size:var(--t-xl);line-height:var(--lh-heading);font-weight:700;margin-bottom:var(--sp2)}
+h2{font-size:var(--t-lg);line-height:var(--lh-heading);font-weight:700;margin:0 0 var(--sp1)}
+p{font-size:var(--t-body);line-height:var(--lh-body);margin-bottom:var(--sp3)}
+p:last-child{margin-bottom:0}
+a{color:var(--link);text-decoration:underline;text-underline-offset:3px}
+a:hover{color:var(--hover)}
+a:visited{color:#4c2c92}
+
+:focus-visible{outline:3px solid var(--focus);outline-offset:0;background:var(--focus);color:var(--text);box-shadow:0 -2px var(--focus),0 4px var(--border-dk)}
+a:focus-visible{color:var(--text)}
+
+.skip{position:absolute;top:-100px;left:var(--sp3);background:var(--focus);color:var(--text);padding:var(--sp2) var(--sp3);font-weight:700;z-index:1000;text-decoration:none}
+.skip:focus{top:var(--sp2)}
+
+/* HEADER */
+.hdr{background:var(--deep);border-bottom:4px solid var(--blue)}
+.hdr-in{max-width:var(--max);margin:0 auto;padding:var(--sp3) var(--sp4);display:flex;align-items:center;justify-content:space-between}
+.logo{display:flex;align-items:center;gap:var(--sp2);text-decoration:none;color:var(--white)}
+.logo img{height:40px;width:auto}
+.logo-txt{font-size:var(--t-md);font-weight:700}
+.hdr-nav{display:flex;gap:var(--sp3);list-style:none}
+.hdr-nav a{color:rgba(255,255,255,.85);text-decoration:none;font-size:var(--t-sm);padding:var(--sp1) var(--sp2);min-height:var(--touch);display:flex;align-items:center}
+.hdr-nav a:hover{color:var(--white);text-decoration:underline}
+
+/* SERVICE + BC */
+.svc{background:var(--blue);padding:var(--sp2) var(--sp4)}
+.svc-in{max-width:var(--max);margin:0 auto;font-size:var(--t-sm);color:var(--white)}
+.bc{background:var(--grey);border-bottom:1px solid var(--divider)}
+.bc-in{max-width:var(--max);margin:0 auto;padding:var(--sp2) var(--sp4)}
+.bc-list{list-style:none;display:flex;flex-wrap:wrap;gap:var(--sp1);font-size:var(--t-sm)}
+.bc-item{display:flex;align-items:center;gap:var(--sp1)}
+.bc-item+.bc-item::before{content:"›";color:var(--muted)}
+.bc-item a{color:var(--link)}
+.bc-cur{color:var(--text2);font-weight:700}
+
+/* PAGE */
+.page{max-width:var(--max);margin:0 auto;padding:var(--sp5) var(--sp4) var(--sp7)}
+
+/* PAGE HEADER */
+.pg-hdr{margin-bottom:var(--sp5)}
+.pg-lead{font-size:var(--t-md);color:var(--text2);line-height:var(--lh-tight);margin-top:var(--sp2);margin-bottom:0}
+
+/* GRID ROWS */
+/* grid-row-1 removed — replaced by primary-nav */
+/* Row 2: 3 secondary cards */
+
+
+/* CARD */
+.card{
+  border:2px solid var(--border-dk);
+  background:var(--white);
+  display:flex;
+  flex-direction:column;
+}
+/* PRIMARY NAV BUTTONS — row 1 */
+.primary-nav{
+  display:grid;
+  grid-template-columns:1fr 1fr 1fr;
+  gap:var(--sp4);
+  margin-bottom:var(--sp4);
+  align-items:stretch;
+}
+/* ROW 2 */
+.grid-row-2{
+  display:grid;
+  grid-template-columns:1fr 1fr 1fr;
+  gap:var(--sp4);
+  margin-bottom:var(--sp6);
+  align-items:stretch;
+}
+.primary-nav .primary-btn,
+.grid-row-2 .primary-btn{
+  min-height:120px;
+  box-sizing:border-box;
+}
+.primary-btn{
+  display:flex;
+  flex-direction:column;
+  align-items:flex-start;
+  justify-content:flex-start;  /* text from top, not bottom */
+  background:var(--deep);
+  color:var(--white);
+  font-size:var(--t-lg);
+  font-weight:700;
+  text-decoration:none;
+  padding:var(--sp4);
+  min-height:auto;             /* no forced height — content drives size */
+  border:2px solid var(--deep);
+  text-align:left;
+  transition:background .1s, border-color .1s;
+}
+.primary-btn-title{
+  font-size:var(--t-lg);
+  font-weight:700;
+  line-height:var(--lh-heading);
+  margin-bottom:var(--sp1);
+}
+.primary-btn-sub{
+  font-size:var(--t-body);     /* up from 14px to 16px for readability */
+  font-weight:400;
+  color:rgba(255,255,255,.85); /* higher opacity — passes WCAG AA */
+  line-height:var(--lh-tight);
+}
+.primary-btn:hover{
+  background:var(--blue);
+  border-color:var(--blue);
+  color:var(--white);
+  text-decoration:none;
+}
+.primary-btn:visited{color:var(--white)}
+.primary-btn:focus-visible{
+  outline:3px solid var(--focus);
+  outline-offset:0;
+  background:var(--focus);
+  color:var(--text);
+  border-color:var(--border-dk);
+  box-shadow:0 -2px var(--focus),0 4px var(--border-dk);
+}
+.primary-btn--pending{
+  background:var(--muted);       /* solid colour — no opacity contrast issue */
+  border-color:var(--muted);
+  cursor:default;
+  pointer-events:none;
+}
+.primary-btn--pending .primary-btn-sub{
+  color:rgba(255,255,255,1);     /* full white — passes WCAG AA on #6F777B */
+}
+
+/* CARD HEADER */
+.card-hdr{
+  background:var(--deep);
+  color:var(--white);
+  padding:var(--sp4);
+  border-bottom:4px solid var(--blue);
+}
+.card-hdr h2{color:var(--white);font-size:var(--t-lg)}
+.card-hdr-desc{
+  font-size:var(--t-sm);
+  color:rgba(255,255,255,.7);
+  margin-top:var(--sp1);
+  margin-bottom:0;
+  line-height:var(--lh-tight);
+}
+
+/* PENDING card header variant */
+.card-hdr--pending{border-bottom-color:var(--border)}
+.card-hdr--pending h2{color:rgba(255,255,255,.6)}
+.card-hdr--pending .card-hdr-desc{color:rgba(255,255,255,.45)}
+
+/* CARD BODY */
+.card-body{padding:var(--sp2) 0;flex:1;display:flex;flex-direction:column}
+
+/* LINK GROUP LABEL */
+.link-grp-lbl{
+  display:block;
+  font-size:var(--t-xs);
+  font-weight:700;
+  text-transform:uppercase;
+  letter-spacing:.07em;
+  color:var(--muted);
+  padding:var(--sp2) var(--sp4) var(--sp1);
+}
+.card-body>.link-grp-lbl:first-child{padding-top:var(--sp3)}
+
+/* CARD LINK */
+/* card-cta removed */
+.card-link{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:var(--sp3);
+  padding:var(--sp2) var(--sp4);
+  font-size:var(--t-body);
+  font-weight:700;
+  color:var(--link);
+  text-decoration:none;
+  border-bottom:1px solid var(--divider);
+  min-height:var(--touch);
+  transition:background .1s;
+}
+.card-link:last-child{border-bottom:none}
+.card-link:hover{background:var(--grey);color:var(--hover);text-decoration:none}
+.card-link:focus-visible{outline:3px solid var(--focus);outline-offset:-3px;background:var(--focus);color:var(--text)}
+.card-link-arr{font-size:var(--t-md);color:var(--border);flex-shrink:0;transition:color .1s}
+.card-link:hover .card-link-arr{color:var(--link)}
+
+/* PENDING card link */
+.card-link--pending{
+  color:var(--muted);
+  font-weight:400;
+  cursor:default;
+  pointer-events:none;
+}
+.card-link--pending .card-link-arr{display:none}
+
+/* PENDING message block */
+.card-pending-msg{
+  padding:var(--sp4);
+  font-size:var(--t-sm);
+  color:var(--text2);
+  line-height:var(--lh-body);
+  flex:1;
+  display:flex;
+  flex-direction:column;
+  justify-content:center;
+}
+.card-pending-msg p{margin-bottom:var(--sp2)}
+.card-pending-msg p:last-child{margin-bottom:0}
+
+/* CONTACT STRIP removed */
+
+/* FOOTER */
+.ftr{background:var(--deep);color:var(--white);padding:var(--sp5) var(--sp4)}
+.ftr-in{max-width:var(--max);margin:0 auto;display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:var(--sp5)}
+.ftr-h{font-size:var(--t-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;margin-bottom:var(--sp3)}
+.ftr-ul{list-style:none}
+.ftr-ul li{margin-bottom:var(--sp2)}
+.ftr-ul a{color:rgba(255,255,255,.75);font-size:var(--t-sm);text-decoration:underline}
+.ftr-ul a:hover{color:var(--white)}
+.ftr-bot{max-width:var(--max);margin:var(--sp4) auto 0;padding-top:var(--sp3);border-top:1px solid rgba(255,255,255,.12);font-size:var(--t-xs);color:rgba(255,255,255,.45);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--sp2)}
+
+/* RESPONSIVE */
+@media(max-width:900px){
+  .hdr-in,.bc-in,.svc-in,.page{padding-left:var(--sp3);padding-right:var(--sp3)}
+  .hdr-nav{display:none}
+  .primary-nav{grid-template-columns:1fr}
+  .grid-row-2{grid-template-columns:1fr}
+}
+@media(max-width:600px){
+  h1{font-size:var(--t-xl-m)}
+  .grid-row-2{grid-template-columns:1fr}
+  .contact-items{flex-direction:column;align-items:flex-start;gap:var(--sp2)}
+}
+@media(forced-colors:active){
+  .card{border:2px solid ButtonText}
+  .card-hdr{border-bottom:4px solid ButtonText}
+}
+</style>
+</head>
+<body>
+
+<a href="#main-content" class="skip">Skip to main content</a>
+
+<header class="hdr" role="banner">
+  <div class="hdr-in">
+    <a href="/" class="logo" aria-label="Gloucester City Council — home">
+      <img src="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/templates/assets/GCC_logo.svg" alt="Gloucester City Council" style="filter:brightness(0) invert(1)">
+    </a>
+  </div>
+</header>
+
+<div class="svc"><div class="svc-in">Licensing &amp; regulations</div></div>
+
+<nav class="bc" aria-label="Breadcrumb">
+  <div class="bc-in"><ol class="bc-list">
+    <li class="bc-item"><a href="#">Home</a></li>
+    <li class="bc-item"><a href="#">Licensing &amp; regulations</a></li>
+    <li class="bc-item"><span class="bc-cur" aria-current="page">Hackney carriage and private hire</span></li>
+  </ol></div>
+</nav>
+
+<main id="main-content">
+<div class="page">
+
+  <header class="pg-hdr">
+    <h1>Hackney carriage and private hire licensing</h1>
+    <p class="pg-lead">Licences for drivers and vehicles in the Gloucester City Council area. Select what you need below.</p>
+  </header>
+
+  <!-- ROW 1: THREE PRIMARY BUTTONS -->
+  <nav class="primary-nav" aria-label="Licensing sections">
+    <a href="gcc-driver-licence.html" class="primary-btn">
+      <span class="primary-btn-title">Drivers</span>
+      <span class="primary-btn-sub">Apply for or renew your driver licence</span>
+    </a>
+    <a href="gcc-vehicle-licence.html" class="primary-btn">
+      <span class="primary-btn-title">Vehicles</span>
+      <span class="primary-btn-sub">Apply for or renew your vehicle licence</span>
+    </a>
+    <a href="#" class="primary-btn primary-btn--pending">
+      <span class="primary-btn-title">Operators</span>
+      <span class="primary-btn-sub">Content coming soon</span>
+    </a>
+  </nav>
+
+  <!-- ROW 2: SECONDARY — OPERATORS, CHANGES, PASSENGERS -->
+  <div class="grid-row-2" role="list" aria-label="Passengers, changes and useful documents">
+
+    <!-- PASSENGERS -->
+    <a href="gcc-hcph-passengers.html" class="primary-btn">
+      <span class="primary-btn-title">Passengers</span>
+      <span class="primary-btn-sub">Taxi ranks, fares, complaints and accessibility</span>
+    </a>
+
+    <!-- SOMETHING HAS CHANGED -->
+    <a href="gcc-hcph-changes.html" class="primary-btn">
+      <span class="primary-btn-title">Something has changed</span>
+      <span class="primary-btn-sub">Updates to your licence, vehicle or circumstances</span>
+    </a>
+
+    <!-- POLICIES AND DOCUMENTS -->
+    <a href="gcc-hcph-documents.html" class="primary-btn">
+      <span class="primary-btn-title">Licensing information</span>
+      <span class="primary-btn-sub">Rule books, policies, forms and reference documents</span>
+    </a>
+
+  </div><!-- /row 2 -->
+
+</div><!-- /page -->
+
+</main>
+
+<footer class="ftr" role="contentinfo">
+  <div class="ftr-in">
+    <div>
+      <div class="ftr-h">Licensing</div>
+      <ul class="ftr-ul">
+        <li><a href="#">Hackney carriage and private hire</a></li>
+        <li><a href="#">Premises licences</a></li>
+        <li><a href="#">Personal licences</a></li>
+        <li><a href="#">Street trading</a></li>
+      </ul>
+    </div>
+    <div>
+      <div class="ftr-h">About GCC</div>
+      <ul class="ftr-ul">
+        <li><a href="#">Accessibility statement</a></li>
+        <li><a href="#">Privacy notice</a></li>
+        <li><a href="#">Cookies</a></li>
+        <li><a href="#">Contact us</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="ftr-bot">
+    <span>© Gloucester City Council</span>
+    <span>Last updated: July 2026</span>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/Taxi website/Webpages/gcc-hcph-passengers.html
+++ b/Taxi website/Webpages/gcc-hcph-passengers.html
@@ -1,0 +1,614 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Passengers — Gloucester City Council</title>
+<style>
+/* ══════════════════════════════════════════════════════════════
+   GCC LICENSING — SHARED STYLESHEET
+   GOV.UK Done With Intention
+   All pages: landing, driver, vehicle, operator
+   ══════════════════════════════════════════════════════════════ */
+
+:root {
+  /* Brand */
+  --blue:       #0054A4;
+  --hover:      #003E7B;
+  --deep:       #0B2E53;
+  --white:      #FFFFFF;
+  --grey:       #F3F2F1;
+  --grey2:      #E8E8E8;
+  --border:     #B1B4B6;
+  --border-dk:  #0B0C0C;
+  --divider:    #D8D8D8;
+  --text:       #0B0C0C;
+  --text2:      #505A5F;
+  --muted:      #6F777B;
+  --link:       #0054A4;
+  --focus:      #FFDD00;
+
+  /* Spacing */
+  --sp1:4px; --sp2:8px; --sp3:16px; --sp4:24px;
+  --sp5:32px; --sp6:48px; --sp7:64px;
+
+  /* Type scale — GOV.UK */
+  --t-xl:      2.25rem;   /* h1 desktop */
+  --t-xl-m:    1.875rem;  /* h1 mobile */
+  --t-section: 1.75rem;   /* h2 section headings */
+  --t-lg:      1.5rem;    /* h2 base */
+  --t-md:      1.125rem;  /* h3 */
+  --t-body:    1rem;
+  --t-sm:      .875rem;
+  --t-xs:      .75rem;
+
+  /* Line heights */
+  --lh-heading: 1.1;
+  --lh-body:    1.5;
+  --lh-tight:   1.4;
+
+  /* Components */
+  --btn-pad-v: 10px;
+  --touch:     44px;
+  --max:       1200px;
+}
+
+/* ── RESET ──────────────────────────────────────────────────── */
+*,*::before,*::after { box-sizing:border-box; margin:0; padding:0 }
+html { font-size:16px; scroll-behavior:smooth }
+body {
+  font-family:"GDS Transport",Arial,sans-serif;
+  font-size:var(--t-body);
+  line-height:var(--lh-body);
+  color:var(--text);
+  background:var(--white);
+  -webkit-font-smoothing:antialiased;
+}
+@media(prefers-reduced-motion:reduce){*{transition-duration:.01ms!important}}
+
+/* ── TYPOGRAPHY ─────────────────────────────────────────────── */
+h1 { font-size:var(--t-xl); line-height:var(--lh-heading); font-weight:700; margin-bottom:var(--sp2) }
+h2 { font-size:var(--t-lg); line-height:var(--lh-heading); font-weight:700; color:var(--deep); margin:0 0 var(--sp3) }
+h3 { font-size:var(--t-md); line-height:var(--lh-heading); font-weight:700; color:var(--text); margin:0 0 var(--sp2) }
+p  { font-size:var(--t-body); line-height:var(--lh-body); margin-bottom:var(--sp3) }
+p:last-child { margin-bottom:0 }
+a  { color:var(--link); text-decoration:underline; text-underline-offset:3px }
+a:hover { color:var(--hover) }
+a:visited { color:#4c2c92 }
+
+/* ── SECTION CAPTIONS (h2 variant) ─────────────────────────── */
+h2.section-caption {
+  font-size:var(--t-section);
+  font-weight:700;
+  color:var(--deep);
+  padding-left:var(--sp3);
+  border-left:5px solid var(--blue);
+  margin-top:var(--sp6);
+  margin-bottom:var(--sp4);
+  line-height:var(--lh-heading);
+}
+.pg-hdr + section h2.section-caption { margin-top:0 }
+
+/* ── FOCUS ──────────────────────────────────────────────────── */
+:focus-visible {
+  outline:3px solid var(--focus);
+  outline-offset:0;
+  background:var(--focus);
+  color:var(--text);
+  box-shadow:0 -2px var(--focus),0 4px var(--border-dk);
+}
+a:focus-visible { color:var(--text) }
+
+/* ── SKIP ───────────────────────────────────────────────────── */
+.skip {
+  position:absolute; top:-100px; left:var(--sp3);
+  background:var(--focus); color:var(--text);
+  padding:var(--sp2) var(--sp3); font-weight:700;
+  z-index:1000; text-decoration:none;
+}
+.skip:focus { top:var(--sp2) }
+
+/* ── HEADER ─────────────────────────────────────────────────── */
+.hdr { background:var(--deep); border-bottom:4px solid var(--blue) }
+.hdr-in {
+  max-width:var(--max); margin:0 auto;
+  padding:var(--sp3) var(--sp4);
+  display:flex; align-items:center; justify-content:space-between;
+}
+.logo { display:flex; align-items:center; gap:var(--sp2); text-decoration:none; color:var(--white) }
+.logo img { height:40px; width:auto }
+.logo-txt { font-size:var(--t-md); font-weight:700 }
+.hdr-nav { display:flex; gap:var(--sp3); list-style:none }
+.hdr-nav a {
+  color:rgba(255,255,255,.85); text-decoration:none;
+  font-size:var(--t-sm); padding:var(--sp1) var(--sp2);
+  min-height:var(--touch); display:flex; align-items:center;
+}
+.hdr-nav a:hover { color:var(--white); text-decoration:underline }
+
+/* ── SERVICE BAR ────────────────────────────────────────────── */
+.svc { background:var(--blue); padding:var(--sp2) var(--sp4) }
+.svc-in { max-width:var(--max); margin:0 auto; font-size:var(--t-sm); color:var(--white) }
+
+/* ── BREADCRUMB ─────────────────────────────────────────────── */
+.bc { background:var(--grey); border-bottom:1px solid var(--divider) }
+.bc-in { max-width:var(--max); margin:0 auto; padding:var(--sp2) var(--sp4) }
+.bc-list { list-style:none; display:flex; flex-wrap:wrap; gap:var(--sp1); font-size:var(--t-sm) }
+.bc-item { display:flex; align-items:center; gap:var(--sp1) }
+.bc-item+.bc-item::before { content:"›"; color:var(--muted) }
+.bc-item a { color:var(--link) }
+.bc-cur { color:var(--text2); font-weight:700 }
+
+/* ── PAGE LAYOUT ────────────────────────────────────────────── */
+.page { max-width:var(--max); margin:0 auto; padding:var(--sp5) var(--sp4) var(--sp7) }
+
+/* ── BACK LINK ──────────────────────────────────────────────── */
+.back {
+  display:inline-flex; align-items:center; gap:var(--sp1);
+  font-size:var(--t-sm); color:var(--link);
+  text-decoration:none; margin-bottom:var(--sp5);
+  min-height:var(--touch); padding:var(--sp1) 0;
+}
+.back::before {
+  content:""; display:inline-block; width:0; height:0;
+  border-top:5px solid transparent; border-bottom:5px solid transparent;
+  border-right:6px solid var(--link); margin-top:1px;
+}
+.back:hover { color:var(--hover) }
+.back:hover::before { border-right-color:var(--hover) }
+
+/* ── PAGE HEADER ────────────────────────────────────────────── */
+.pg-hdr { margin-bottom:var(--sp4) }
+.pg-lead { font-size:var(--t-md); color:var(--text2); line-height:var(--lh-tight); margin-top:var(--sp2) }
+
+/* ── TOGGLES ────────────────────────────────────────────────── */
+.toggles { display:flex; flex-direction:column; gap:var(--sp3); margin-bottom:var(--sp5) }
+.toggle-row { display:grid; grid-template-columns:160px auto; align-items:center; gap:var(--sp3) }
+.toggle-lbl { font-size:var(--t-sm); font-weight:700; color:var(--text2) }
+.toggle { display:inline-flex; border:2px solid var(--border-dk); overflow:hidden; width:fit-content }
+.tog-btn {
+  padding:var(--btn-pad-v) var(--sp4);
+  background:var(--white); color:var(--text);
+  border:none; border-right:1px solid var(--border);
+  font-size:var(--t-sm); font-weight:700;
+  cursor:pointer; min-height:var(--touch); min-width:140px;
+  font-family:inherit; transition:background .1s; text-align:center;
+}
+.tog-btn:last-child { border-right:none }
+.tog-btn:hover { background:var(--grey) }
+.tog-btn.active { background:var(--deep); color:var(--white) }
+
+/* ── ELIGIBILITY LIST ───────────────────────────────────────── */
+.elig-list { list-style:none; border-top:1px solid var(--divider) }
+.elig-item {
+  display:grid; grid-template-columns:28px 1fr; gap:var(--sp2);
+  padding:var(--sp3) 0; border-bottom:1px solid var(--divider);
+  font-size:var(--t-body); align-items:flex-start; line-height:var(--lh-body);
+}
+.elig-mark {
+  width:22px; height:22px; border-radius:50%;
+  background:var(--blue); color:var(--white);
+  display:flex; align-items:center; justify-content:center;
+  font-size:var(--t-xs); font-weight:700; flex-shrink:0; margin-top:2px;
+}
+.elig-note {
+  font-size:var(--t-body); color:var(--text2);
+  margin-top:var(--sp1); margin-bottom:0; line-height:var(--lh-tight);
+}
+
+/* ── BOOK BEFORE YOU APPLY ──────────────────────────────────── */
+.book-list { list-style:none; border-top:1px solid var(--divider) }
+.book-item {
+  display:grid; grid-template-columns:1fr auto;
+  align-items:center; gap:var(--sp3);
+  padding:var(--sp3) 0; border-bottom:1px solid var(--divider);
+}
+.book-title { font-size:var(--t-body); font-weight:700; color:var(--text); margin-bottom:2px }
+.book-desc { font-size:var(--t-body); color:var(--text2); margin:0; line-height:var(--lh-body) }
+.book-link {
+  display:inline-flex; align-items:center; gap:var(--sp1);
+  font-size:var(--t-body); font-weight:700;
+  color:var(--link); text-decoration:none; white-space:nowrap;
+}
+.book-link:hover { color:var(--hover); text-decoration:underline }
+.book-note { font-size:var(--t-body); color:var(--text2); white-space:nowrap }
+
+/* Expandable providers */
+.book-details { width:100%;grid-column:1/-1 }
+.book-summary-inline {
+  font-size:var(--t-sm); color:var(--link); cursor:pointer;
+  list-style:none; display:inline-flex; align-items:center; gap:var(--sp1);
+  padding:var(--sp2) 0; font-weight:700; min-height:var(--touch);
+}
+.book-summary-inline::-webkit-details-marker { display:none }
+.book-details-body {
+  font-size:var(--t-sm); padding:var(--sp2) 0 var(--sp2) var(--sp4);
+  border-left:3px solid var(--divider); margin-top:var(--sp1);
+  display:flex; flex-direction:column; gap:var(--sp2);
+}
+.book-provider {
+  display:flex; align-items:center; justify-content:space-between;
+  gap:var(--sp3); font-size:var(--t-body); color:var(--text2);
+}
+
+/* ── REQUIREMENT LIST (documents) ───────────────────────────── */
+.req-list { list-style:none; border-top:1px solid var(--divider) }
+.req-item {
+  border-left:5px solid var(--blue);
+  padding:var(--sp3) 0 var(--sp3) var(--sp4);
+  margin-bottom:var(--sp1);
+  border-bottom:1px solid var(--divider);
+}
+.req-item:last-of-type { border-bottom:none }
+/* req-item--fee removed — all req-items use consistent GCC blue border */
+.req-title { font-size:var(--t-body); font-weight:700; color:var(--text); margin-bottom:var(--sp1) }
+.req-desc { font-size:var(--t-body); color:var(--text2); margin:0; line-height:var(--lh-body) }
+
+/* ── INSET ──────────────────────────────────────────────────── */
+.inset {
+  border-left:5px solid var(--border);
+  padding:var(--sp2) var(--sp3); margin-top:var(--sp2);
+}
+.inset p { font-size:var(--t-body); color:var(--text2); line-height:var(--lh-tight); margin-bottom:var(--sp1) }
+.inset p:last-child { margin-bottom:0 }
+
+/* ── FEE TAGS ───────────────────────────────────────────────── */
+.fee-tag+.fee-tag { margin-left:var(--sp2) }
+.fee-tag {
+  display:inline-block; font-size:var(--t-body); font-weight:700;
+  color:var(--deep); background:var(--grey);
+  padding:3px 10px; border:1px solid var(--border); margin-top:var(--sp2);
+}
+.fee-label {
+  display:block; font-size:var(--t-xs); font-weight:700;
+  color:var(--muted); text-transform:uppercase; letter-spacing:.05em;
+  margin-top:var(--sp2); margin-bottom:var(--sp1);
+}
+
+/* ── GOV.UK DETAILS/SUMMARY ─────────────────────────────────── */
+.govuk-details { margin-top:var(--sp2) }
+.govuk-details summary {
+  font-size:var(--t-body); color:var(--link); cursor:pointer;
+  list-style:none; display:inline-flex; align-items:center; gap:var(--sp1);
+  padding:var(--sp2) 0; min-height:var(--touch); font-weight:700;
+}
+.govuk-details summary::-webkit-details-marker { display:none }
+.govuk-details summary::before { content:"▶"; font-size:.6875rem; transition:transform .15s }
+.govuk-details[open] summary::before { transform:rotate(90deg) }
+.govuk-details-body {
+  font-size:var(--t-body); color:var(--text2);
+  padding:var(--sp2) 0 var(--sp2) var(--sp4);
+  border-left:5px solid var(--border);
+  margin-top:var(--sp1); line-height:var(--lh-body);
+}
+.govuk-details-body p { margin-bottom:var(--sp2) }
+.govuk-details-body p:last-child { margin-bottom:0 }
+
+/* ── WARNING TEXT ───────────────────────────────────────────── */
+.govuk-warning {
+  display:flex; align-items:flex-start; gap:var(--sp2); margin-bottom:var(--sp4);
+}
+.govuk-warning-icon { font-size:1.5rem; font-weight:700; color:var(--text); flex-shrink:0; line-height:1; margin-top:2px }
+.govuk-warning-text { font-weight:700; font-size:var(--t-body); color:var(--text) }
+
+/* ── PH NOTE ────────────────────────────────────────────────── */
+.ph-note {
+  font-size:var(--t-body); color:var(--text2);
+  padding:var(--sp2) var(--sp3); background:var(--grey);
+  border-left:5px solid var(--blue);
+}
+
+/* ── CTA ────────────────────────────────────────────────────── */
+.cta-wrap { margin-top:var(--sp6); padding-top:var(--sp4); border-top:1px solid var(--divider) }
+.cta {
+  display:inline-flex; align-items:center; gap:var(--sp2);
+  background:var(--blue); color:var(--white);
+  padding:var(--btn-pad-v) var(--sp5);
+  font-size:var(--t-md); font-weight:700;
+  text-decoration:none; min-height:var(--touch);
+  cursor:pointer; font-family:inherit; transition:background .1s;
+}
+.cta:hover { background:var(--hover); color:var(--white); text-decoration:none }
+.cta:visited { color:var(--white) }
+.cta:focus-visible {
+  outline:3px solid var(--focus); outline-offset:0;
+  background:var(--focus); color:var(--text);
+  box-shadow:0 -2px var(--focus),0 4px var(--border-dk);
+}
+.cta-sub { margin-top:var(--sp3); font-size:var(--t-sm); color:var(--muted) }
+
+/* ── FOOTER ─────────────────────────────────────────────────── */
+.ftr { background:var(--deep); color:var(--white); padding:var(--sp5) var(--sp4) }
+.ftr-in { max-width:var(--max); margin:0 auto; display:grid; grid-template-columns:repeat(auto-fit,minmax(180px,1fr)); gap:var(--sp5) }
+.ftr-h { font-size:var(--t-xs); font-weight:700; text-transform:uppercase; letter-spacing:.06em; margin-bottom:var(--sp3) }
+.ftr-ul { list-style:none }
+.ftr-ul li { margin-bottom:var(--sp2) }
+.ftr-ul a { color:rgba(255,255,255,.75); font-size:var(--t-sm); text-decoration:underline }
+.ftr-ul a:hover { color:var(--white) }
+.ftr-bot {
+  max-width:var(--max); margin:var(--sp4) auto 0;
+  padding-top:var(--sp3); border-top:1px solid rgba(255,255,255,.12);
+  font-size:var(--t-xs); color:rgba(255,255,255,.45);
+  display:flex; justify-content:space-between; flex-wrap:wrap; gap:var(--sp2);
+}
+
+/* ── RESPONSIVE ─────────────────────────────────────────────── */
+@media(max-width:800px) {
+  .hdr-in,.bc-in,.svc-in,.page { padding-left:var(--sp3); padding-right:var(--sp3) }
+  .hdr-nav { display:none }
+  h1 { font-size:var(--t-xl-m) }
+  h2.section-caption { font-size:var(--t-lg) }
+  .toggle-row { grid-template-columns:1fr; gap:var(--sp1) }
+  .toggle { width:100% }
+  .tog-btn { min-width:0; flex:1 }
+  .book-item { grid-template-columns:1fr; gap:var(--sp2) }
+  .book-action { justify-self:start }
+}
+@media(max-width:480px) {
+  h1 { font-size:var(--t-lg) }
+  .cta { width:100%; justify-content:center }
+}
+@media(forced-colors:active) {
+  .cta,.elig-mark { border:2px solid ButtonText }
+  .req-item { border-left-color:ButtonText }
+}
+
+
+.pass-section { margin-bottom:var(--sp4); padding-bottom:var(--sp4); border-bottom:1px solid var(--divider); }
+.pass-section h2 {
+  font-size:var(--t-section); font-weight:700; color:var(--deep);
+  border-left:5px solid var(--blue); padding-left:var(--sp3); margin-bottom:var(--sp4);
+}
+.rank-table {
+  width:100%; border-collapse:collapse; font-size:var(--t-body); margin-bottom:var(--sp4);
+}
+.rank-table th {
+  text-align:left; padding:var(--sp2) var(--sp3);
+  background:var(--deep); color:var(--white); font-weight:700;
+}
+.rank-table td {
+  padding:var(--sp2) var(--sp3); border-bottom:1px solid var(--divider); vertical-align:top;
+}
+.rank-table tr:last-child td { border-bottom:none; }
+.rank-table td:last-child { text-align:right; }
+.rank-table th:last-child { text-align:right; }
+.complaint-list {
+  list-style:disc; padding-left:var(--sp5); margin-bottom:var(--sp4);
+}
+.complaint-list li {
+  font-size:var(--t-body); color:var(--text); padding:var(--sp1) 0; line-height:var(--lh-body);
+}
+
+.fares-placeholder {
+  border:2px dashed var(--border); padding:var(--sp5) var(--sp4);
+  text-align:center; color:var(--muted); font-size:var(--t-body);
+  margin-bottom:var(--sp4);
+}
+
+/* CALCULATOR */
+</style>
+</head>
+<body>
+
+<a href="#main-content" class="skip">Skip to main content</a>
+
+<header class="hdr" role="banner">
+  <div class="hdr-in">
+    <a href="/" class="logo" aria-label="Gloucester City Council — home">
+      <img src="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/templates/assets/GCC_logo.svg" alt="Gloucester City Council" style="filter:brightness(0) invert(1)">
+    </a>
+  </div>
+</header>
+
+<div class="svc"><div class="svc-in">Licensing &amp; regulations</div></div>
+
+<nav class="bc" aria-label="Breadcrumb">
+  <div class="bc-in"><ol class="bc-list">
+    <li class="bc-item"><a href="#">Home</a></li>
+    <li class="bc-item"><a href="#">Licensing &amp; regulations</a></li>
+    <li class="bc-item"><a href="gcc-hcph-landing.html">Hackney carriage and private hire</a></li>
+    <li class="bc-item"><span class="bc-cur" aria-current="page">Passengers</span></li>
+  </ol></div>
+</nav>
+
+<main id="main-content">
+<div class="page">
+
+  <a href="gcc-hcph-landing.html" class="back">Back</a>
+
+  <header class="pg-hdr" style="margin-bottom:var(--sp4)">
+    <h1>Passengers</h1>
+    <p class="pg-lead">Information for passengers using hackney carriage and private hire vehicles.</p>
+  </header>
+
+  <!-- FINDING A TAXI -->
+  <div class="pass-section">
+    <h2>Finding a taxi</h2>
+    <p style="font-size:var(--t-body);color:var(--text2);margin-bottom:var(--sp4)">Hackney carriages can be hailed in the street or found at the following ranks. Private hire vehicles must be pre-booked through a licensed operator and cannot be hailed.</p>
+
+    <table class="rank-table" aria-label="Taxi ranks">
+      <thead>
+        <tr>
+          <th scope="col">Location</th>
+          <th scope="col" style="text-align:right">Spaces</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><a href="https://maps.app.goo.gl/oFpurt87a9H6asUv8" target="_blank" rel="noopener">Grosvenor House</a> (Bus station)</td>
+          <td>7</td>
+        </tr>
+        <tr>
+          <td><a href="https://maps.app.goo.gl/X1hfgi266pMopJZu9" target="_blank" rel="noopener">Railway station</a></td>
+          <td>5</td>
+        </tr>
+        <tr>
+          <td><a href="https://maps.app.goo.gl/BRg6A8FwD5a6PrfDA" target="_blank" rel="noopener">The Oxebode</a></td>
+          <td>7</td>
+        </tr>
+        <tr>
+          <td><a href="https://maps.app.goo.gl/Nnv2VBhschmy7GbJ6" target="_blank" rel="noopener">Merchants Road</a> (opposite Pillar and Lucy Warehouse)</td>
+          <td>2</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <!-- FARES -->
+  <div class="pass-section">
+    <h2>Fares</h2>
+    <p style="font-size:var(--t-body);color:var(--text2);margin-bottom:var(--sp4)">Hackney carriage fares are set by us and apply to all licensed hackney carriages. Private hire fares are agreed with the operator when you book.</p>
+
+    <div style="background:var(--grey);border:1px solid var(--divider);padding:var(--sp4);margin-bottom:var(--sp3)">
+
+      <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:var(--sp3);margin-bottom:var(--sp4)">
+        <div>
+          <label for="rate" style="display:block;font-size:var(--t-body);color:var(--text2);margin-bottom:var(--sp1)">When are you travelling?</label>
+          <select id="rate" style="width:100%;padding:var(--sp2) var(--sp3);border:2px solid var(--border-dk);background:var(--white);color:var(--text);font-size:var(--t-body)">
+            <option value="1">Daytime — Rate 1 (7am to 9pm, Monday to Saturday)</option>
+            <option value="2">Night-time — Rate 2 (9pm to 7am, Sundays)</option>
+            <option value="3">Public holiday — Rate 3</option>
+          </select>
+        </div>
+        <div>
+          <label for="passengers" style="display:block;font-size:var(--t-body);color:var(--text2);margin-bottom:var(--sp1)">Passengers</label>
+          <select id="passengers" style="width:100%;padding:var(--sp2) var(--sp3);border:2px solid var(--border-dk);background:var(--white);color:var(--text);font-size:var(--t-body)">
+            <option value="1">1 passenger</option>
+            <option value="2">2 passengers</option>
+            <option value="3">3 passengers</option>
+            <option value="4">4 passengers</option>
+            <option value="5">5 passengers</option>
+            <option value="6">6 passengers</option>
+            <option value="7">7 passengers</option>
+            <option value="8">8 passengers</option>
+          </select>
+        </div>
+      </div>
+
+      <div style="margin-bottom:var(--sp4)">
+        <div style="display:flex;justify-content:space-between;align-items:baseline;margin-bottom:var(--sp1)">
+          <label for="distance" style="font-size:var(--t-body);color:var(--text2)">Journey distance</label>
+          <span style="font-size:var(--t-body);font-weight:700;color:var(--text)" id="dist-out">1.0 miles</span>
+        </div>
+        <input type="range" id="distance" min="0.5" max="10" step="0.5" value="1" style="width:100%;touch-action:none;accent-color:var(--blue)">
+        <div style="display:flex;justify-content:space-between;font-size:var(--t-xs);color:var(--muted);margin-top:var(--sp1)">
+          <span>0.5 mi</span><span>5 mi</span><span>10 mi</span>
+        </div>
+      </div>
+
+      <div style="background:var(--white);border:2px solid var(--blue);padding:var(--sp4)">
+        <div style="display:flex;align-items:baseline;gap:var(--sp2);margin-bottom:var(--sp1);flex-wrap:wrap">
+          <span style="font-size:2.5rem;font-weight:700;color:var(--deep)" id="total-fare">£5.40</span>
+          <span style="font-size:var(--t-body);color:var(--text2)" id="fare-label">Daytime (Rate 1)</span>
+        </div>
+        <div style="height:1px;background:var(--divider);margin:var(--sp3) 0"></div>
+        <div id="breakdown" style="display:flex;flex-direction:column;gap:var(--sp2)"></div>
+      </div>
+
+      <p style="font-size:var(--t-sm);color:var(--muted);margin-top:var(--sp3)">Estimate only — the meter may differ slightly. Waiting time not included. Wheelchairs and guide dogs: no charge. <a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/taxi-tariff-november-24.pdf" target="_blank" rel="noopener">View the full tariff</a>.</p>
+    </div>
+  </div>
+
+  <!-- TRAVELLING IN A WHEELCHAIR -->
+  <div class="pass-section">
+    <h2>Travelling in a wheelchair</h2>
+    <p style="font-size:var(--t-body);margin-bottom:var(--sp3)">Under the Taxis and Private Hire Vehicles (Disabled Persons) Act 2022, drivers of designated wheelchair accessible vehicles must assist wheelchair users and cannot charge extra for doing so. If you are travelling in one of these vehicles your driver must:</p>
+    <ul class="complaint-list">
+      <li>Transport you in your wheelchair if you wish to remain in it</li>
+      <li>Transport your wheelchair separately if you choose to sit in a passenger seat</li>
+      <li>Ensure you are transported in safety and reasonable comfort</li>
+      <li>Help you to get into and out of the vehicle</li>
+      <li>Load and unload your luggage</li>
+      <li>Load and unload your wheelchair as needed</li>
+    </ul>
+    <p style="font-size:var(--t-body);color:var(--text2);margin-bottom:var(--sp3)">The meter must not be left running while helping you in or out of the vehicle. No extra charge may be made for carrying or assisting a passenger with a wheelchair.</p>
+    <p style="font-size:var(--t-body);color:var(--text2)">Some drivers may hold an exemption certificate on medical grounds — if so they must display it in their vehicle. You can view the full list of <a href="gcc-hcph-wav.html">designated wheelchair accessible vehicles</a>.</p>
+  </div>
+
+  <!-- MAKE A COMPLAINT -->
+  <div class="pass-section" style="border-bottom:none">
+    <h2>Make a complaint</h2>
+    <p style="font-size:var(--t-body);margin-bottom:var(--sp3)">If you wish to report an issue about a taxi or private hire driver or vehicle, please provide as much detail as possible.</p>
+    <p style="font-size:var(--t-body);font-weight:700;margin-bottom:var(--sp2)">Information we need:</p>
+    <ul class="complaint-list">
+      <li>Your name, address, email and a daytime telephone number</li>
+      <li>The plate number or vehicle registration</li>
+      <li>A full description of the issue or incident and any witnesses</li>
+      <li>The date, time and location where the incident happened or your journey details</li>
+      <li>A description of the driver and the driver's badge number if known</li>
+      <li>As much detail as you can about the vehicle type, colour and any distinguishing features</li>
+    </ul>
+    <p style="font-size:var(--t-body)">Email <a href="mailto:licensing@gloucester.gov.uk">licensing@gloucester.gov.uk</a> or call the Licensing Team on <a href="tel:01452396396">01452 396396</a>.</p>
+  </div>
+
+
+</div>
+</main>
+
+<footer class="ftr" role="contentinfo">
+  <div class="ftr-in">
+    <div>
+      <div class="ftr-h">Licensing</div>
+      <ul class="ftr-ul">
+        <li><a href="gcc-hcph-landing.html">Hackney carriage and private hire</a></li>
+        <li><a href="#">Premises licences</a></li>
+        <li><a href="#">Personal licences</a></li>
+      </ul>
+    </div>
+    <div>
+      <div class="ftr-h">About GCC</div>
+      <ul class="ftr-ul">
+        <li><a href="#">Accessibility statement</a></li>
+        <li><a href="#">Privacy notice</a></li>
+        <li><a href="#">Cookies</a></li>
+        <li><a href="#">Contact us</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="ftr-bot">
+    <span>© Gloucester City Council</span>
+    <span>Last updated: July 2026</span>
+  </div>
+</footer>
+
+
+
+<script>
+const FARES={
+  1:{flag:3.60,miles:[5.40,7.80,10.50,12.90,15.30,17.70,20.10,22.80,25.20,27.60]},
+  2:{flag:4.00,miles:[7.00,10.00,13.30,16.30,19.60,22.60,25.90,28.90,31.90,35.20]},
+  3:{flag:5.00,miles:[8.00,11.60,15.20,18.80,22.40,26.30,29.90,33.50,37.10,40.70]},
+};
+function calc(){
+  const rate=parseInt(document.getElementById('rate').value);
+  const dist=parseFloat(document.getElementById('distance').value);
+  const pax=parseInt(document.getElementById('passengers').value);
+  document.getElementById('dist-out').textContent=dist.toFixed(1)+(dist===1?' mile':' miles');
+  const f=FARES[rate];
+  let base;
+  if(dist<=1){base=f.flag+(f.miles[0]-f.flag)*dist;}
+  else{
+    const lo=Math.floor(dist),hi=Math.ceil(dist);
+    if(lo===hi){base=f.miles[lo-1];}
+    else{const lv=f.miles[lo-1],hv=hi>10?f.miles[9]:f.miles[hi-1];base=lv+(hv-lv)*(dist-lo);}
+  }
+  let paxExtra=0;
+  if(pax>=2&&pax<=4)paxExtra=(pax-1)*0.30;
+  else if(pax>4)paxExtra=3*0.30+(pax-4)*0.60;
+  const total=base+paxExtra;
+  document.getElementById('total-fare').textContent='£'+total.toFixed(2);
+  const rateLabel=['','Daytime (Rate 1)','Night-time (Rate 2)','Public holiday (Rate 3)'][rate];
+  document.getElementById('fare-label').textContent=rateLabel;
+  const bd=document.getElementById('breakdown');
+  const rows=[['Base fare','£'+base.toFixed(2)]];
+  if(paxExtra>0)rows.push(['Passenger supplement ('+(pax-1)+' extra)','£'+paxExtra.toFixed(2)]);
+  rows.push(['Estimated total','£'+total.toFixed(2)]);
+  bd.innerHTML=rows.map((r,i)=>`<div style="display:flex;justify-content:space-between;font-size:var(--t-body);${i===rows.length-1?'font-weight:700;color:var(--text)':'color:var(--text2)'}"><span>${r[0]}</span><span>${r[1]}</span></div>`).join('');
+}
+document.getElementById('distance').addEventListener('input',calc);
+document.getElementById('rate').addEventListener('change',calc);
+document.getElementById('passengers').addEventListener('change',calc);
+calc();
+</script>
+</body>
+</html>

--- a/Taxi website/Webpages/gcc-hcph-register.html
+++ b/Taxi website/Webpages/gcc-hcph-register.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Public register — Gloucester City Council</title>
+<style>
+:root{
+  --deep:#1F3763;--blue:#0054A4;--white:#FFFFFF;--text:#0B0C0C;
+  --text2:#505A5F;--muted:#8F8F8F;--grey:#F3F2F1;--divider:#D8D8D8;
+  --border:#B1B4B6;--border-dk:#505A5F;--link:#0054A4;--hover:#003F8A;
+  --max:960px;--sp1:4px;--sp2:8px;--sp3:12px;--sp4:16px;
+  --sp5:24px;--sp6:40px;--sp7:56px;
+  --t-xs:.75rem;--t-sm:.875rem;--t-body:1rem;--t-md:1.125rem;
+  --t-section:1.25rem;--t-h1:2rem;--lh-body:1.6;
+}
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:var(--text);background:var(--white);line-height:var(--lh-body)}
+.skip{position:absolute;left:-9999px;top:4px;padding:8px 16px;background:var(--deep);color:var(--white);font-weight:700;z-index:999}
+.skip:focus{left:4px}
+.hdr{background:var(--deep);padding:var(--sp3) 0}
+.hdr-in{max-width:var(--max);margin:0 auto;padding:0 var(--sp4)}
+.logo img{height:48px}
+.svc{background:var(--blue);padding:var(--sp2) 0}
+.svc-in{max-width:var(--max);margin:0 auto;padding:0 var(--sp4);font-size:var(--t-sm);color:var(--white);font-weight:700}
+.bc{background:var(--grey);border-bottom:1px solid var(--divider);padding:var(--sp2) 0}
+.bc-in{max-width:var(--max);margin:0 auto;padding:0 var(--sp4)}
+.bc-list{display:flex;flex-wrap:wrap;gap:var(--sp1);list-style:none;font-size:var(--t-sm)}
+.bc-item{display:flex;align-items:center;gap:var(--sp1);color:var(--text2)}
+.bc-item a{color:var(--link)}
+.bc-item+.bc-item::before{content:"›";color:var(--muted)}
+.bc-cur{color:var(--text);font-weight:600}
+.page{max-width:var(--max);margin:0 auto;padding:var(--sp5) var(--sp4) var(--sp7)}
+.back{display:inline-flex;align-items:center;gap:var(--sp1);font-size:var(--t-sm);color:var(--link);text-decoration:none;margin-bottom:var(--sp5)}
+.back::before{content:"‹";font-size:1.2em}
+.back:hover{color:var(--hover);text-decoration:underline}
+.pg-hdr{margin-bottom:var(--sp5);padding-top:var(--sp5);border-top:2px solid var(--divider)}
+h1{font-size:var(--t-h1);font-weight:700;color:var(--deep);margin-bottom:var(--sp3)}
+.pg-lead{font-size:var(--t-md);color:var(--text2);margin-bottom:var(--sp5)}
+.toggle-group{display:flex;gap:0;margin-bottom:var(--sp4)}
+.tog-btn{
+  font-family:inherit;font-size:var(--t-body);font-weight:700;
+  padding:var(--sp2) var(--sp5);min-height:44px;cursor:pointer;
+  border:2px solid var(--border-dk);border-right-width:0;
+  background:var(--white);color:var(--text);
+}
+.tog-btn:last-child{border-right-width:2px}
+.tog-btn[aria-pressed="true"]{background:var(--deep);color:var(--white);border-color:var(--deep)}
+.tog-btn:hover:not([aria-pressed="true"]){background:var(--grey)}
+.tog-btn:focus-visible{outline:3px solid #FFDD00;outline-offset:-3px}
+.count{font-size:var(--t-sm);color:var(--text2);margin-bottom:var(--sp3)}
+.table-wrap{overflow-x:auto}
+table{width:100%;border-collapse:collapse;font-size:var(--t-body)}
+th{text-align:left;padding:var(--sp2) var(--sp3);background:var(--deep);color:var(--white);font-weight:700;white-space:nowrap}
+td{padding:var(--sp2) var(--sp3);border-bottom:1px solid var(--divider);vertical-align:top}
+tr:nth-child(even) td{background:var(--grey)}
+tr:last-child td{border-bottom:none}
+.loading{text-align:center;padding:var(--sp6);color:var(--text2);font-size:var(--t-body)}
+.reg-note{font-size:var(--t-sm);color:var(--text2);margin-top:var(--sp5);padding-top:var(--sp3);border-top:1px solid var(--divider)}
+.ftr{background:var(--deep);color:rgba(255,255,255,.8);padding:var(--sp6) 0 var(--sp4);margin-top:var(--sp7)}
+.ftr-in{max-width:var(--max);margin:0 auto;padding:0 var(--sp4);display:grid;grid-template-columns:1fr 1fr;gap:var(--sp6);margin-bottom:var(--sp5)}
+.ftr-h{font-weight:700;color:var(--white);margin-bottom:var(--sp3);font-size:var(--t-body)}
+.ftr-ul{list-style:none}
+.ftr-ul li{margin-bottom:var(--sp2)}
+.ftr-ul a{color:rgba(255,255,255,.8);font-size:var(--t-sm);text-decoration:none}
+.ftr-ul a:hover{color:var(--white);text-decoration:underline}
+.ftr-bot{max-width:var(--max);margin:0 auto;padding:var(--sp4) var(--sp4) 0;border-top:1px solid rgba(255,255,255,.2);display:flex;justify-content:space-between;font-size:var(--t-sm)}
+</style>
+</head>
+<body>
+
+<a href="#main-content" class="skip">Skip to main content</a>
+
+<header class="hdr" role="banner">
+  <div class="hdr-in">
+    <a href="/" class="logo" aria-label="Gloucester City Council — home">
+      <img src="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/templates/assets/GCC_logo.svg" alt="Gloucester City Council" style="filter:brightness(0) invert(1)">
+    </a>
+  </div>
+</header>
+
+<div class="svc"><div class="svc-in">Licensing &amp; regulations</div></div>
+
+<nav class="bc" aria-label="Breadcrumb">
+  <div class="bc-in"><ol class="bc-list">
+    <li class="bc-item"><a href="#">Home</a></li>
+    <li class="bc-item"><a href="#">Licensing &amp; regulations</a></li>
+    <li class="bc-item"><a href="gcc-hcph-landing.html">Hackney carriage and private hire</a></li>
+    <li class="bc-item"><a href="gcc-hcph-documents.html">Licensing information</a></li>
+    <li class="bc-item"><span class="bc-cur" aria-current="page">Public register</span></li>
+  </ol></div>
+</nav>
+
+<main id="main-content">
+<div class="page">
+
+  <a href="gcc-hcph-documents.html" class="back">Back</a>
+
+  <header class="pg-hdr">
+    <h1>Public register</h1>
+    <p class="pg-lead">All currently licensed hackney carriage and private hire drivers, vehicles and operators.</p>
+  </header>
+
+  <div class="toggle-group" role="group" aria-label="Filter by licence type">
+    <button type="button" class="tog-btn" id="btn-driver" aria-pressed="true" onclick="setView('driver')">Drivers</button>
+    <button type="button" class="tog-btn" id="btn-vehicle" aria-pressed="false" onclick="setView('vehicle')">Vehicles</button>
+    <button type="button" class="tog-btn" id="btn-operator" aria-pressed="false" onclick="setView('operator')">Operators</button>
+  </div>
+
+  <p class="count" id="count" aria-live="polite">Loading…</p>
+
+  <div class="table-wrap">
+    <table id="reg-table" aria-label="Public register">
+      <thead id="thead"></thead>
+      <tbody id="tbody"><tr><td colspan="7" class="loading">Loading register…</td></tr></tbody>
+    </table>
+  </div>
+
+  <p class="reg-note">Records are provided for information only and may not reflect changes since the last update. A licence past its expiry date may have since been renewed — email <a href="mailto:licensing@gloucester.gov.uk">licensing@gloucester.gov.uk</a> to confirm current status.</p>
+
+</div>
+</main>
+
+<footer class="ftr" role="contentinfo">
+  <div class="ftr-in">
+    <div>
+      <div class="ftr-h">Licensing</div>
+      <ul class="ftr-ul">
+        <li><a href="gcc-hcph-landing.html">Hackney carriage and private hire</a></li>
+        <li><a href="#">Premises licences</a></li>
+        <li><a href="#">Personal licences</a></li>
+      </ul>
+    </div>
+    <div>
+      <div class="ftr-h">About GCC</div>
+      <ul class="ftr-ul">
+        <li><a href="#">Accessibility statement</a></li>
+        <li><a href="#">Privacy notice</a></li>
+        <li><a href="#">Cookies</a></li>
+        <li><a href="#">Contact us</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="ftr-bot">
+    <span>© Gloucester City Council</span>
+    <span>Last updated: July 2026</span>
+  </div>
+</footer>
+
+<script>
+const JSON_URL = 'https://api.github.com/repos/Gloucester-City-Council/GCC-Beta-site-v1/contents/Taxi%20website/PublicRegister/LIC_Public_Register.json';
+
+let DATA = null;
+
+function fmtDate(d) {
+  if (!d) return '—';
+  const parts = d.split('-');
+  if (parts.length !== 3) return d;
+  if (parseInt(parts[0]) < 1970) return '—';
+  const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+  return parseInt(parts[2],10) + ' ' + months[parseInt(parts[1],10)-1] + ' ' + parts[0];
+}
+
+function cell(v) { return (v !== null && v !== undefined && v !== '') ? String(v) : '—'; }
+
+function parseData(data) {
+  if (data.driver) return data;
+  const records = data.records || [];
+  return {
+    driver: records.filter(r => r.licence_type && r.licence_type.toLowerCase().includes('driver')),
+    vehicle: records.filter(r => r.licence_type && r.licence_type.toLowerCase().includes('vehicle')),
+    operator: records.filter(r => r.licence_type && r.licence_type.toLowerCase().includes('operator'))
+  };
+}
+
+fetch(JSON_URL, { headers: { 'Accept': 'application/vnd.github.v3.raw' } })
+  .then(r => { if (!r.ok) throw new Error('Failed'); return r.json(); })
+  .then(data => {
+    DATA = parseData(data);
+    setView('driver');
+  })
+  .catch(() => {
+    document.getElementById('tbody').innerHTML = '<tr><td colspan="7" class="loading">Unable to load the register at this time. Please try again later.</td></tr>';
+    document.getElementById('count').textContent = '';
+  });
+</script>
+
+</body>
+</html>

--- a/Taxi website/Webpages/gcc-hcph-wav.html
+++ b/Taxi website/Webpages/gcc-hcph-wav.html
@@ -1,0 +1,247 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Wheelchair accessible vehicles — Gloucester City Council</title>
+<style>
+:root {
+  --deep:#1F3763; --blue:#0054A4; --white:#FFFFFF; --text:#0B0C0C;
+  --text2:#505A5F; --muted:#8F8F8F; --grey:#F3F2F1; --divider:#D8D8D8;
+  --border:#B1B4B6; --border-dk:#505A5F; --link:#0054A4; --hover:#003F8A;
+  --max:960px; --sp1:4px; --sp2:8px; --sp3:12px; --sp4:16px;
+  --sp5:24px; --sp6:40px; --sp7:56px;
+  --t-xs:.75rem; --t-sm:.875rem; --t-body:1rem; --t-md:1.125rem;
+  --t-section:1.25rem; --t-h1:2rem; --lh-body:1.6;
+}
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:var(--text);background:var(--white);line-height:var(--lh-body)}
+.skip{position:absolute;left:-9999px;top:4px;padding:8px 16px;background:var(--deep);color:var(--white);font-weight:700;z-index:999}
+.skip:focus{left:4px}
+.hdr{background:var(--deep);padding:var(--sp3) 0}
+.hdr-in{max-width:var(--max);margin:0 auto;padding:0 var(--sp4)}
+.logo img{height:48px}
+.svc{background:var(--blue);padding:var(--sp2) 0}
+.svc-in{max-width:var(--max);margin:0 auto;padding:0 var(--sp4);font-size:var(--t-sm);color:var(--white);font-weight:700}
+.bc{background:var(--grey);border-bottom:1px solid var(--divider);padding:var(--sp2) 0}
+.bc-in{max-width:var(--max);margin:0 auto;padding:0 var(--sp4)}
+.bc-list{display:flex;flex-wrap:wrap;gap:var(--sp1);list-style:none;font-size:var(--t-sm)}
+.bc-item{display:flex;align-items:center;gap:var(--sp1);color:var(--text2)}
+.bc-item a{color:var(--link)}
+.bc-item+.bc-item::before{content:"›";color:var(--muted)}
+.bc-cur{color:var(--text);font-weight:600}
+.page{max-width:var(--max);margin:0 auto;padding:var(--sp5) var(--sp4) var(--sp7)}
+.back{display:inline-flex;align-items:center;gap:var(--sp1);font-size:var(--t-sm);color:var(--link);text-decoration:none;margin-bottom:var(--sp5)}
+.back::before{content:"‹";font-size:1.2em}
+.back:hover{color:var(--hover);text-decoration:underline}
+.pg-hdr{margin-bottom:var(--sp5);padding-top:var(--sp5);border-top:2px solid var(--divider)}
+h1{font-size:var(--t-h1);font-weight:700;color:var(--deep);margin-bottom:var(--sp3)}
+.pg-lead{font-size:var(--t-md);color:var(--text2)}
+.wav-section{margin-bottom:var(--sp5);padding-bottom:var(--sp5);border-bottom:1px solid var(--divider)}
+.wav-section:last-of-type{border-bottom:none}
+.wav-section h2{font-size:var(--t-section);font-weight:700;color:var(--deep);border-left:5px solid var(--blue);padding-left:var(--sp3);margin-bottom:var(--sp4)}
+.wav-section h3{font-size:var(--t-body);font-weight:700;color:var(--text);margin-bottom:var(--sp2);margin-top:var(--sp4)}
+.wav-section p{font-size:var(--t-body);color:var(--text2);margin-bottom:var(--sp3)}
+.wav-list{list-style:disc;padding-left:var(--sp5);margin-bottom:var(--sp3)}
+.wav-list li{font-size:var(--t-body);color:var(--text);padding:var(--sp1) 0;line-height:var(--lh-body)}
+.inset{background:var(--grey);border-left:5px solid var(--blue);padding:var(--sp3) var(--sp4);margin-bottom:var(--sp3)}
+.inset p{font-size:var(--t-body);color:var(--text2)}
+.section-caption{font-size:var(--t-section);font-weight:700;color:var(--deep);border-left:5px solid var(--blue);padding-left:var(--sp3);margin-bottom:var(--sp4)}
+/* TABLES */
+.wav-table{width:100%;border-collapse:collapse;font-size:var(--t-body);margin-bottom:var(--sp4)}
+.wav-table th{text-align:left;padding:var(--sp2) var(--sp3);background:var(--deep);color:var(--white);font-weight:700}
+.wav-table td{padding:var(--sp2) var(--sp3);border-bottom:1px solid var(--divider);vertical-align:top}
+.wav-table tr:last-child td{border-bottom:none}
+.wav-table tr:nth-child(even){background:var(--grey)}
+.flag-note{font-size:var(--t-body);color:var(--text2);font-style:italic;margin-bottom:var(--sp4)}
+/* FOOTER */
+.ftr{background:var(--deep);color:rgba(255,255,255,.8);padding:var(--sp6) 0 var(--sp4)}
+.ftr-in{max-width:var(--max);margin:0 auto;padding:0 var(--sp4);display:grid;grid-template-columns:1fr 1fr;gap:var(--sp6);margin-bottom:var(--sp5)}
+.ftr-h{font-weight:700;color:var(--white);margin-bottom:var(--sp3);font-size:var(--t-body)}
+.ftr-ul{list-style:none}
+.ftr-ul li{margin-bottom:var(--sp2)}
+.ftr-ul a{color:rgba(255,255,255,.8);font-size:var(--t-sm);text-decoration:none}
+.ftr-ul a:hover{color:var(--white);text-decoration:underline}
+.ftr-bot{max-width:var(--max);margin:0 auto;padding:var(--sp4) var(--sp4) 0;border-top:1px solid rgba(255,255,255,.2);display:flex;justify-content:space-between;font-size:var(--t-sm)}
+</style>
+</head>
+<body>
+
+<a href="#main-content" class="skip">Skip to main content</a>
+
+<header class="hdr" role="banner">
+  <div class="hdr-in">
+    <a href="/" class="logo" aria-label="Gloucester City Council — home">
+      <img src="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/templates/assets/GCC_logo.svg" alt="Gloucester City Council" style="filter:brightness(0) invert(1)">
+    </a>
+  </div>
+</header>
+
+<div class="svc"><div class="svc-in">Licensing &amp; regulations</div></div>
+
+<nav class="bc" aria-label="Breadcrumb">
+  <div class="bc-in"><ol class="bc-list">
+    <li class="bc-item"><a href="#">Home</a></li>
+    <li class="bc-item"><a href="#">Licensing &amp; regulations</a></li>
+    <li class="bc-item"><a href="gcc-hcph-landing.html">Hackney carriage and private hire</a></li>
+    <li class="bc-item"><span class="bc-cur" aria-current="page">Wheelchair accessible vehicles</span></li>
+  </ol></div>
+</nav>
+
+<main id="main-content">
+<div class="page">
+
+  <a href="gcc-hcph-landing.html" class="back">Back</a>
+
+  <header class="pg-hdr">
+    <h1>Wheelchair accessible vehicles</h1>
+    <p class="pg-lead">Guidance for drivers, vehicle proprietors and operators of designated wheelchair accessible hackney carriages and private hire vehicles.</p>
+  </header>
+
+  <!-- THE 2022 ACT -->
+  <div class="wav-section">
+    <h2>The 2022 Act</h2>
+    <p>The Taxis and Private Hire Vehicles (Disabled Persons) Act 2022 places duties on hackney carriage and private hire drivers, vehicles and operators to ensure disabled passengers have specific rights and protections when using licensed vehicles.</p>
+  </div>
+
+  <!-- DRIVER DUTIES -->
+  <div class="wav-section">
+    <h2>Driver duties</h2>
+    <p>Drivers of designated wheelchair accessible vehicles must:</p>
+    <ul class="wav-list">
+      <li>Transport the wheelchair if the passenger chooses to sit in a passenger seat</li>
+      <li>Give the passenger reasonable mobility assistance — including helping them into and out of the vehicle whether they remain in their wheelchair or move to a passenger seat</li>
+      <li>Ensure the passenger is transported in safety and reasonable comfort</li>
+      <li>Load and unload the passenger's luggage</li>
+    </ul>
+    <div class="inset">
+      <p>The meter must not be left running while helping a passenger in or out of the vehicle. No extra charge may be made for carrying or assisting a wheelchair user.</p>
+    </div>
+
+    <h3>Guide and assistance dogs</h3>
+    <p>A hackney carriage or private hire driver must not refuse a guide or assistance dog accompanying a disabled person unless an exemption certificate has been issued to that driver on medical grounds by us. A driver with a valid exemption certificate must display it in their vehicle at all times.</p>
+
+    <h3>Driver exemptions</h3>
+    <p>A driver may apply for an exemption from the duty to carry wheelchair users on medical grounds. The exemption must be granted by us. If granted, the driver must display the exemption certificate in a prominent position in their vehicle.</p>
+
+    <h3>Enhanced driving assessment</h3>
+    <p>Drivers intending to drive a wheelchair accessible vehicle must complete the enhanced driving assessment in addition to the standard driving assessment. Both pass certificates must be provided on application.</p>
+  </div>
+
+  <!-- VEHICLE CONDITIONS -->
+  <div class="wav-section">
+    <h2>Vehicle conditions</h2>
+
+    <h3>New hackney carriage licences</h3>
+    <p>All new hackney carriage vehicle licences are only issued to wheelchair accessible vehicles. A WAV licence is conditional on the vehicle always remaining as a wheelchair accessible vehicle or people carrier. It cannot be transferred to a non-WAV.</p>
+    <p>Where a hackney carriage vehicle licence has been issued for a saloon type vehicle, that vehicle may be replaced by another saloon type at the end of its working life, or upgraded to a WAV at the owner's discretion.</p>
+
+    <h3>Availability for wheelchair access</h3>
+    <p>All wheelchair accessible vehicles when licensed must be available for wheelchair access when plying for hire or operating as a private hire vehicle.</p>
+
+    <h3>Vehicles over 10 years old</h3>
+    <p>All wheelchair accessible vehicles licensed for the first time and over 10 years old will be subject to an inspection by a Licensing Officer before a vehicle licence is granted, provided that all other documentation has been submitted and the appropriate fee paid.</p>
+
+    <h3>Anchorages and restraints</h3>
+    <p>Approved anchorages must be provided for the wheelchair and passenger. These must be either chassis or floor linked and capable of withstanding approved dynamic or static tests. Restraints for the wheelchair and occupant must be independent of each other.</p>
+
+    <h3>Ramps</h3>
+    <p>A ramp or ramps for loading a wheelchair and occupant must be available at all times. An adequate locking device must be fitted to ensure ramps do not slip or tilt when in use. Provision must be made for ramps to be stowed safely when not in use.</p>
+  </div>
+
+  <!-- OPERATOR DUTIES -->
+  <div class="wav-section">
+    <h2>Operator duties</h2>
+    <p>A private hire operator must not refuse to take a booking from a disabled person if the reason for refusal is that a guide or assistance dog will accompany the person. An operator must not make an additional charge to carry a guide or assistance dog.</p>
+  </div>
+
+  <!-- WAV REGISTER -->
+  <div class="wav-section">
+    <h2>Designated wheelchair accessible vehicles</h2>
+    <p class="flag-note" style="font-size:var(--t-body)">This register is reviewed periodically. If you believe information is incorrect please email the Licensing Team at <a href="mailto:licensing@gloucester.gov.uk">licensing@gloucester.gov.uk</a>.</p>
+
+    <h3>Hackney carriage</h3>
+    <table class="wav-table" aria-label="Designated wheelchair accessible hackney carriages">
+      <thead>
+        <tr>
+          <th scope="col">Plate number</th>
+          <th scope="col">Registration</th>
+          <th scope="col">Make</th>
+          <th scope="col">Passengers</th>
+          <th scope="col">Contact</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td>HCV502</td><td>YJ66 CDO</td><td>Renault Traffic</td><td>5 + 1 wheelchair</td><td><a href="tel:07857224764">07857 224764</a></td></tr>
+        <tr><td>HCV505</td><td>SF16 CVE</td><td>Peugeot Horizon</td><td>2 + 1 wheelchair</td><td><a href="tel:07963095023">07963 095023</a></td></tr>
+        <tr><td>HCV537</td><td>SF13 MZE</td><td>Peugeot Partner</td><td>2 + 1 wheelchair</td><td><a href="tel:07860888057">07860 888057</a></td></tr>
+      </tbody>
+    </table>
+
+    <h3>Private hire</h3>
+    <table class="wav-table" aria-label="Designated wheelchair accessible private hire vehicles">
+      <thead>
+        <tr>
+          <th scope="col">Plate number</th>
+          <th scope="col">Registration</th>
+          <th scope="col">Make</th>
+          <th scope="col">Passengers</th>
+          <th scope="col">Operator / Contact</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td>PHV150</td><td>FL63 VTC</td><td>Vauxhall Vivaro</td><td>5 + 1 wheelchair</td><td>Andy Cars <a href="tel:01452523000">01452 523000</a></td></tr>
+        <tr><td>PHV213</td><td>SF14 DCU</td><td>Peugeot Horizon</td><td>2 + 1 wheelchair</td><td>Uber Gloucester</td></tr>
+        <tr><td>PHV231</td><td>SF14 EPX</td><td>Peugeot Horizon</td><td>2 + 1 wheelchair</td><td>Fixat 4 U Ltd <a href="tel:07426984184">07426 984184</a></td></tr>
+        <tr><td>PHV257</td><td>DY66 NKK</td><td>Vauxhall Vivaro</td><td>5 + 1 wheelchair</td><td>John's Private Hire <a href="tel:01452385050">01452 385050</a></td></tr>
+        <tr><td>PHV278</td><td>WA64 EGJ</td><td>Citroen Berlingo</td><td>1 + 1 wheelchair</td><td>John's Private Hire <a href="tel:01452385050">01452 385050</a></td></tr>
+        <tr><td>PHV314</td><td>SF62 AFE</td><td>Peugeot Partner</td><td>2 + 1 wheelchair</td><td>Fixat 4 U Ltd <a href="tel:07426984184">07426 984184</a></td></tr>
+        <tr><td>PHV354</td><td>SF11 GHK</td><td>Peugeot Partner</td><td>2 + 1 wheelchair</td><td>Mr XXL Transport Ltd <a href="tel:07399598969">07399 598969</a></td></tr>
+        <tr><td>PHV428</td><td>HK67 SYS</td><td>Renault Traffic</td><td>5 + 1 wheelchair</td><td>Fixat 4 U Ltd <a href="tel:07426984184">07426 984184</a></td></tr>
+        <tr><td>PHV612</td><td>NK15 CXW</td><td>Citroen Berlingo</td><td>1 + 1 wheelchair</td><td>Fixat 4 U Ltd <a href="tel:07426984184">07426 984184</a></td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <!-- RELATED -->
+  <aside aria-label="Related information" style="margin-top:var(--sp7)">
+    <h2 class="section-caption">Related information</h2>
+    <ul style="list-style:none;border-top:1px solid var(--divider)">
+      <li style="padding:var(--sp3) 0;border-bottom:1px solid var(--divider)">
+        <a href="gcc-hcph-passengers.html" style="font-weight:700;font-size:var(--t-body)">Passengers</a>
+        <p style="font-size:var(--t-body);color:var(--text2);margin-top:var(--sp1)">Information for passengers travelling in a wheelchair accessible vehicle</p>
+      </li>
+    </ul>
+  </aside>
+
+</div>
+</main>
+
+<footer class="ftr" role="contentinfo">
+  <div class="ftr-in">
+    <div>
+      <div class="ftr-h">Licensing</div>
+      <ul class="ftr-ul">
+        <li><a href="gcc-hcph-landing.html">Hackney carriage and private hire</a></li>
+        <li><a href="#">Premises licences</a></li>
+        <li><a href="#">Personal licences</a></li>
+      </ul>
+    </div>
+    <div>
+      <div class="ftr-h">About GCC</div>
+      <ul class="ftr-ul">
+        <li><a href="#">Accessibility statement</a></li>
+        <li><a href="#">Privacy notice</a></li>
+        <li><a href="#">Cookies</a></li>
+        <li><a href="#">Contact us</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="ftr-bot">
+    <span>© Gloucester City Council</span>
+    <span>Last updated: July 2026</span>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/Taxi website/Webpages/gcc-vehicle-licence.html
+++ b/Taxi website/Webpages/gcc-vehicle-licence.html
@@ -1,0 +1,748 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Vehicle licence — Gloucester City Council</title>
+<style>
+/* ══════════════════════════════════════════════════════════════
+   GCC LICENSING — SHARED STYLESHEET
+   GOV.UK Done With Intention
+   All pages: landing, driver, vehicle, operator
+   ══════════════════════════════════════════════════════════════ */
+
+:root {
+  /* Brand */
+  --blue:       #0054A4;
+  --hover:      #003E7B;
+  --deep:       #0B2E53;
+  --white:      #FFFFFF;
+  --grey:       #F3F2F1;
+  --grey2:      #E8E8E8;
+  --border:     #B1B4B6;
+  --border-dk:  #0B0C0C;
+  --divider:    #D8D8D8;
+  --text:       #0B0C0C;
+  --text2:      #505A5F;
+  --muted:      #6F777B;
+  --link:       #0054A4;
+  --focus:      #FFDD00;
+
+  /* Spacing */
+  --sp1:4px; --sp2:8px; --sp3:16px; --sp4:24px;
+  --sp5:32px; --sp6:48px; --sp7:64px;
+
+  /* Type scale — GOV.UK */
+  --t-xl:      2.25rem;   /* h1 desktop */
+  --t-xl-m:    1.875rem;  /* h1 mobile */
+  --t-section: 1.75rem;   /* h2 section headings */
+  --t-lg:      1.5rem;    /* h2 base */
+  --t-md:      1.125rem;  /* h3 */
+  --t-body:    1rem;
+  --t-sm:      .875rem;
+  --t-xs:      .75rem;
+
+  /* Line heights */
+  --lh-heading: 1.1;
+  --lh-body:    1.5;
+  --lh-tight:   1.4;
+
+  /* Components */
+  --btn-pad-v: 10px;
+  --touch:     44px;
+  --max:       1200px;
+}
+
+/* ── RESET ──────────────────────────────────────────────────── */
+*,*::before,*::after { box-sizing:border-box; margin:0; padding:0 }
+html { font-size:16px; scroll-behavior:smooth }
+body {
+  font-family:"GDS Transport",Arial,sans-serif;
+  font-size:var(--t-body);
+  line-height:var(--lh-body);
+  color:var(--text);
+  background:var(--white);
+  -webkit-font-smoothing:antialiased;
+}
+@media(prefers-reduced-motion:reduce){*{transition-duration:.01ms!important}}
+
+/* ── TYPOGRAPHY ─────────────────────────────────────────────── */
+h1 { font-size:var(--t-xl); line-height:var(--lh-heading); font-weight:700; margin-bottom:var(--sp2) }
+h2 { font-size:var(--t-lg); line-height:var(--lh-heading); font-weight:700; color:var(--deep); margin:0 0 var(--sp3) }
+h3 { font-size:var(--t-md); line-height:var(--lh-heading); font-weight:700; color:var(--text); margin:0 0 var(--sp2) }
+p  { font-size:var(--t-body); line-height:var(--lh-body); margin-bottom:var(--sp3) }
+p:last-child { margin-bottom:0 }
+a  { color:var(--link); text-decoration:underline; text-underline-offset:3px }
+a:hover { color:var(--hover) }
+a:visited { color:#4c2c92 }
+
+/* ── SECTION CAPTIONS (h2 variant) ─────────────────────────── */
+h2.section-caption {
+  font-size:var(--t-section);
+  font-weight:700;
+  color:var(--deep);
+  padding-left:var(--sp3);
+  border-left:5px solid var(--blue);
+  margin-top:var(--sp6);
+  margin-bottom:var(--sp4);
+  line-height:var(--lh-heading);
+}
+.pg-hdr + section h2.section-caption { margin-top:0 }
+
+/* ── FOCUS ──────────────────────────────────────────────────── */
+:focus-visible {
+  outline:3px solid var(--focus);
+  outline-offset:0;
+  background:var(--focus);
+  color:var(--text);
+  box-shadow:0 -2px var(--focus),0 4px var(--border-dk);
+}
+a:focus-visible { color:var(--text) }
+
+/* ── SKIP ───────────────────────────────────────────────────── */
+.skip {
+  position:absolute; top:-100px; left:var(--sp3);
+  background:var(--focus); color:var(--text);
+  padding:var(--sp2) var(--sp3); font-weight:700;
+  z-index:1000; text-decoration:none;
+}
+.skip:focus { top:var(--sp2) }
+
+/* ── HEADER ─────────────────────────────────────────────────── */
+.hdr { background:var(--deep); border-bottom:4px solid var(--blue) }
+.hdr-in {
+  max-width:var(--max); margin:0 auto;
+  padding:var(--sp3) var(--sp4);
+  display:flex; align-items:center; justify-content:space-between;
+}
+.logo { display:flex; align-items:center; gap:var(--sp2); text-decoration:none; color:var(--white) }
+.logo img { height:40px; width:auto }
+.logo-txt { font-size:var(--t-md); font-weight:700 }
+.hdr-nav { display:flex; gap:var(--sp3); list-style:none }
+.hdr-nav a {
+  color:rgba(255,255,255,.85); text-decoration:none;
+  font-size:var(--t-sm); padding:var(--sp1) var(--sp2);
+  min-height:var(--touch); display:flex; align-items:center;
+}
+.hdr-nav a:hover { color:var(--white); text-decoration:underline }
+
+/* ── SERVICE BAR ────────────────────────────────────────────── */
+.svc { background:var(--blue); padding:var(--sp2) var(--sp4) }
+.svc-in { max-width:var(--max); margin:0 auto; font-size:var(--t-sm); color:var(--white) }
+
+/* ── BREADCRUMB ─────────────────────────────────────────────── */
+.bc { background:var(--grey); border-bottom:1px solid var(--divider) }
+.bc-in { max-width:var(--max); margin:0 auto; padding:var(--sp2) var(--sp4) }
+.bc-list { list-style:none; display:flex; flex-wrap:wrap; gap:var(--sp1); font-size:var(--t-sm) }
+.bc-item { display:flex; align-items:center; gap:var(--sp1) }
+.bc-item+.bc-item::before { content:"›"; color:var(--muted) }
+.bc-item a { color:var(--link) }
+.bc-cur { color:var(--text2); font-weight:700 }
+
+/* ── PAGE LAYOUT ────────────────────────────────────────────── */
+.page { max-width:var(--max); margin:0 auto; padding:var(--sp5) var(--sp4) var(--sp7) }
+
+/* ── BACK LINK ──────────────────────────────────────────────── */
+.back {
+  display:inline-flex; align-items:center; gap:var(--sp1);
+  font-size:var(--t-sm); color:var(--link);
+  text-decoration:none; margin-bottom:var(--sp5);
+  min-height:var(--touch); padding:var(--sp1) 0;
+}
+.back::before {
+  content:""; display:inline-block; width:0; height:0;
+  border-top:5px solid transparent; border-bottom:5px solid transparent;
+  border-right:6px solid var(--link); margin-top:1px;
+}
+.back:hover { color:var(--hover) }
+.back:hover::before { border-right-color:var(--hover) }
+
+/* ── PAGE HEADER ────────────────────────────────────────────── */
+.pg-hdr { margin-bottom:var(--sp4) }
+.pg-lead { font-size:var(--t-md); color:var(--text2); line-height:var(--lh-tight); margin-top:var(--sp2) }
+
+/* ── TOGGLES ────────────────────────────────────────────────── */
+.toggles { display:flex; flex-direction:column; gap:var(--sp3); margin-bottom:var(--sp5) }
+.toggle-row { display:grid; grid-template-columns:160px auto; align-items:center; gap:var(--sp3) }
+.toggle-lbl { font-size:var(--t-sm); font-weight:700; color:var(--text2) }
+.toggle { display:inline-flex; border:2px solid var(--border-dk); overflow:hidden; width:fit-content }
+.tog-btn {
+  padding:var(--btn-pad-v) var(--sp4);
+  background:var(--white); color:var(--text);
+  border:none; border-right:1px solid var(--border);
+  font-size:var(--t-sm); font-weight:700;
+  cursor:pointer; min-height:var(--touch); min-width:140px;
+  font-family:inherit; transition:background .1s; text-align:center;
+}
+.tog-btn:last-child { border-right:none }
+.tog-btn:hover { background:var(--grey) }
+.tog-btn.active { background:var(--deep); color:var(--white) }
+
+/* ── ELIGIBILITY LIST ───────────────────────────────────────── */
+.elig-list { list-style:none; border-top:1px solid var(--divider) }
+.elig-item {
+  display:grid; grid-template-columns:28px 1fr; gap:var(--sp2);
+  padding:var(--sp3) 0; border-bottom:1px solid var(--divider);
+  border-top:1px solid var(--divider); margin-top:-1px;
+  font-size:var(--t-body); align-items:flex-start; line-height:var(--lh-body);
+}
+.elig-mark {
+  width:22px; height:22px; border-radius:50%;
+  background:var(--blue); color:var(--white);
+  display:flex; align-items:center; justify-content:center;
+  font-size:var(--t-xs); font-weight:700; flex-shrink:0; margin-top:2px;
+}
+.elig-note {
+  font-size:var(--t-body); color:var(--text2);
+  margin-top:var(--sp1); margin-bottom:0; line-height:var(--lh-tight);
+}
+
+/* ── BOOK BEFORE YOU APPLY ──────────────────────────────────── */
+.book-list { list-style:none; border-top:1px solid var(--divider) }
+.book-item {
+  display:grid; grid-template-columns:1fr auto;
+  align-items:center; gap:var(--sp3);
+  padding:var(--sp3) 0; border-bottom:1px solid var(--divider);
+}
+.book-title { font-size:var(--t-body); font-weight:700; color:var(--text); margin-bottom:2px }
+.book-desc { font-size:var(--t-body); color:var(--text2); margin:0; line-height:var(--lh-body) }
+.book-link {
+  display:inline-flex; align-items:center; gap:var(--sp1);
+  font-size:var(--t-body); font-weight:700;
+  color:var(--link); text-decoration:none; white-space:nowrap;
+}
+.book-link:hover { color:var(--hover); text-decoration:underline }
+.book-note { font-size:var(--t-body); color:var(--text2); white-space:nowrap }
+
+/* Expandable providers */
+.book-details { width:100%;grid-column:1/-1 }
+.book-summary-inline {
+  font-size:var(--t-sm); color:var(--link); cursor:pointer;
+  list-style:none; display:inline-flex; align-items:center; gap:var(--sp1);
+  padding:var(--sp2) 0; font-weight:700; min-height:var(--touch);
+}
+.book-summary-inline::-webkit-details-marker { display:none }
+.book-details-body {
+  font-size:var(--t-sm); padding:var(--sp2) 0 var(--sp2) var(--sp4);
+  border-left:3px solid var(--divider); margin-top:var(--sp1);
+  display:flex; flex-direction:column; gap:var(--sp2);
+}
+.book-provider {
+  display:flex; align-items:center; justify-content:space-between;
+  gap:var(--sp3); font-size:var(--t-body); color:var(--text2);
+}
+
+/* ── REQUIREMENT LIST (documents) ───────────────────────────── */
+.req-list { list-style:none; border-top:1px solid var(--divider) }
+.req-item {
+  border-left:5px solid var(--blue);
+  padding:var(--sp3) 0 var(--sp3) var(--sp4);
+  margin-bottom:var(--sp1);
+  border-bottom:1px solid var(--divider);
+}
+.req-item:last-of-type { border-bottom:none }
+/* req-item--fee removed — all req-items use consistent GCC blue border */
+.req-title { font-size:var(--t-body); font-weight:700; color:var(--text); margin-bottom:var(--sp1) }
+.req-desc { font-size:var(--t-body); color:var(--text2); margin:0; line-height:var(--lh-body) }
+
+/* ── INSET ──────────────────────────────────────────────────── */
+.inset {
+  border-left:5px solid var(--border);
+  padding:var(--sp2) var(--sp3); margin-top:var(--sp2);
+}
+.inset p { font-size:var(--t-body); color:var(--text2); line-height:var(--lh-tight); margin-bottom:var(--sp1) }
+.inset p:last-child { margin-bottom:0 }
+
+/* ── FEE TAGS ───────────────────────────────────────────────── */
+.fee-tag+.fee-tag { margin-left:var(--sp2) }
+.fee-tag {
+  display:inline-block; font-size:var(--t-body); font-weight:700;
+  color:var(--deep); background:var(--grey);
+  padding:3px 10px; border:1px solid var(--border); margin-top:var(--sp2);
+}
+.fee-label {
+  display:block; font-size:var(--t-xs); font-weight:700;
+  color:var(--muted); text-transform:uppercase; letter-spacing:.05em;
+  margin-top:var(--sp2); margin-bottom:var(--sp1);
+}
+
+/* ── GOV.UK DETAILS/SUMMARY ─────────────────────────────────── */
+.govuk-details { margin-top:var(--sp2) }
+.govuk-details summary {
+  font-size:var(--t-body); color:var(--link); cursor:pointer;
+  list-style:none; display:inline-flex; align-items:center; gap:var(--sp1);
+  padding:var(--sp2) 0; min-height:var(--touch); font-weight:700;
+}
+.govuk-details summary::-webkit-details-marker { display:none }
+.govuk-details summary::before { content:"▶"; font-size:.6875rem; transition:transform .15s }
+.govuk-details[open] summary::before { transform:rotate(90deg) }
+.govuk-details-body {
+  font-size:var(--t-body); color:var(--text2);
+  padding:var(--sp2) 0 var(--sp2) var(--sp4);
+  border-left:5px solid var(--border);
+  margin-top:var(--sp1); line-height:var(--lh-body);
+}
+.govuk-details-body p { margin-bottom:var(--sp2) }
+.govuk-details-body p:last-child { margin-bottom:0 }
+
+/* ── WARNING TEXT ───────────────────────────────────────────── */
+.govuk-warning {
+  display:flex; align-items:flex-start; gap:var(--sp2); margin-bottom:var(--sp4);
+}
+.govuk-warning-icon { font-size:1.5rem; font-weight:700; color:var(--text); flex-shrink:0; line-height:1; margin-top:2px }
+.govuk-warning-text { font-weight:700; font-size:var(--t-body); color:var(--text) }
+
+/* ── PH NOTE ────────────────────────────────────────────────── */
+.ph-note {
+  font-size:var(--t-body); color:var(--text2);
+  padding:var(--sp2) var(--sp3); background:var(--grey);
+  border-left:5px solid var(--blue);
+}
+
+/* ── CTA ────────────────────────────────────────────────────── */
+.cta-wrap { margin-top:var(--sp6); padding-top:var(--sp4) }
+.cta {
+  display:inline-flex; align-items:center; gap:var(--sp2);
+  background:var(--blue); color:var(--white);
+  padding:var(--btn-pad-v) var(--sp5);
+  font-size:var(--t-md); font-weight:700;
+  text-decoration:none; min-height:var(--touch);
+  cursor:pointer; font-family:inherit; transition:background .1s;
+}
+.cta:hover { background:var(--hover); color:var(--white); text-decoration:none }
+.cta:visited { color:var(--white) }
+.cta:focus-visible {
+  outline:3px solid var(--focus); outline-offset:0;
+  background:var(--focus); color:var(--text);
+  box-shadow:0 -2px var(--focus),0 4px var(--border-dk);
+}
+.cta-sub { margin-top:var(--sp3); font-size:var(--t-sm); color:var(--muted) }
+
+/* ── FOOTER ─────────────────────────────────────────────────── */
+.ftr { background:var(--deep); color:var(--white); padding:var(--sp5) var(--sp4) }
+.ftr-in { max-width:var(--max); margin:0 auto; display:grid; grid-template-columns:repeat(auto-fit,minmax(180px,1fr)); gap:var(--sp5) }
+.ftr-h { font-size:var(--t-xs); font-weight:700; text-transform:uppercase; letter-spacing:.06em; margin-bottom:var(--sp3) }
+.ftr-ul { list-style:none }
+.ftr-ul li { margin-bottom:var(--sp2) }
+.ftr-ul a { color:rgba(255,255,255,.75); font-size:var(--t-sm); text-decoration:underline }
+.ftr-ul a:hover { color:var(--white) }
+.ftr-bot {
+  max-width:var(--max); margin:var(--sp4) auto 0;
+  padding-top:var(--sp3); border-top:1px solid rgba(255,255,255,.12);
+  font-size:var(--t-xs); color:rgba(255,255,255,.45);
+  display:flex; justify-content:space-between; flex-wrap:wrap; gap:var(--sp2);
+}
+
+/* ── RESPONSIVE ─────────────────────────────────────────────── */
+@media(max-width:800px) {
+  .hdr-in,.bc-in,.svc-in,.page { padding-left:var(--sp3); padding-right:var(--sp3) }
+  .hdr-nav { display:none }
+  h1 { font-size:var(--t-xl-m) }
+  h2.section-caption { font-size:var(--t-lg) }
+  .toggle-row { grid-template-columns:1fr; gap:var(--sp1) }
+  .toggle { width:100% }
+  .tog-btn { min-width:0; flex:1 }
+  .book-item { grid-template-columns:1fr; gap:var(--sp2) }
+  .book-action { justify-self:start }
+}
+@media(max-width:480px) {
+  h1 { font-size:var(--t-lg) }
+  .cta { width:100%; justify-content:center }
+}
+@media(forced-colors:active) {
+  .cta,.elig-mark { border:2px solid ButtonText }
+  .req-item { border-left-color:ButtonText }
+}
+
+</style>
+</head>
+<body>
+
+<a href="#main-content" class="skip">Skip to main content</a>
+
+<header class="hdr" role="banner">
+  <div class="hdr-in">
+    <a href="/" class="logo" aria-label="Gloucester City Council — home">
+      <img src="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/templates/assets/GCC_logo.svg" alt="Gloucester City Council" style="filter:brightness(0) invert(1)">
+    </a>
+  </div>
+</header>
+
+<div class="svc"><div class="svc-in">Licensing &amp; regulations</div></div>
+
+<nav class="bc" aria-label="Breadcrumb">
+  <div class="bc-in"><ol class="bc-list">
+    <li class="bc-item"><a href="#">Home</a></li>
+    <li class="bc-item"><a href="#">Licensing &amp; regulations</a></li>
+    <li class="bc-item"><a href="gcc-hcph-landing.html">Hackney carriage and private hire</a></li>
+    <li class="bc-item"><span class="bc-cur" aria-current="page">Vehicle licence</span></li>
+  </ol></div>
+</nav>
+
+<main id="main-content">
+<div class="page">
+
+  <a href="gcc-hcph-landing.html" class="back">Back</a>
+
+  <header class="pg-hdr">
+    <h1>Vehicle licence</h1>
+    <p class="pg-lead">Apply for a new licence or renew an existing one. This page covers both hackney carriage and private hire vehicle licences.</p>
+  </header>
+
+  <!-- TOGGLES -->
+  <div class="toggles">
+    <div class="toggle-row" role="group" aria-label="New licence or renewal?">
+      <span class="toggle-lbl">What do you need?</span>
+      <div class="toggle">
+        <button class="tog-btn active" id="btn-new"   onclick="setMode('new')"   aria-pressed="true">New licence</button>
+        <button class="tog-btn"        id="btn-renew" onclick="setMode('renew')" aria-pressed="false">Renew my licence</button>
+      </div>
+    </div>
+    <div class="toggle-row" role="group" aria-label="Hackney carriage or private hire?">
+      <span class="toggle-lbl">Type of licence</span>
+      <div class="toggle">
+        <button class="tog-btn active" id="btn-hc" onclick="setType('hc')" aria-pressed="true">Hackney carriage</button>
+        <button class="tog-btn"        id="btn-ph" onclick="setType('ph')" aria-pressed="false">Private hire</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- ══ NEW APPLICATION ══════════════════════════════════════ -->
+  <div id="view-new">
+
+    <!-- 1. ELIGIBILITY -->
+    <section aria-labelledby="h-elig">
+      <h2 class="section-caption" id="h-elig">Check your vehicle is eligible</h2>
+      <ul class="elig-list">
+
+        <li class="elig-item">
+          <span class="elig-mark" aria-hidden="true">✓</span>
+          <span>Must be right-hand drive with a minimum of 4 doors</span>
+        </li>
+
+        <li class="elig-item">
+          <span class="elig-mark" aria-hidden="true">✓</span>
+          <div>
+            <span>No more than 7 years old from the date of first registration</span>
+            <p class="elig-note">Wheelchair accessible vehicles (WAVs) are exempt from this age limit but must meet Euro 5 or above.</p>
+          </div>
+        </li>
+
+        <li class="elig-item">
+          <span class="elig-mark" aria-hidden="true">✓</span>
+          <span>Must meet Euro 6 emissions standard</span>
+        </li>
+
+        <li class="elig-item">
+          <span class="elig-mark" aria-hidden="true">✓</span>
+          <span>Must not already be licensed by another authority</span>
+        </li>
+
+        <li class="elig-item">
+          <span class="elig-mark" aria-hidden="true">✓</span>
+          <div>
+            <span>Must carry a fire extinguisher and first aid kit</span>
+            <p class="elig-note">Both must meet the required standards set out in the vehicle conditions.</p>
+          </div>
+        </li>
+
+      </ul>
+
+      <!-- HC specific — outside ul so borders don't conflict with hidden PH items -->
+      <ul class="elig-list" id="elig-hc-items" style="border-top:none">
+        <li class="elig-item">
+          <span class="elig-mark" aria-hidden="true">✓</span>
+          <span>Must be white in colour</span>
+        </li>
+        <li class="elig-item">
+          <span class="elig-mark" aria-hidden="true">✓</span>
+          <div>
+<span>Must be a wheelchair accessible vehicle (WAV)</span>
+            <details class="govuk-details">
+              <summary>Existing licence holders</summary>
+              <div class="govuk-details-body">
+                <p>If you hold an existing saloon-type hackney carriage licence, that vehicle may be replaced by another saloon type at the end of its working life, or upgraded to a WAV at the owner's discretion.</p>
+                <p>A WAV licence is conditional on the vehicle always remaining as a wheelchair accessible vehicle or people carrier — it cannot be transferred to a non-WAV.</p>
+                <p>WAVs first licensed at over 10 years old will be subject to a cosmetic inspection by a Licensing Officer before the licence is granted.</p>
+              </div>
+            </details>
+          </div>
+        </li>
+      </ul>
+
+      <!-- PH specific -->
+      <ul class="elig-list" id="elig-ph-items" style="display:none;border-top:none">
+        <li class="elig-item">
+          <span class="elig-mark" aria-hidden="true">✓</span>
+          <span>Can be any colour — but must not be white</span>
+        </li>
+        <li class="elig-item">
+          <span class="elig-mark" aria-hidden="true">✓</span>
+          <span>Must not be a metropolitan type vehicle (e.g. black cab or TX series)</span>
+        </li>
+      </ul>
+
+    </section>
+
+    <!-- 2. DOCUMENTS — NEW -->
+    <section aria-labelledby="h-docs-new">
+      <h2 class="section-caption" id="h-docs-new">Gather your documents and apply</h2>
+      <p style="font-size:var(--t-body);color:var(--text2);margin-bottom:var(--sp4)">Have everything below ready before you start. You will not be able to save and return to your application.</p>
+
+
+
+      <ul class="req-list">
+
+        <li class="req-item" id="ownership-hc-item">
+          <div class="req-title">Proof of ownership</div>
+          <p class="req-desc">A bill of sale, invoice or hire purchase agreement in your name.</p>
+        </li>
+
+        <li class="req-item">
+          <div class="req-title">V5 registration document</div>
+          <p class="req-desc" id="v5-hc">Or the new keeper supplement if you have recently purchased the vehicle.</p>
+          <p class="req-desc" id="v5-ph" style="display:none">Or the new keeper supplement if you have recently purchased the vehicle. The V5 is also sufficient as proof of ownership.</p>
+        </li>
+
+        <li class="req-item">
+          <div class="req-title">Insurance certificate</div>
+          <p class="req-desc" id="ins-new-hc">Must cover the vehicle for hackney carriage use. If you provide a cover note, you must follow up with the full certificate within 2 working days of it expiring.</p>
+          <p class="req-desc" id="ins-new-ph" style="display:none">Must cover the vehicle for private hire use. If you provide a cover note, you must follow up with the full certificate within 2 working days of it expiring.</p>
+        </li>
+
+        <li class="req-item">
+          <div class="req-title">MOT certificate</div>
+          <p class="req-desc">Not required if the vehicle is less than 1 year old.</p>
+        </li>
+
+        <li class="req-item">
+          <div class="req-title">Vehicle inspection certificate</div>
+          <p class="req-desc">No more than 2 months old, carried out at <a href="gcc-approved-garages.html">one of our approved testing garages</a>.</p>
+        </li>
+
+        <li class="req-item" id="meter-new-hc">
+          <div class="req-title">Meter inspection certificate</div>
+          <p class="req-desc">Required for all hackney carriage vehicles. From an approved installer, dated to the <a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/taxi-tariff-november-24.pdf" target="_blank" rel="noopener">current tariff</a>.</p>
+        </li>
+
+        <li class="req-item" id="meter-new-ph" style="display:none">
+          <div class="req-title">Meter inspection certificate</div>
+          <p class="req-desc">Only required if a meter is fitted. From an approved installer, dated to the <a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/taxi-tariff-november-24.pdf" target="_blank" rel="noopener">current tariff</a>.</p>
+        </li>
+
+        <li class="req-item">
+          <div class="req-title">Basic DBS check</div>
+          <p class="req-desc">If you are not a licensed driver with us — <a href="https://www.gov.uk/request-copy-criminal-record">apply for a basic DBS check at gov.uk</a>.</p>
+          <p class="req-desc">If you are a licensed driver with us — you are exempt from this requirement.</p>
+        </li>
+
+        <li class="req-item">
+          <div class="req-title">Application fee</div>
+          <p class="req-desc">Paid when you submit your application online.</p>
+          <span class="fee-tag">£222.00 per year</span>
+        </li>
+
+      </ul>
+
+      <div class="cta-wrap">
+        <a href="https://gloucester-self.achieveservice.com/service/Taxi___Apply_for_a_new_hackney_carriage_or_private_hire_vehicle_licence" class="cta" role="button">Apply now <span aria-hidden="true">→</span></a>
+      </div>
+    </section>
+
+  </div><!-- /view-new -->
+
+  <!-- ══ RENEWAL ═══════════════════════════════════════════════ -->
+  <div id="view-renew" style="display:none">
+
+    <!-- EXPIRY WARNING -->
+    <div class="inset" role="note" style="margin-bottom:var(--sp4);border-left-color:var(--blue)">
+      <p style="font-weight:700;margin-bottom:var(--sp2)">Renew before your licence expires</p>
+      <p>A licence renewed after the expiry date is not valid — you cannot use the vehicle for hackney carriage or private hire purposes until a new licence is issued. There is no period of grace.</p>
+    </div>
+
+    <!-- DOCUMENTS — RENEWAL -->
+    <section aria-labelledby="h-docs-renew">
+      <h2 class="section-caption" id="h-docs-renew">Gather your documents and renew</h2>
+      <p style="font-size:var(--t-body);color:var(--text2);margin-bottom:var(--sp4)">Have everything below ready before you start. All documents must be received before the licence can be issued.</p>
+
+      <ul class="req-list">
+
+        <li class="req-item">
+          <div class="req-title">V5 registration certificate</div>
+          <p class="req-desc">In your name.</p>
+        </li>
+
+        <li class="req-item">
+          <div class="req-title">Insurance certificate</div>
+          <p class="req-desc" id="ins-ren-hc">Must cover the vehicle for hackney carriage use. If you provide a cover note, you must follow up with the full certificate within 2 working days of it expiring.</p>
+          <p class="req-desc" id="ins-ren-ph" style="display:none">Must cover the vehicle for private hire use. If you provide a cover note, you must follow up with the full certificate within 2 working days of it expiring.</p>
+        </li>
+
+        <li class="req-item">
+          <div class="req-title">MOT certificate</div>
+          <p class="req-desc">Including any advisory notice.</p>
+        </li>
+
+        <li class="req-item">
+          <div class="req-title">Vehicle inspection certificate</div>
+          <p class="req-desc">No more than 2 months old, carried out at <a href="gcc-approved-garages.html">one of our approved testing garages</a>.</p>
+          <div class="inset">
+            <p>If your MOT was carried out within the last 2 months without the additional vehicle inspection checks, a Licensing and Enforcement Officer can check the cosmetic elements for an additional fee of £23.00.</p>
+          </div>
+        </li>
+
+        <li class="req-item" id="meter-ren-hc">
+          <div class="req-title">Meter inspection certificate</div>
+          <p class="req-desc">Required for all hackney carriage vehicles. From an approved installer, dated to the <a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/taxi-tariff-november-24.pdf" target="_blank" rel="noopener">current tariff</a>.</p>
+        </li>
+
+        <li class="req-item" id="meter-ren-ph" style="display:none">
+          <div class="req-title">Meter inspection certificate</div>
+          <p class="req-desc">Only required if a meter is fitted. From an approved installer, dated to the <a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/taxi-tariff-november-24.pdf" target="_blank" rel="noopener">current tariff</a>.</p>
+        </li>
+
+        <li class="req-item" id="meter-ren-hc">
+          <div class="req-title">Meter inspection certificate</div>
+          <p class="req-desc">Required for all hackney carriage vehicles. From an approved installer, dated to the <a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/taxi-tariff-november-24.pdf" target="_blank" rel="noopener">current tariff</a>.</p>
+        </li>
+
+        <li class="req-item" id="meter-ren-ph" style="display:none">
+          <div class="req-title">Meter inspection certificate</div>
+          <p class="req-desc">Only required if a meter is fitted. From an approved installer, dated to the <a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/taxi-tariff-november-24.pdf" target="_blank" rel="noopener">current tariff</a>.</p>
+        </li>
+
+        <li class="req-item">
+          <div class="req-title">Basic DBS check</div>
+          <p class="req-desc">If you are not a licensed driver with us — <a href="https://www.gov.uk/request-copy-criminal-record">apply for a basic DBS check at gov.uk</a>.</p>
+          <p class="req-desc">If you are a licensed driver with us — provide your DBS Online Update Service certificate number.</p>
+        </li>
+
+        <li class="req-item">
+          <div class="req-title">Renewal fee</div>
+          <p class="req-desc">Paid when you submit your renewal online.</p>
+          <span class="fee-tag">£222.00 per year</span>
+        </li>
+
+      </ul>
+
+      <div class="cta-wrap">
+        <a href="https://gloucester-self.achieveservice.com/service/Taxi___Renew_a_Hackney_Carriage_or_Private_Hire_vehicle_licence" class="cta" role="button">Renew now <span aria-hidden="true">→</span></a>
+      </div>
+    </section>
+
+  </div><!-- /view-renew -->
+
+
+  <!-- RELATED INFORMATION -->
+  <aside aria-label="Related information" style="margin-top:var(--sp7)">
+    <h2 class="section-caption">Related information</h2>
+    <ul style="list-style:none;border-top:1px solid var(--divider)">
+      <li style="padding:var(--sp3) 0;border-bottom:1px solid var(--divider)">
+        <a href="gcc-hcph-documents.html" style="font-weight:700;font-size:var(--t-body)">Licensing information</a>
+        <p style="font-size:var(--t-body);color:var(--text2);margin-top:var(--sp1)">Rule books, policies, forms and reference documents</p>
+      </li>
+      <li style="padding:var(--sp3) 0;border-bottom:1px solid var(--divider)">
+        <a href="gcc-hcph-wav.html" style="font-weight:700;font-size:var(--t-body)">Wheelchair accessible vehicles</a>
+        <p style="font-size:var(--t-body);color:var(--text2);margin-top:var(--sp1)">Guidance and register of designated WAVs</p>
+      </li>
+      <li style="padding:var(--sp3) 0;border-bottom:1px solid var(--divider)">
+        <a href="gcc-hcph-fees.html" style="font-weight:700;font-size:var(--t-body)">Fees and charges</a>
+        <p style="font-size:var(--t-body);color:var(--text2);margin-top:var(--sp1)">Full fee schedule for 2026 to 2027</p>
+      </li>
+    </ul>
+  </aside>
+
+</div>
+</main>
+
+<footer class="ftr" role="contentinfo">
+  <div class="ftr-in">
+    <div>
+      <div class="ftr-h">Licensing</div>
+      <ul class="ftr-ul">
+        <li><a href="gcc-hcph-landing.html">Hackney carriage and private hire</a></li>
+        <li><a href="#">Premises licences</a></li>
+        <li><a href="#">Personal licences</a></li>
+      </ul>
+    </div>
+    <div>
+      <div class="ftr-h">About GCC</div>
+      <ul class="ftr-ul">
+        <li><a href="#">Accessibility statement</a></li>
+        <li><a href="#">Privacy notice</a></li>
+        <li><a href="#">Cookies</a></li>
+        <li><a href="#">Contact us</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="ftr-bot">
+    <span>© Gloucester City Council</span>
+    <span>Last updated: July 2026</span>
+  </div>
+</footer>
+
+<script>
+let mode='new', type='hc';
+
+function show(id){const el=document.getElementById(id);if(el)el.style.display='block'}
+function hide(id){const el=document.getElementById(id);if(el)el.style.display='none'}
+
+function render(){
+  // Mode
+  if(mode==='new'){ show('view-new'); hide('view-renew'); }
+  else { hide('view-new'); show('view-renew'); }
+
+  // Type
+  if(type==='hc'){
+    // Insurance
+    show('ins-new-hc'); hide('ins-new-ph');
+    show('ins-ren-hc'); hide('ins-ren-ph');
+    // Meter
+    show('meter-new-hc'); hide('meter-new-ph');
+    show('meter-ren-hc'); hide('meter-ren-ph');
+    // Expired licence rules
+    // PH-only condition
+    hide('ph-already-licensed');
+    // Eligibility — HC specific
+    show('elig-hc-items'); hide('elig-ph-items');
+    show('ownership-hc-item'); show('v5-hc'); hide('v5-ph');
+  } else {
+    // Insurance
+    hide('ins-new-hc'); show('ins-new-ph');
+    hide('ins-ren-hc'); show('ins-ren-ph');
+    // Meter — HC always has one, PH only if fitted
+    hide('meter-new-hc'); show('meter-new-ph');
+    hide('meter-ren-hc'); show('meter-ren-ph');
+    // Expired licence rules
+    // PH-only condition
+    show('ph-already-licensed');
+    // Eligibility — PH specific
+    hide('elig-hc-items'); show('elig-ph-items');
+    hide('ownership-hc-item'); hide('v5-hc'); show('v5-ph');
+  }
+}
+
+function setMode(m){
+  mode=m;
+  ['new','renew'].forEach(v=>{
+    const b=document.getElementById('btn-'+v);
+    b.classList.toggle('active',v===m);
+    b.setAttribute('aria-pressed',v===m?'true':'false');
+  });
+  render();
+}
+
+function setType(t){
+  type=t;
+  ['hc','ph'].forEach(v=>{
+    const b=document.getElementById('btn-'+v);
+    b.classList.toggle('active',v===t);
+    b.setAttribute('aria-pressed',v===t?'true':'false');
+  });
+  render();
+}
+
+render();
+</script>
+</body>
+</html>

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -50,7 +50,8 @@
       "*.woff2",
       "*.ttf",
       "*.eot",
-      "*.html"
+      "*.html",
+      "/Taxi website/Webpages/*.html"
     ]
   },
   "responseOverrides": {


### PR DESCRIPTION
## Summary
- Adds 10 hackney carriage / private hire licensing pages to `Taxi website/Webpages/`: `gcc-hcph-landing.html`, `gcc-driver-licence.html`, `gcc-vehicle-licence.html`, `gcc-approved-garages.html`, `gcc-hcph-changes.html`, `gcc-hcph-documents.html`, `gcc-hcph-fees.html`, `gcc-hcph-passengers.html`, `gcc-hcph-wav.html`, `gcc-hcph-register.html`
- Fixes `staticwebapp.config.json` so `navigationFallback` no longer intercepts HTML files in this subfolder — the existing `"*.html"` exclude pattern only matches root-level files under Azure Static Web Apps' route-matching rules, so files nested under `Taxi website/Webpages/` were being rewritten to `/index.html` instead of being served directly. Added an explicit `"/Taxi website/Webpages/*.html"` exclude entry alongside it.

## Test plan
- [ ] After merge, confirm each page is served directly (not rewritten to the SPA fallback) at `https://gentle-sand-0782dd703.2.azurestaticapps.net/Taxi%20website/Webpages/<filename>.html`
- [ ] Spot-check internal links between the new pages (landing → driver/vehicle/passengers/changes/documents → fees/wav/register/approved-garages)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmXBkt59tXj7B2g1x81yQX)_