### PR TITLE
Link footer Privacy notice to the real data protection page

### DIFF
--- a/Taxi website/Webpages/gcc-approved-garages.html
+++ b/Taxi website/Webpages/gcc-approved-garages.html
@@ -623,7 +623,7 @@ a:focus-visible { color:var(--text) }
       <div class="ftr-h">About GCC</div>
       <ul class="ftr-ul">
         <li><a href="https://www.gloucester.gov.uk/accessibility/">Accessibility statement</a></li>
-        <li><a href="#">Privacy notice</a></li>
+        <li><a href="https://www.gloucester.gov.uk/about-the-council/data-protection-and-freedom-of-information/data-protection/">Privacy notice</a></li>
         <li><a href="https://www.gloucester.gov.uk/cookies/">Cookies</a></li>
         <li><a href="https://www.gloucester.gov.uk/sitemap/">Site map</a></li>
         <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>

--- a/Taxi website/Webpages/gcc-driver-licence.html
+++ b/Taxi website/Webpages/gcc-driver-licence.html
@@ -721,7 +721,7 @@ a:focus-visible { color:var(--text) }
       <div class="ftr-h">About GCC</div>
       <ul class="ftr-ul">
         <li><a href="https://www.gloucester.gov.uk/accessibility/">Accessibility statement</a></li>
-        <li><a href="#">Privacy notice</a></li>
+        <li><a href="https://www.gloucester.gov.uk/about-the-council/data-protection-and-freedom-of-information/data-protection/">Privacy notice</a></li>
         <li><a href="https://www.gloucester.gov.uk/cookies/">Cookies</a></li>
         <li><a href="https://www.gloucester.gov.uk/sitemap/">Site map</a></li>
         <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>

--- a/Taxi website/Webpages/gcc-hcph-changes.html
+++ b/Taxi website/Webpages/gcc-hcph-changes.html
@@ -610,7 +610,7 @@ a:focus-visible { color:var(--text) }
       <div class="ftr-h">About GCC</div>
       <ul class="ftr-ul">
         <li><a href="https://www.gloucester.gov.uk/accessibility/">Accessibility statement</a></li>
-        <li><a href="#">Privacy notice</a></li>
+        <li><a href="https://www.gloucester.gov.uk/about-the-council/data-protection-and-freedom-of-information/data-protection/">Privacy notice</a></li>
         <li><a href="https://www.gloucester.gov.uk/cookies/">Cookies</a></li>
         <li><a href="https://www.gloucester.gov.uk/sitemap/">Site map</a></li>
         <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>

--- a/Taxi website/Webpages/gcc-hcph-documents.html
+++ b/Taxi website/Webpages/gcc-hcph-documents.html
@@ -617,7 +617,7 @@ a:focus-visible { color:var(--text) }
       <div class="ftr-h">About GCC</div>
       <ul class="ftr-ul">
         <li><a href="https://www.gloucester.gov.uk/accessibility/">Accessibility statement</a></li>
-        <li><a href="#">Privacy notice</a></li>
+        <li><a href="https://www.gloucester.gov.uk/about-the-council/data-protection-and-freedom-of-information/data-protection/">Privacy notice</a></li>
         <li><a href="https://www.gloucester.gov.uk/cookies/">Cookies</a></li>
         <li><a href="https://www.gloucester.gov.uk/sitemap/">Site map</a></li>
         <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>

--- a/Taxi website/Webpages/gcc-hcph-fees.html
+++ b/Taxi website/Webpages/gcc-hcph-fees.html
@@ -614,7 +614,7 @@ a:focus-visible { color:var(--text) }
       <div class="ftr-h">About GCC</div>
       <ul class="ftr-ul">
         <li><a href="https://www.gloucester.gov.uk/accessibility/">Accessibility statement</a></li>
-        <li><a href="#">Privacy notice</a></li>
+        <li><a href="https://www.gloucester.gov.uk/about-the-council/data-protection-and-freedom-of-information/data-protection/">Privacy notice</a></li>
         <li><a href="https://www.gloucester.gov.uk/cookies/">Cookies</a></li>
         <li><a href="https://www.gloucester.gov.uk/sitemap/">Site map</a></li>
         <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>

--- a/Taxi website/Webpages/gcc-hcph-landing.html
+++ b/Taxi website/Webpages/gcc-hcph-landing.html
@@ -431,7 +431,7 @@ a:focus-visible{color:var(--text)}
       <div class="ftr-h">About GCC</div>
       <ul class="ftr-ul">
         <li><a href="https://www.gloucester.gov.uk/accessibility/">Accessibility statement</a></li>
-        <li><a href="#">Privacy notice</a></li>
+        <li><a href="https://www.gloucester.gov.uk/about-the-council/data-protection-and-freedom-of-information/data-protection/">Privacy notice</a></li>
         <li><a href="https://www.gloucester.gov.uk/cookies/">Cookies</a></li>
         <li><a href="https://www.gloucester.gov.uk/sitemap/">Site map</a></li>
         <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>

--- a/Taxi website/Webpages/gcc-hcph-passengers.html
+++ b/Taxi website/Webpages/gcc-hcph-passengers.html
@@ -636,7 +636,7 @@ a:focus-visible { color:var(--text) }
       <div class="ftr-h">About GCC</div>
       <ul class="ftr-ul">
         <li><a href="https://www.gloucester.gov.uk/accessibility/">Accessibility statement</a></li>
-        <li><a href="#">Privacy notice</a></li>
+        <li><a href="https://www.gloucester.gov.uk/about-the-council/data-protection-and-freedom-of-information/data-protection/">Privacy notice</a></li>
         <li><a href="https://www.gloucester.gov.uk/cookies/">Cookies</a></li>
         <li><a href="https://www.gloucester.gov.uk/sitemap/">Site map</a></li>
         <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>

--- a/Taxi website/Webpages/gcc-hcph-register.html
+++ b/Taxi website/Webpages/gcc-hcph-register.html
@@ -209,7 +209,7 @@ tr:last-child td{border-bottom:none}
       <div class="ftr-h">About GCC</div>
       <ul class="ftr-ul">
         <li><a href="https://www.gloucester.gov.uk/accessibility/">Accessibility statement</a></li>
-        <li><a href="#">Privacy notice</a></li>
+        <li><a href="https://www.gloucester.gov.uk/about-the-council/data-protection-and-freedom-of-information/data-protection/">Privacy notice</a></li>
         <li><a href="https://www.gloucester.gov.uk/cookies/">Cookies</a></li>
         <li><a href="https://www.gloucester.gov.uk/sitemap/">Site map</a></li>
         <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>

--- a/Taxi website/Webpages/gcc-hcph-wav.html
+++ b/Taxi website/Webpages/gcc-hcph-wav.html
@@ -310,7 +310,7 @@ h1{font-size:var(--t-h1);font-weight:700;color:var(--deep);margin-bottom:var(--s
       <div class="ftr-h">About GCC</div>
       <ul class="ftr-ul">
         <li><a href="https://www.gloucester.gov.uk/accessibility/">Accessibility statement</a></li>
-        <li><a href="#">Privacy notice</a></li>
+        <li><a href="https://www.gloucester.gov.uk/about-the-council/data-protection-and-freedom-of-information/data-protection/">Privacy notice</a></li>
         <li><a href="https://www.gloucester.gov.uk/cookies/">Cookies</a></li>
         <li><a href="https://www.gloucester.gov.uk/sitemap/">Site map</a></li>
         <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>

--- a/Taxi website/Webpages/gcc-vehicle-licence.html
+++ b/Taxi website/Webpages/gcc-vehicle-licence.html
@@ -747,7 +747,7 @@ a:focus-visible { color:var(--text) }
       <div class="ftr-h">About GCC</div>
       <ul class="ftr-ul">
         <li><a href="https://www.gloucester.gov.uk/accessibility/">Accessibility statement</a></li>
-        <li><a href="#">Privacy notice</a></li>
+        <li><a href="https://www.gloucester.gov.uk/about-the-council/data-protection-and-freedom-of-information/data-protection/">Privacy notice</a></li>
         <li><a href="https://www.gloucester.gov.uk/cookies/">Cookies</a></li>
         <li><a href="https://www.gloucester.gov.uk/sitemap/">Site map</a></li>
         <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>


### PR DESCRIPTION
## Summary
- The footer's "Privacy notice" link was still `href="#"` on all 10 pages. Linked it to `https://www.gloucester.gov.uk/about-the-council/data-protection-and-freedom-of-information/data-protection/`.

Only "Premises licences" and "Personal licences" remain as placeholder `href="#"` links now — those are for licensing categories with no page built yet, not general site chrome.

## Test plan
- [ ] Click "Privacy notice" in the footer on any page and confirm it opens the data protection page

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmXBkt59tXj7B2g1x81yQX)_