### PR TITLE
Fix undersized back-button touch target on WAV and register pages

### DIFF
--- a/Taxi website/Webpages/gcc-hcph-register.html
+++ b/Taxi website/Webpages/gcc-hcph-register.html
@@ -12,7 +12,7 @@
   --max:960px;--sp1:4px;--sp2:8px;--sp3:12px;--sp4:16px;
   --sp5:24px;--sp6:40px;--sp7:56px;
   --t-xs:.75rem;--t-sm:.875rem;--t-body:1rem;--t-md:1.125rem;
-  --t-section:1.25rem;--t-h1:2rem;--lh-body:1.6;
+  --t-section:1.25rem;--t-h1:2rem;--lh-body:1.6;--touch:44px;
 }
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:var(--text);background:var(--white);line-height:var(--lh-body)}
@@ -31,7 +31,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;c
 .bc-item+.bc-item::before{content:"›";color:var(--muted)}
 .bc-cur{color:var(--text);font-weight:600}
 .page{max-width:var(--max);margin:0 auto;padding:var(--sp5) var(--sp4) var(--sp7)}
-.back{display:inline-flex;align-items:center;gap:var(--sp1);font-size:var(--t-sm);color:var(--link);text-decoration:none;margin-bottom:var(--sp5)}
+.back{display:inline-flex;align-items:center;gap:var(--sp1);font-size:var(--t-sm);color:var(--link);text-decoration:none;margin-bottom:var(--sp5);min-height:var(--touch);padding:var(--sp1) 0}
 .back::before{content:"‹";font-size:1.2em}
 .back:hover{color:var(--hover);text-decoration:underline}
 .pg-hdr{margin-bottom:var(--sp5);padding-top:var(--sp5);border-top:2px solid var(--divider)}

--- a/Taxi website/Webpages/gcc-hcph-wav.html
+++ b/Taxi website/Webpages/gcc-hcph-wav.html
@@ -12,7 +12,7 @@
   --max:960px; --sp1:4px; --sp2:8px; --sp3:12px; --sp4:16px;
   --sp5:24px; --sp6:40px; --sp7:56px;
   --t-xs:.75rem; --t-sm:.875rem; --t-body:1rem; --t-md:1.125rem;
-  --t-section:1.25rem; --t-h1:2rem; --lh-body:1.6;
+  --t-section:1.25rem; --t-h1:2rem; --lh-body:1.6; --touch:44px;
 }
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:var(--text);background:var(--white);line-height:var(--lh-body)}
@@ -31,7 +31,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;c
 .bc-item+.bc-item::before{content:"›";color:var(--muted)}
 .bc-cur{color:var(--text);font-weight:600}
 .page{max-width:var(--max);margin:0 auto;padding:var(--sp5) var(--sp4) var(--sp7)}
-.back{display:inline-flex;align-items:center;gap:var(--sp1);font-size:var(--t-sm);color:var(--link);text-decoration:none;margin-bottom:var(--sp5)}
+.back{display:inline-flex;align-items:center;gap:var(--sp1);font-size:var(--t-sm);color:var(--link);text-decoration:none;margin-bottom:var(--sp5);min-height:var(--touch);padding:var(--sp1) 0}
 .back::before{content:"‹";font-size:1.2em}
 .back:hover{color:var(--hover);text-decoration:underline}
 .pg-hdr{margin-bottom:var(--sp5);padding-top:var(--sp5);border-top:2px solid var(--divider)}


### PR DESCRIPTION
## Summary
- `gcc-hcph-wav.html` and `gcc-hcph-register.html` use a different, older stylesheet than the other 7 taxi licensing pages, where `.back` had no `min-height` or padding — sized purely by 14px text, giving a clickable height of roughly 22px.
- The other 7 pages (driver, vehicle, garages, changes, documents, fees, passengers licences) all use `min-height: 44px` on `.back`, meeting WCAG 2.5.5 (AAA touch target) and 2.5.8 (AA minimum).
- Added a `--touch: 44px` variable to both pages' `:root` and applied `min-height: var(--touch)` + vertical padding to `.back`, bringing them in line with the rest of the site. No visual/layout changes beyond the larger tap area.

## Test plan
- [ ] On mobile/touch, confirm the "Back" link on the Wheelchair Accessible Vehicles and Public Register pages is easier to tap and roughly matches the size of the back link on other pages

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmXBkt59tXj7B2g1x81yQX)_