### PR TITLE
Fix broken medical/conviction form links; stop pinning documents to a stale commit

### DIFF
--- a/Taxi website/Webpages/gcc-driver-licence.html
+++ b/Taxi website/Webpages/gcc-driver-licence.html
@@ -580,7 +580,7 @@ a:focus-visible { color:var(--text) }
 
         <li class="req-item">
           <div class="req-title">Driving medical certificate</div>
-          <p class="req-desc">Your GP must complete this to the standard required for professional drivers. No more than 3 months old, on the <a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/medical-examination-report.pdf" target="_blank" rel="noopener">approved medical form</a>.</p>
+          <p class="req-desc">Your GP must complete this to the standard required for professional drivers. No more than 3 months old, on the <a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/Taxi%20website/Documents/medical-examination-report.pdf" target="_blank" rel="noopener">approved medical form</a>.</p>
         </li>
 
         <li class="req-item">
@@ -653,7 +653,7 @@ a:focus-visible { color:var(--text) }
 
         <li class="req-item">
           <div class="req-title">Driving medical certificate</div>
-          <p class="req-desc">Your GP must complete this to the standard required for professional drivers. No more than 3 months old, on the <a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/medical-examination-report.pdf" target="_blank" rel="noopener">approved medical form</a>.</p>
+          <p class="req-desc">Your GP must complete this to the standard required for professional drivers. No more than 3 months old, on the <a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/Taxi%20website/Documents/medical-examination-report.pdf" target="_blank" rel="noopener">approved medical form</a>.</p>
           <div class="inset">
             <p>If you are aged 45 or over: required every 5 years.</p>
             <p>If you are aged 65 or over: required every year.</p>

--- a/Taxi website/Webpages/gcc-hcph-changes.html
+++ b/Taxi website/Webpages/gcc-hcph-changes.html
@@ -510,7 +510,7 @@ a:focus-visible { color:var(--text) }
           <div class="change-title">Notify us of a conviction, caution or fixed penalty</div>
           <p class="change-desc">You must notify us within 48 hours of any conviction, caution, fixed penalty or pending court case.</p>
         </div>
-        <a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/notification-of-conviction.pdf" target="_blank" rel="noopener" class="change-action">Download form →</a>
+        <a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/Taxi%20website/Documents/notification-of-conviction.pdf" target="_blank" rel="noopener" class="change-action">Download form →</a>
       </li>
 
     </ul>

--- a/Taxi website/Webpages/gcc-hcph-documents.html
+++ b/Taxi website/Webpages/gcc-hcph-documents.html
@@ -523,32 +523,32 @@ a:focus-visible { color:var(--text) }
     <ul class="doc-list">
 
       <li class="doc-item">
-        <div class="doc-title"><a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/taxi-tariff-november-24.pdf" target="_blank" rel="noopener">Taxi tariff</a></div>
+        <div class="doc-title"><a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/Taxi%20website/Documents/taxi-tariff-november-24.pdf" target="_blank" rel="noopener">Taxi tariff</a></div>
         <span class="doc-meta">Approved November 2024</span>
       </li>
 
       <li class="doc-item">
-        <div class="doc-title"><a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/hc-driver-and-vehicle-rule-books-june-2025.pdf" target="_blank" rel="noopener">Hackney Carriage Driver and Vehicle Rule Book</a></div>
+        <div class="doc-title"><a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/Taxi%20website/Documents/hc-driver-and-vehicle-rule-books-june-2025.pdf" target="_blank" rel="noopener">Hackney Carriage Driver and Vehicle Rule Book</a></div>
         <span class="doc-meta">Approved June 2025</span>
       </li>
 
       <li class="doc-item">
-        <div class="doc-title"><a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/ph-driver-and-vehicle-rule-book-june-2025.pdf" target="_blank" rel="noopener">Private Hire Driver and Vehicle Rule Book</a></div>
+        <div class="doc-title"><a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/Taxi%20website/Documents/ph-driver-and-vehicle-rule-book-june-2025.pdf" target="_blank" rel="noopener">Private Hire Driver and Vehicle Rule Book</a></div>
         <span class="doc-meta">Approved June 2025</span>
       </li>
 
       <li class="doc-item">
-        <div class="doc-title"><a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/pho-rule-book-june-2025.pdf" target="_blank" rel="noopener">Private Hire Operators Rule Book</a></div>
+        <div class="doc-title"><a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/Taxi%20website/Documents/pho-rule-book-june-2025.pdf" target="_blank" rel="noopener">Private Hire Operators Rule Book</a></div>
         <span class="doc-meta">Approved June 2025</span>
       </li>
 
       <li class="doc-item">
-        <div class="doc-title"><a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/hc-ph-regulatory-guidelines-approved-september-21.pdf" target="_blank" rel="noopener">Hackney Carriage and Private Hire Regulatory Guidelines</a></div>
+        <div class="doc-title"><a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/Taxi%20website/Documents/hc-ph-regulatory-guidelines-approved-september-21.pdf" target="_blank" rel="noopener">Hackney Carriage and Private Hire Regulatory Guidelines</a></div>
         <span class="doc-meta">Approved September 2021</span>
       </li>
 
       <li class="doc-item">
-        <div class="doc-title"><a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/common-standards-for-licensing-hackney-carriage-and-private-hire-drivers-approved-september-2021.pdf" target="_blank" rel="noopener">Common Standards for Licensing Drivers in Gloucestershire</a></div>
+        <div class="doc-title"><a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/Taxi%20website/Documents/common-standards-for-licensing-hackney-carriage-and-private-hire-drivers-approved-september-2021.pdf" target="_blank" rel="noopener">Common Standards for Licensing Drivers in Gloucestershire</a></div>
         <span class="doc-meta">Approved September 2021</span>
       </li>
 
@@ -561,12 +561,12 @@ a:focus-visible { color:var(--text) }
     <ul class="doc-list">
 
       <li class="doc-item">
-        <div class="doc-title"><a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/medical-examination-report.pdf" target="_blank" rel="noopener">Medical examination form</a></div>
+        <div class="doc-title"><a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/Taxi%20website/Documents/medical-examination-report.pdf" target="_blank" rel="noopener">Medical examination form</a></div>
         <p class="doc-desc">A standard DVLA medical form is not accepted — your GP must use this form.</p>
       </li>
 
       <li class="doc-item">
-        <div class="doc-title"><a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/notification-of-conviction.pdf" target="_blank" rel="noopener">Notification of conviction form</a></div>
+        <div class="doc-title"><a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/Taxi%20website/Documents/notification-of-conviction.pdf" target="_blank" rel="noopener">Notification of conviction form</a></div>
         <p class="doc-desc">Licence holders must notify us within 48 hours of any conviction, caution, fixed penalty or pending court case.</p>
       </li>
 

--- a/Taxi website/Webpages/gcc-hcph-passengers.html
+++ b/Taxi website/Webpages/gcc-hcph-passengers.html
@@ -582,7 +582,7 @@ a:focus-visible { color:var(--text) }
         <div id="breakdown" style="display:flex;flex-direction:column;gap:var(--sp2)"></div>
       </div>
 
-      <p style="font-size:var(--t-sm);color:var(--muted);margin-top:var(--sp3)">Estimate only — the meter may differ slightly. Waiting time not included. Wheelchairs and guide dogs: no charge. <a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/taxi-tariff-november-24.pdf" target="_blank" rel="noopener">View the full tariff</a>.</p>
+      <p style="font-size:var(--t-sm);color:var(--muted);margin-top:var(--sp3)">Estimate only — the meter may differ slightly. Waiting time not included. Wheelchairs and guide dogs: no charge. <a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/Taxi%20website/Documents/taxi-tariff-november-24.pdf" target="_blank" rel="noopener">View the full tariff</a>.</p>
     </div>
   </div>
 

--- a/Taxi website/Webpages/gcc-vehicle-licence.html
+++ b/Taxi website/Webpages/gcc-vehicle-licence.html
@@ -596,12 +596,12 @@ a:focus-visible { color:var(--text) }
 
         <li class="req-item" id="meter-new-hc">
           <div class="req-title">Meter inspection certificate</div>
-          <p class="req-desc">Required for all hackney carriage vehicles. From an approved installer, dated to the <a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/taxi-tariff-november-24.pdf" target="_blank" rel="noopener">current tariff</a>.</p>
+          <p class="req-desc">Required for all hackney carriage vehicles. From an approved installer, dated to the <a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/Taxi%20website/Documents/taxi-tariff-november-24.pdf" target="_blank" rel="noopener">current tariff</a>.</p>
         </li>
 
         <li class="req-item" id="meter-new-ph" style="display:none">
           <div class="req-title">Meter inspection certificate</div>
-          <p class="req-desc">Only required if a meter is fitted. From an approved installer, dated to the <a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/taxi-tariff-november-24.pdf" target="_blank" rel="noopener">current tariff</a>.</p>
+          <p class="req-desc">Only required if a meter is fitted. From an approved installer, dated to the <a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/Taxi%20website/Documents/taxi-tariff-november-24.pdf" target="_blank" rel="noopener">current tariff</a>.</p>
         </li>
 
         <li class="req-item">
@@ -667,22 +667,22 @@ a:focus-visible { color:var(--text) }
 
         <li class="req-item" id="meter-ren-hc">
           <div class="req-title">Meter inspection certificate</div>
-          <p class="req-desc">Required for all hackney carriage vehicles. From an approved installer, dated to the <a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/taxi-tariff-november-24.pdf" target="_blank" rel="noopener">current tariff</a>.</p>
+          <p class="req-desc">Required for all hackney carriage vehicles. From an approved installer, dated to the <a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/Taxi%20website/Documents/taxi-tariff-november-24.pdf" target="_blank" rel="noopener">current tariff</a>.</p>
         </li>
 
         <li class="req-item" id="meter-ren-ph" style="display:none">
           <div class="req-title">Meter inspection certificate</div>
-          <p class="req-desc">Only required if a meter is fitted. From an approved installer, dated to the <a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/taxi-tariff-november-24.pdf" target="_blank" rel="noopener">current tariff</a>.</p>
+          <p class="req-desc">Only required if a meter is fitted. From an approved installer, dated to the <a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/Taxi%20website/Documents/taxi-tariff-november-24.pdf" target="_blank" rel="noopener">current tariff</a>.</p>
         </li>
 
         <li class="req-item" id="meter-ren-hc">
           <div class="req-title">Meter inspection certificate</div>
-          <p class="req-desc">Required for all hackney carriage vehicles. From an approved installer, dated to the <a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/taxi-tariff-november-24.pdf" target="_blank" rel="noopener">current tariff</a>.</p>
+          <p class="req-desc">Required for all hackney carriage vehicles. From an approved installer, dated to the <a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/Taxi%20website/Documents/taxi-tariff-november-24.pdf" target="_blank" rel="noopener">current tariff</a>.</p>
         </li>
 
         <li class="req-item" id="meter-ren-ph" style="display:none">
           <div class="req-title">Meter inspection certificate</div>
-          <p class="req-desc">Only required if a meter is fitted. From an approved installer, dated to the <a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/0c3f73fab3f96cd45bd421796d5103ddd09f86ba/Taxi%20website/Documents/taxi-tariff-november-24.pdf" target="_blank" rel="noopener">current tariff</a>.</p>
+          <p class="req-desc">Only required if a meter is fitted. From an approved installer, dated to the <a href="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/Taxi%20website/Documents/taxi-tariff-november-24.pdf" target="_blank" rel="noopener">current tariff</a>.</p>
         </li>
 
         <li class="req-item">


### PR DESCRIPTION
## Summary

The Medical examination form and Notification of conviction form links (on the driver licence, "something has changed", and licensing information pages) 404'd because both PDFs were added to the repo *after* the commit SHA every document link was pinned to — they never existed at that commit in the first place.

Rather than patch just those two, I switched all 18 document link occurrences (8 distinct PDFs, across the driver licence, vehicle licence, changes, documents and passengers pages) from that pinned commit to `/main/`:
- Fixes the two broken links.
- The other 6 links happened to still resolve, but were one file replacement away from silently serving a stale version forever, since they were frozen to one specific old commit. This matches the same `/main/` pattern already used for the public register JSON, so replacing a document at its existing filename just works going forward with no code changes.

Verified all 8 referenced filenames exist on `main`, and spot-checked 3 of the corrected URLs (medical exam, notification of conviction, common standards) return HTTP 200.

## Test plan
- [ ] Click the medical examination form and notification of conviction form links (documents page, driver licence page, changes page) and confirm the PDFs open
- [ ] Spot-check the other document links (rule books, tariff, regulatory guidelines) still open correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmXBkt59tXj7B2g1x81yQX)_