### PR TITLE
Add "Something has changed" to related info; fix broken document link

### DIFF
--- a/Taxi website/Webpages/gcc-driver-licence.html
+++ b/Taxi website/Webpages/gcc-driver-licence.html
@@ -697,6 +697,10 @@ a:focus-visible { color:var(--text) }
         <a href="gcc-hcph-fees.html" style="font-weight:700;font-size:var(--t-body)">Fees and charges</a>
         <p style="font-size:var(--t-body);color:var(--text2);margin-top:var(--sp1)">Full fee schedule for 2026 to 2027</p>
       </li>
+      <li style="padding:var(--sp3) 0;border-bottom:1px solid var(--divider)">
+        <a href="gcc-hcph-changes.html" style="font-weight:700;font-size:var(--t-body)">Something has changed</a>
+        <p style="font-size:var(--t-body);color:var(--text2);margin-top:var(--sp1)">Updates to your licence, vehicle or circumstances</p>
+      </li>
     </ul>
   </aside>
 

--- a/Taxi website/Webpages/gcc-hcph-documents.html
+++ b/Taxi website/Webpages/gcc-hcph-documents.html
@@ -548,7 +548,7 @@ a:focus-visible { color:var(--text) }
       </li>
 
       <li class="doc-item">
-        <div class="doc-title"><a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/common-standards-for-licensing-hackney-carriage-and-private-hire-drivers-app.pdf" target="_blank" rel="noopener">Common Standards for Licensing Drivers in Gloucestershire</a></div>
+        <div class="doc-title"><a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/common-standards-for-licensing-hackney-carriage-and-private-hire-drivers-approved-september-2021.pdf" target="_blank" rel="noopener">Common Standards for Licensing Drivers in Gloucestershire</a></div>
         <span class="doc-meta">Approved September 2021</span>
       </li>
 

--- a/Taxi website/Webpages/gcc-vehicle-licence.html
+++ b/Taxi website/Webpages/gcc-vehicle-licence.html
@@ -723,6 +723,10 @@ a:focus-visible { color:var(--text) }
         <a href="gcc-hcph-fees.html" style="font-weight:700;font-size:var(--t-body)">Fees and charges</a>
         <p style="font-size:var(--t-body);color:var(--text2);margin-top:var(--sp1)">Full fee schedule for 2026 to 2027</p>
       </li>
+      <li style="padding:var(--sp3) 0;border-bottom:1px solid var(--divider)">
+        <a href="gcc-hcph-changes.html" style="font-weight:700;font-size:var(--t-body)">Something has changed</a>
+        <p style="font-size:var(--t-body);color:var(--text2);margin-top:var(--sp1)">Updates to your licence, vehicle or circumstances</p>
+      </li>
     </ul>
   </aside>
 


### PR DESCRIPTION
## Summary
- Added a "Something has changed" entry to the Related information section at the bottom of both the driver licence and vehicle licence pages, using the same title/description already used for that link on the landing page.
- Fixed the "Common Standards for Licensing Drivers in Gloucestershire" link on the licensing information page (`gcc-hcph-documents.html`): the filename in the URL was truncated to `...-drivers-app.pdf`, which doesn't exist in the repo — the actual file is `...-drivers-approved-september-2021.pdf`. Confirmed the corrected filename exists at the pinned commit the URL already points to, so the link now resolves.

## Test plan
- [ ] On the driver and vehicle licence pages, confirm "Something has changed" appears in Related information and links to the changes page
- [ ] Click the "Common Standards for Licensing Drivers in Gloucestershire" link on the licensing information page and confirm the PDF opens instead of 404ing

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmXBkt59tXj7B2g1x81yQX)_