### PR TITLE
Connect public register page to LIC_Public_Register.json

### DIFF
--- a/Taxi website/Webpages/gcc-hcph-register.html
+++ b/Taxi website/Webpages/gcc-hcph-register.html
@@ -148,9 +148,26 @@ tr:last-child td{border-bottom:none}
 </footer>
 
 <script>
-const JSON_URL = 'https://api.github.com/repos/Gloucester-City-Council/GCC-Beta-site-v1/contents/Taxi%20website/PublicRegister/LIC_Public_Register.json';
+// Always resolves to whatever is currently committed at this path on main —
+// replace the file's contents each month, no code or URL changes needed.
+const JSON_URL = 'https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/Taxi%20website/PublicRegister/LIC_Public_Register.json';
+
+const COLUMNS = [
+  { label: 'Plate / ref',    get: r => r.plate_ref },
+  { label: 'Licence type',   get: r => r.licence_type },
+  { label: 'Registration',   get: r => r.vehicle_reg_no },
+  { label: 'Vehicle',        get: r => [r.vehicle_make, r.vehicle_model].filter(Boolean).join(' ') || null },
+  { label: 'Trading as',     get: r => r.trading_as },
+  { label: 'Issued',         get: r => fmtDate(r.issued_date) },
+  { label: 'Expiry',         get: r => fmtDate(r.expiry_date) },
+];
 
 let DATA = null;
+let currentView = 'driver';
+
+function esc(v) {
+  return String(v).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+}
 
 function fmtDate(d) {
   if (!d) return '—';
@@ -161,7 +178,7 @@ function fmtDate(d) {
   return parseInt(parts[2],10) + ' ' + months[parseInt(parts[1],10)-1] + ' ' + parts[0];
 }
 
-function cell(v) { return (v !== null && v !== undefined && v !== '') ? String(v) : '—'; }
+function cell(v) { return esc((v !== null && v !== undefined && v !== '') ? String(v) : '—'); }
 
 function parseData(data) {
   if (data.driver) return data;
@@ -173,14 +190,52 @@ function parseData(data) {
   };
 }
 
-fetch(JSON_URL, { headers: { 'Accept': 'application/vnd.github.v3.raw' } })
+function renderHead() {
+  document.getElementById('thead').innerHTML =
+    '<tr>' + COLUMNS.map(c => '<th scope="col">' + esc(c.label) + '</th>').join('') + '</tr>';
+}
+
+function renderRows(view) {
+  const tbody = document.getElementById('tbody');
+  const count = document.getElementById('count');
+
+  if (!DATA) {
+    tbody.innerHTML = '<tr><td colspan="' + COLUMNS.length + '" class="loading">Loading register…</td></tr>';
+    count.textContent = '';
+    return;
+  }
+
+  const rows = DATA[view] || [];
+  if (!rows.length) {
+    tbody.innerHTML = '<tr><td colspan="' + COLUMNS.length + '" class="loading">No records found.</td></tr>';
+    count.textContent = '0 records';
+    return;
+  }
+
+  count.textContent = rows.length + (rows.length === 1 ? ' record' : ' records');
+  tbody.innerHTML = rows.map(r =>
+    '<tr>' + COLUMNS.map(c => '<td>' + cell(c.get(r)) + '</td>').join('') + '</tr>'
+  ).join('');
+}
+
+function setView(view) {
+  currentView = view;
+  ['driver','vehicle','operator'].forEach(v => {
+    document.getElementById('btn-' + v).setAttribute('aria-pressed', v === view ? 'true' : 'false');
+  });
+  renderRows(view);
+}
+
+renderHead();
+
+fetch(JSON_URL)
   .then(r => { if (!r.ok) throw new Error('Failed'); return r.json(); })
   .then(data => {
     DATA = parseData(data);
-    setView('driver');
+    setView(currentView);
   })
   .catch(() => {
-    document.getElementById('tbody').innerHTML = '<tr><td colspan="7" class="loading">Unable to load the register at this time. Please try again later.</td></tr>';
+    document.getElementById('tbody').innerHTML = '<tr><td colspan="' + COLUMNS.length + '" class="loading">Unable to load the register at this time. Please try again later.</td></tr>';
     document.getElementById('count').textContent = '';
   });
 </script>


### PR DESCRIPTION
## Summary
- `gcc-hcph-register.html` fetched the register JSON but never rendered it — `setView()`, called by both the toggle buttons and the fetch success handler, was never defined, so the table stayed on "Loading register…" regardless of whether the fetch succeeded.
- Implements the missing `setView()` / render logic: builds the table header once (Plate/ref, Licence type, Registration, Vehicle, Trading as, Issued, Expiry) and renders rows for the driver/vehicle/operator toggle views from the existing bucketed data.
- Switches the fetch URL from the GitHub contents API to `raw.githubusercontent.com/.../main/Taxi%20website/PublicRegister/LIC_Public_Register.json`, which always serves whatever is currently committed at that path — so updating the register each month just means replacing that file's contents (same path/filename), no code or URL changes needed.
- Escapes rendered cell values before inserting into `innerHTML`.

Verified the bucketing logic against the real `LIC_Public_Register.json` currently in the repo: 630 driver / 615 vehicle / 65 operator records, totalling the file's declared `record_count` of 1310.

## Test plan
- [ ] After merge, open the live Public register page and confirm all three toggles (Drivers/Vehicles/Operators) populate with data and show a sensible record count
- [ ] Next month, replace only the contents of `Taxi website/PublicRegister/LIC_Public_Register.json` (same filename) and confirm the page picks it up without any further changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmXBkt59tXj7B2g1x81yQX)_