### PR TITLE
Restructure footer: add address/phone, split Contact us and About us

### DIFF
--- a/Taxi website/Webpages/gcc-approved-garages.html
+++ b/Taxi website/Webpages/gcc-approved-garages.html
@@ -620,21 +620,25 @@ a:focus-visible { color:var(--text) }
       </ul>
     </div>
     <div>
-      <div class="ftr-h">About GCC</div>
+      <div class="ftr-h">Contact us</div>
+      <ul class="ftr-ul">
+        <li><address style="font-style:normal">Gloucester City Council<br>Eastgate Management Suite<br>Eastgate Street<br>Gloucester<br>GL1 1PA</address></li>
+        <li><a href="tel:01452396396">01452 396 396</a></li>
+        <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>
+      </ul>
+      <div style="display:flex;gap:12px;margin-top:var(--sp2)">
+        <a href="https://www.facebook.com/GloucesterCityCouncil/" target="_blank" rel="noopener" aria-label="Gloucester City Council on Facebook" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path fill="currentColor" d="M22 12a10 10 0 1 0-11.6 9.9v-7H7.9V12h2.5V9.8c0-2.5 1.5-3.9 3.8-3.9 1.1 0 2.2.2 2.2.2v2.4h-1.2c-1.2 0-1.6.8-1.6 1.6V12h2.8l-.4 2.9h-2.4v7A10 10 0 0 0 22 12z"/></svg></a>
+        <a href="https://x.com/GloucesterCity" target="_blank" rel="noopener" aria-label="Gloucester City Council on X" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" focusable="false"><path fill="currentColor" d="M18.9 2H22l-7.2 8.3L23.3 22h-6.7l-5.2-6.8L5.4 22H2.2l7.7-8.9L1 2h6.9l4.7 6.2L18.9 2zm-1.2 18h1.9L7.4 4H5.4l12.3 16z"/></svg></a>
+      </div>
+    </div>
+    <div>
+      <div class="ftr-h">About us</div>
       <ul class="ftr-ul">
         <li><a href="https://www.gloucester.gov.uk/accessibility/">Accessibility statement</a></li>
         <li><a href="https://www.gloucester.gov.uk/about-the-council/data-protection-and-freedom-of-information/data-protection/">Privacy notice</a></li>
         <li><a href="https://www.gloucester.gov.uk/cookies/">Cookies</a></li>
         <li><a href="https://www.gloucester.gov.uk/sitemap/">Site map</a></li>
-        <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>
       </ul>
-    </div>
-    <div>
-      <div class="ftr-h">Follow us</div>
-      <div style="display:flex;gap:12px">
-        <a href="https://www.facebook.com/GloucesterCityCouncil/" target="_blank" rel="noopener" aria-label="Gloucester City Council on Facebook" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path fill="currentColor" d="M22 12a10 10 0 1 0-11.6 9.9v-7H7.9V12h2.5V9.8c0-2.5 1.5-3.9 3.8-3.9 1.1 0 2.2.2 2.2.2v2.4h-1.2c-1.2 0-1.6.8-1.6 1.6V12h2.8l-.4 2.9h-2.4v7A10 10 0 0 0 22 12z"/></svg></a>
-        <a href="https://x.com/GloucesterCity" target="_blank" rel="noopener" aria-label="Gloucester City Council on X" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" focusable="false"><path fill="currentColor" d="M18.9 2H22l-7.2 8.3L23.3 22h-6.7l-5.2-6.8L5.4 22H2.2l7.7-8.9L1 2h6.9l4.7 6.2L18.9 2zm-1.2 18h1.9L7.4 4H5.4l12.3 16z"/></svg></a>
-      </div>
     </div>
   </div>
   <div class="ftr-bot">

--- a/Taxi website/Webpages/gcc-driver-licence.html
+++ b/Taxi website/Webpages/gcc-driver-licence.html
@@ -718,21 +718,25 @@ a:focus-visible { color:var(--text) }
       </ul>
     </div>
     <div>
-      <div class="ftr-h">About GCC</div>
+      <div class="ftr-h">Contact us</div>
+      <ul class="ftr-ul">
+        <li><address style="font-style:normal">Gloucester City Council<br>Eastgate Management Suite<br>Eastgate Street<br>Gloucester<br>GL1 1PA</address></li>
+        <li><a href="tel:01452396396">01452 396 396</a></li>
+        <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>
+      </ul>
+      <div style="display:flex;gap:12px;margin-top:var(--sp2)">
+        <a href="https://www.facebook.com/GloucesterCityCouncil/" target="_blank" rel="noopener" aria-label="Gloucester City Council on Facebook" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path fill="currentColor" d="M22 12a10 10 0 1 0-11.6 9.9v-7H7.9V12h2.5V9.8c0-2.5 1.5-3.9 3.8-3.9 1.1 0 2.2.2 2.2.2v2.4h-1.2c-1.2 0-1.6.8-1.6 1.6V12h2.8l-.4 2.9h-2.4v7A10 10 0 0 0 22 12z"/></svg></a>
+        <a href="https://x.com/GloucesterCity" target="_blank" rel="noopener" aria-label="Gloucester City Council on X" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" focusable="false"><path fill="currentColor" d="M18.9 2H22l-7.2 8.3L23.3 22h-6.7l-5.2-6.8L5.4 22H2.2l7.7-8.9L1 2h6.9l4.7 6.2L18.9 2zm-1.2 18h1.9L7.4 4H5.4l12.3 16z"/></svg></a>
+      </div>
+    </div>
+    <div>
+      <div class="ftr-h">About us</div>
       <ul class="ftr-ul">
         <li><a href="https://www.gloucester.gov.uk/accessibility/">Accessibility statement</a></li>
         <li><a href="https://www.gloucester.gov.uk/about-the-council/data-protection-and-freedom-of-information/data-protection/">Privacy notice</a></li>
         <li><a href="https://www.gloucester.gov.uk/cookies/">Cookies</a></li>
         <li><a href="https://www.gloucester.gov.uk/sitemap/">Site map</a></li>
-        <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>
       </ul>
-    </div>
-    <div>
-      <div class="ftr-h">Follow us</div>
-      <div style="display:flex;gap:12px">
-        <a href="https://www.facebook.com/GloucesterCityCouncil/" target="_blank" rel="noopener" aria-label="Gloucester City Council on Facebook" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path fill="currentColor" d="M22 12a10 10 0 1 0-11.6 9.9v-7H7.9V12h2.5V9.8c0-2.5 1.5-3.9 3.8-3.9 1.1 0 2.2.2 2.2.2v2.4h-1.2c-1.2 0-1.6.8-1.6 1.6V12h2.8l-.4 2.9h-2.4v7A10 10 0 0 0 22 12z"/></svg></a>
-        <a href="https://x.com/GloucesterCity" target="_blank" rel="noopener" aria-label="Gloucester City Council on X" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" focusable="false"><path fill="currentColor" d="M18.9 2H22l-7.2 8.3L23.3 22h-6.7l-5.2-6.8L5.4 22H2.2l7.7-8.9L1 2h6.9l4.7 6.2L18.9 2zm-1.2 18h1.9L7.4 4H5.4l12.3 16z"/></svg></a>
-      </div>
     </div>
   </div>
   <div class="ftr-bot">

--- a/Taxi website/Webpages/gcc-hcph-changes.html
+++ b/Taxi website/Webpages/gcc-hcph-changes.html
@@ -607,21 +607,25 @@ a:focus-visible { color:var(--text) }
       </ul>
     </div>
     <div>
-      <div class="ftr-h">About GCC</div>
+      <div class="ftr-h">Contact us</div>
+      <ul class="ftr-ul">
+        <li><address style="font-style:normal">Gloucester City Council<br>Eastgate Management Suite<br>Eastgate Street<br>Gloucester<br>GL1 1PA</address></li>
+        <li><a href="tel:01452396396">01452 396 396</a></li>
+        <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>
+      </ul>
+      <div style="display:flex;gap:12px;margin-top:var(--sp2)">
+        <a href="https://www.facebook.com/GloucesterCityCouncil/" target="_blank" rel="noopener" aria-label="Gloucester City Council on Facebook" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path fill="currentColor" d="M22 12a10 10 0 1 0-11.6 9.9v-7H7.9V12h2.5V9.8c0-2.5 1.5-3.9 3.8-3.9 1.1 0 2.2.2 2.2.2v2.4h-1.2c-1.2 0-1.6.8-1.6 1.6V12h2.8l-.4 2.9h-2.4v7A10 10 0 0 0 22 12z"/></svg></a>
+        <a href="https://x.com/GloucesterCity" target="_blank" rel="noopener" aria-label="Gloucester City Council on X" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" focusable="false"><path fill="currentColor" d="M18.9 2H22l-7.2 8.3L23.3 22h-6.7l-5.2-6.8L5.4 22H2.2l7.7-8.9L1 2h6.9l4.7 6.2L18.9 2zm-1.2 18h1.9L7.4 4H5.4l12.3 16z"/></svg></a>
+      </div>
+    </div>
+    <div>
+      <div class="ftr-h">About us</div>
       <ul class="ftr-ul">
         <li><a href="https://www.gloucester.gov.uk/accessibility/">Accessibility statement</a></li>
         <li><a href="https://www.gloucester.gov.uk/about-the-council/data-protection-and-freedom-of-information/data-protection/">Privacy notice</a></li>
         <li><a href="https://www.gloucester.gov.uk/cookies/">Cookies</a></li>
         <li><a href="https://www.gloucester.gov.uk/sitemap/">Site map</a></li>
-        <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>
       </ul>
-    </div>
-    <div>
-      <div class="ftr-h">Follow us</div>
-      <div style="display:flex;gap:12px">
-        <a href="https://www.facebook.com/GloucesterCityCouncil/" target="_blank" rel="noopener" aria-label="Gloucester City Council on Facebook" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path fill="currentColor" d="M22 12a10 10 0 1 0-11.6 9.9v-7H7.9V12h2.5V9.8c0-2.5 1.5-3.9 3.8-3.9 1.1 0 2.2.2 2.2.2v2.4h-1.2c-1.2 0-1.6.8-1.6 1.6V12h2.8l-.4 2.9h-2.4v7A10 10 0 0 0 22 12z"/></svg></a>
-        <a href="https://x.com/GloucesterCity" target="_blank" rel="noopener" aria-label="Gloucester City Council on X" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" focusable="false"><path fill="currentColor" d="M18.9 2H22l-7.2 8.3L23.3 22h-6.7l-5.2-6.8L5.4 22H2.2l7.7-8.9L1 2h6.9l4.7 6.2L18.9 2zm-1.2 18h1.9L7.4 4H5.4l12.3 16z"/></svg></a>
-      </div>
     </div>
   </div>
   <div class="ftr-bot">

--- a/Taxi website/Webpages/gcc-hcph-documents.html
+++ b/Taxi website/Webpages/gcc-hcph-documents.html
@@ -614,21 +614,25 @@ a:focus-visible { color:var(--text) }
       </ul>
     </div>
     <div>
-      <div class="ftr-h">About GCC</div>
+      <div class="ftr-h">Contact us</div>
+      <ul class="ftr-ul">
+        <li><address style="font-style:normal">Gloucester City Council<br>Eastgate Management Suite<br>Eastgate Street<br>Gloucester<br>GL1 1PA</address></li>
+        <li><a href="tel:01452396396">01452 396 396</a></li>
+        <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>
+      </ul>
+      <div style="display:flex;gap:12px;margin-top:var(--sp2)">
+        <a href="https://www.facebook.com/GloucesterCityCouncil/" target="_blank" rel="noopener" aria-label="Gloucester City Council on Facebook" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path fill="currentColor" d="M22 12a10 10 0 1 0-11.6 9.9v-7H7.9V12h2.5V9.8c0-2.5 1.5-3.9 3.8-3.9 1.1 0 2.2.2 2.2.2v2.4h-1.2c-1.2 0-1.6.8-1.6 1.6V12h2.8l-.4 2.9h-2.4v7A10 10 0 0 0 22 12z"/></svg></a>
+        <a href="https://x.com/GloucesterCity" target="_blank" rel="noopener" aria-label="Gloucester City Council on X" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" focusable="false"><path fill="currentColor" d="M18.9 2H22l-7.2 8.3L23.3 22h-6.7l-5.2-6.8L5.4 22H2.2l7.7-8.9L1 2h6.9l4.7 6.2L18.9 2zm-1.2 18h1.9L7.4 4H5.4l12.3 16z"/></svg></a>
+      </div>
+    </div>
+    <div>
+      <div class="ftr-h">About us</div>
       <ul class="ftr-ul">
         <li><a href="https://www.gloucester.gov.uk/accessibility/">Accessibility statement</a></li>
         <li><a href="https://www.gloucester.gov.uk/about-the-council/data-protection-and-freedom-of-information/data-protection/">Privacy notice</a></li>
         <li><a href="https://www.gloucester.gov.uk/cookies/">Cookies</a></li>
         <li><a href="https://www.gloucester.gov.uk/sitemap/">Site map</a></li>
-        <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>
       </ul>
-    </div>
-    <div>
-      <div class="ftr-h">Follow us</div>
-      <div style="display:flex;gap:12px">
-        <a href="https://www.facebook.com/GloucesterCityCouncil/" target="_blank" rel="noopener" aria-label="Gloucester City Council on Facebook" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path fill="currentColor" d="M22 12a10 10 0 1 0-11.6 9.9v-7H7.9V12h2.5V9.8c0-2.5 1.5-3.9 3.8-3.9 1.1 0 2.2.2 2.2.2v2.4h-1.2c-1.2 0-1.6.8-1.6 1.6V12h2.8l-.4 2.9h-2.4v7A10 10 0 0 0 22 12z"/></svg></a>
-        <a href="https://x.com/GloucesterCity" target="_blank" rel="noopener" aria-label="Gloucester City Council on X" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" focusable="false"><path fill="currentColor" d="M18.9 2H22l-7.2 8.3L23.3 22h-6.7l-5.2-6.8L5.4 22H2.2l7.7-8.9L1 2h6.9l4.7 6.2L18.9 2zm-1.2 18h1.9L7.4 4H5.4l12.3 16z"/></svg></a>
-      </div>
     </div>
   </div>
   <div class="ftr-bot">

--- a/Taxi website/Webpages/gcc-hcph-fees.html
+++ b/Taxi website/Webpages/gcc-hcph-fees.html
@@ -611,21 +611,25 @@ a:focus-visible { color:var(--text) }
       </ul>
     </div>
     <div>
-      <div class="ftr-h">About GCC</div>
+      <div class="ftr-h">Contact us</div>
+      <ul class="ftr-ul">
+        <li><address style="font-style:normal">Gloucester City Council<br>Eastgate Management Suite<br>Eastgate Street<br>Gloucester<br>GL1 1PA</address></li>
+        <li><a href="tel:01452396396">01452 396 396</a></li>
+        <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>
+      </ul>
+      <div style="display:flex;gap:12px;margin-top:var(--sp2)">
+        <a href="https://www.facebook.com/GloucesterCityCouncil/" target="_blank" rel="noopener" aria-label="Gloucester City Council on Facebook" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path fill="currentColor" d="M22 12a10 10 0 1 0-11.6 9.9v-7H7.9V12h2.5V9.8c0-2.5 1.5-3.9 3.8-3.9 1.1 0 2.2.2 2.2.2v2.4h-1.2c-1.2 0-1.6.8-1.6 1.6V12h2.8l-.4 2.9h-2.4v7A10 10 0 0 0 22 12z"/></svg></a>
+        <a href="https://x.com/GloucesterCity" target="_blank" rel="noopener" aria-label="Gloucester City Council on X" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" focusable="false"><path fill="currentColor" d="M18.9 2H22l-7.2 8.3L23.3 22h-6.7l-5.2-6.8L5.4 22H2.2l7.7-8.9L1 2h6.9l4.7 6.2L18.9 2zm-1.2 18h1.9L7.4 4H5.4l12.3 16z"/></svg></a>
+      </div>
+    </div>
+    <div>
+      <div class="ftr-h">About us</div>
       <ul class="ftr-ul">
         <li><a href="https://www.gloucester.gov.uk/accessibility/">Accessibility statement</a></li>
         <li><a href="https://www.gloucester.gov.uk/about-the-council/data-protection-and-freedom-of-information/data-protection/">Privacy notice</a></li>
         <li><a href="https://www.gloucester.gov.uk/cookies/">Cookies</a></li>
         <li><a href="https://www.gloucester.gov.uk/sitemap/">Site map</a></li>
-        <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>
       </ul>
-    </div>
-    <div>
-      <div class="ftr-h">Follow us</div>
-      <div style="display:flex;gap:12px">
-        <a href="https://www.facebook.com/GloucesterCityCouncil/" target="_blank" rel="noopener" aria-label="Gloucester City Council on Facebook" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path fill="currentColor" d="M22 12a10 10 0 1 0-11.6 9.9v-7H7.9V12h2.5V9.8c0-2.5 1.5-3.9 3.8-3.9 1.1 0 2.2.2 2.2.2v2.4h-1.2c-1.2 0-1.6.8-1.6 1.6V12h2.8l-.4 2.9h-2.4v7A10 10 0 0 0 22 12z"/></svg></a>
-        <a href="https://x.com/GloucesterCity" target="_blank" rel="noopener" aria-label="Gloucester City Council on X" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" focusable="false"><path fill="currentColor" d="M18.9 2H22l-7.2 8.3L23.3 22h-6.7l-5.2-6.8L5.4 22H2.2l7.7-8.9L1 2h6.9l4.7 6.2L18.9 2zm-1.2 18h1.9L7.4 4H5.4l12.3 16z"/></svg></a>
-      </div>
     </div>
   </div>
   <div class="ftr-bot">

--- a/Taxi website/Webpages/gcc-hcph-landing.html
+++ b/Taxi website/Webpages/gcc-hcph-landing.html
@@ -428,21 +428,25 @@ a:focus-visible{color:var(--text)}
       </ul>
     </div>
     <div>
-      <div class="ftr-h">About GCC</div>
+      <div class="ftr-h">Contact us</div>
+      <ul class="ftr-ul">
+        <li><address style="font-style:normal">Gloucester City Council<br>Eastgate Management Suite<br>Eastgate Street<br>Gloucester<br>GL1 1PA</address></li>
+        <li><a href="tel:01452396396">01452 396 396</a></li>
+        <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>
+      </ul>
+      <div style="display:flex;gap:12px;margin-top:var(--sp2)">
+        <a href="https://www.facebook.com/GloucesterCityCouncil/" target="_blank" rel="noopener" aria-label="Gloucester City Council on Facebook" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path fill="currentColor" d="M22 12a10 10 0 1 0-11.6 9.9v-7H7.9V12h2.5V9.8c0-2.5 1.5-3.9 3.8-3.9 1.1 0 2.2.2 2.2.2v2.4h-1.2c-1.2 0-1.6.8-1.6 1.6V12h2.8l-.4 2.9h-2.4v7A10 10 0 0 0 22 12z"/></svg></a>
+        <a href="https://x.com/GloucesterCity" target="_blank" rel="noopener" aria-label="Gloucester City Council on X" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" focusable="false"><path fill="currentColor" d="M18.9 2H22l-7.2 8.3L23.3 22h-6.7l-5.2-6.8L5.4 22H2.2l7.7-8.9L1 2h6.9l4.7 6.2L18.9 2zm-1.2 18h1.9L7.4 4H5.4l12.3 16z"/></svg></a>
+      </div>
+    </div>
+    <div>
+      <div class="ftr-h">About us</div>
       <ul class="ftr-ul">
         <li><a href="https://www.gloucester.gov.uk/accessibility/">Accessibility statement</a></li>
         <li><a href="https://www.gloucester.gov.uk/about-the-council/data-protection-and-freedom-of-information/data-protection/">Privacy notice</a></li>
         <li><a href="https://www.gloucester.gov.uk/cookies/">Cookies</a></li>
         <li><a href="https://www.gloucester.gov.uk/sitemap/">Site map</a></li>
-        <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>
       </ul>
-    </div>
-    <div>
-      <div class="ftr-h">Follow us</div>
-      <div style="display:flex;gap:12px">
-        <a href="https://www.facebook.com/GloucesterCityCouncil/" target="_blank" rel="noopener" aria-label="Gloucester City Council on Facebook" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path fill="currentColor" d="M22 12a10 10 0 1 0-11.6 9.9v-7H7.9V12h2.5V9.8c0-2.5 1.5-3.9 3.8-3.9 1.1 0 2.2.2 2.2.2v2.4h-1.2c-1.2 0-1.6.8-1.6 1.6V12h2.8l-.4 2.9h-2.4v7A10 10 0 0 0 22 12z"/></svg></a>
-        <a href="https://x.com/GloucesterCity" target="_blank" rel="noopener" aria-label="Gloucester City Council on X" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" focusable="false"><path fill="currentColor" d="M18.9 2H22l-7.2 8.3L23.3 22h-6.7l-5.2-6.8L5.4 22H2.2l7.7-8.9L1 2h6.9l4.7 6.2L18.9 2zm-1.2 18h1.9L7.4 4H5.4l12.3 16z"/></svg></a>
-      </div>
     </div>
   </div>
   <div class="ftr-bot">

--- a/Taxi website/Webpages/gcc-hcph-passengers.html
+++ b/Taxi website/Webpages/gcc-hcph-passengers.html
@@ -633,21 +633,25 @@ a:focus-visible { color:var(--text) }
       </ul>
     </div>
     <div>
-      <div class="ftr-h">About GCC</div>
+      <div class="ftr-h">Contact us</div>
+      <ul class="ftr-ul">
+        <li><address style="font-style:normal">Gloucester City Council<br>Eastgate Management Suite<br>Eastgate Street<br>Gloucester<br>GL1 1PA</address></li>
+        <li><a href="tel:01452396396">01452 396 396</a></li>
+        <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>
+      </ul>
+      <div style="display:flex;gap:12px;margin-top:var(--sp2)">
+        <a href="https://www.facebook.com/GloucesterCityCouncil/" target="_blank" rel="noopener" aria-label="Gloucester City Council on Facebook" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path fill="currentColor" d="M22 12a10 10 0 1 0-11.6 9.9v-7H7.9V12h2.5V9.8c0-2.5 1.5-3.9 3.8-3.9 1.1 0 2.2.2 2.2.2v2.4h-1.2c-1.2 0-1.6.8-1.6 1.6V12h2.8l-.4 2.9h-2.4v7A10 10 0 0 0 22 12z"/></svg></a>
+        <a href="https://x.com/GloucesterCity" target="_blank" rel="noopener" aria-label="Gloucester City Council on X" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" focusable="false"><path fill="currentColor" d="M18.9 2H22l-7.2 8.3L23.3 22h-6.7l-5.2-6.8L5.4 22H2.2l7.7-8.9L1 2h6.9l4.7 6.2L18.9 2zm-1.2 18h1.9L7.4 4H5.4l12.3 16z"/></svg></a>
+      </div>
+    </div>
+    <div>
+      <div class="ftr-h">About us</div>
       <ul class="ftr-ul">
         <li><a href="https://www.gloucester.gov.uk/accessibility/">Accessibility statement</a></li>
         <li><a href="https://www.gloucester.gov.uk/about-the-council/data-protection-and-freedom-of-information/data-protection/">Privacy notice</a></li>
         <li><a href="https://www.gloucester.gov.uk/cookies/">Cookies</a></li>
         <li><a href="https://www.gloucester.gov.uk/sitemap/">Site map</a></li>
-        <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>
       </ul>
-    </div>
-    <div>
-      <div class="ftr-h">Follow us</div>
-      <div style="display:flex;gap:12px">
-        <a href="https://www.facebook.com/GloucesterCityCouncil/" target="_blank" rel="noopener" aria-label="Gloucester City Council on Facebook" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path fill="currentColor" d="M22 12a10 10 0 1 0-11.6 9.9v-7H7.9V12h2.5V9.8c0-2.5 1.5-3.9 3.8-3.9 1.1 0 2.2.2 2.2.2v2.4h-1.2c-1.2 0-1.6.8-1.6 1.6V12h2.8l-.4 2.9h-2.4v7A10 10 0 0 0 22 12z"/></svg></a>
-        <a href="https://x.com/GloucesterCity" target="_blank" rel="noopener" aria-label="Gloucester City Council on X" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" focusable="false"><path fill="currentColor" d="M18.9 2H22l-7.2 8.3L23.3 22h-6.7l-5.2-6.8L5.4 22H2.2l7.7-8.9L1 2h6.9l4.7 6.2L18.9 2zm-1.2 18h1.9L7.4 4H5.4l12.3 16z"/></svg></a>
-      </div>
     </div>
   </div>
   <div class="ftr-bot">

--- a/Taxi website/Webpages/gcc-hcph-register.html
+++ b/Taxi website/Webpages/gcc-hcph-register.html
@@ -206,21 +206,25 @@ tr:last-child td{border-bottom:none}
       </ul>
     </div>
     <div>
-      <div class="ftr-h">About GCC</div>
+      <div class="ftr-h">Contact us</div>
+      <ul class="ftr-ul">
+        <li><address style="font-style:normal">Gloucester City Council<br>Eastgate Management Suite<br>Eastgate Street<br>Gloucester<br>GL1 1PA</address></li>
+        <li><a href="tel:01452396396">01452 396 396</a></li>
+        <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>
+      </ul>
+      <div style="display:flex;gap:12px;margin-top:var(--sp2)">
+        <a href="https://www.facebook.com/GloucesterCityCouncil/" target="_blank" rel="noopener" aria-label="Gloucester City Council on Facebook" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path fill="currentColor" d="M22 12a10 10 0 1 0-11.6 9.9v-7H7.9V12h2.5V9.8c0-2.5 1.5-3.9 3.8-3.9 1.1 0 2.2.2 2.2.2v2.4h-1.2c-1.2 0-1.6.8-1.6 1.6V12h2.8l-.4 2.9h-2.4v7A10 10 0 0 0 22 12z"/></svg></a>
+        <a href="https://x.com/GloucesterCity" target="_blank" rel="noopener" aria-label="Gloucester City Council on X" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" focusable="false"><path fill="currentColor" d="M18.9 2H22l-7.2 8.3L23.3 22h-6.7l-5.2-6.8L5.4 22H2.2l7.7-8.9L1 2h6.9l4.7 6.2L18.9 2zm-1.2 18h1.9L7.4 4H5.4l12.3 16z"/></svg></a>
+      </div>
+    </div>
+    <div>
+      <div class="ftr-h">About us</div>
       <ul class="ftr-ul">
         <li><a href="https://www.gloucester.gov.uk/accessibility/">Accessibility statement</a></li>
         <li><a href="https://www.gloucester.gov.uk/about-the-council/data-protection-and-freedom-of-information/data-protection/">Privacy notice</a></li>
         <li><a href="https://www.gloucester.gov.uk/cookies/">Cookies</a></li>
         <li><a href="https://www.gloucester.gov.uk/sitemap/">Site map</a></li>
-        <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>
       </ul>
-    </div>
-    <div>
-      <div class="ftr-h">Follow us</div>
-      <div style="display:flex;gap:12px">
-        <a href="https://www.facebook.com/GloucesterCityCouncil/" target="_blank" rel="noopener" aria-label="Gloucester City Council on Facebook" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path fill="currentColor" d="M22 12a10 10 0 1 0-11.6 9.9v-7H7.9V12h2.5V9.8c0-2.5 1.5-3.9 3.8-3.9 1.1 0 2.2.2 2.2.2v2.4h-1.2c-1.2 0-1.6.8-1.6 1.6V12h2.8l-.4 2.9h-2.4v7A10 10 0 0 0 22 12z"/></svg></a>
-        <a href="https://x.com/GloucesterCity" target="_blank" rel="noopener" aria-label="Gloucester City Council on X" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" focusable="false"><path fill="currentColor" d="M18.9 2H22l-7.2 8.3L23.3 22h-6.7l-5.2-6.8L5.4 22H2.2l7.7-8.9L1 2h6.9l4.7 6.2L18.9 2zm-1.2 18h1.9L7.4 4H5.4l12.3 16z"/></svg></a>
-      </div>
     </div>
   </div>
   <div class="ftr-bot">

--- a/Taxi website/Webpages/gcc-hcph-wav.html
+++ b/Taxi website/Webpages/gcc-hcph-wav.html
@@ -307,21 +307,25 @@ h1{font-size:var(--t-h1);font-weight:700;color:var(--deep);margin-bottom:var(--s
       </ul>
     </div>
     <div>
-      <div class="ftr-h">About GCC</div>
+      <div class="ftr-h">Contact us</div>
+      <ul class="ftr-ul">
+        <li><address style="font-style:normal">Gloucester City Council<br>Eastgate Management Suite<br>Eastgate Street<br>Gloucester<br>GL1 1PA</address></li>
+        <li><a href="tel:01452396396">01452 396 396</a></li>
+        <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>
+      </ul>
+      <div style="display:flex;gap:12px;margin-top:var(--sp2)">
+        <a href="https://www.facebook.com/GloucesterCityCouncil/" target="_blank" rel="noopener" aria-label="Gloucester City Council on Facebook" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path fill="currentColor" d="M22 12a10 10 0 1 0-11.6 9.9v-7H7.9V12h2.5V9.8c0-2.5 1.5-3.9 3.8-3.9 1.1 0 2.2.2 2.2.2v2.4h-1.2c-1.2 0-1.6.8-1.6 1.6V12h2.8l-.4 2.9h-2.4v7A10 10 0 0 0 22 12z"/></svg></a>
+        <a href="https://x.com/GloucesterCity" target="_blank" rel="noopener" aria-label="Gloucester City Council on X" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" focusable="false"><path fill="currentColor" d="M18.9 2H22l-7.2 8.3L23.3 22h-6.7l-5.2-6.8L5.4 22H2.2l7.7-8.9L1 2h6.9l4.7 6.2L18.9 2zm-1.2 18h1.9L7.4 4H5.4l12.3 16z"/></svg></a>
+      </div>
+    </div>
+    <div>
+      <div class="ftr-h">About us</div>
       <ul class="ftr-ul">
         <li><a href="https://www.gloucester.gov.uk/accessibility/">Accessibility statement</a></li>
         <li><a href="https://www.gloucester.gov.uk/about-the-council/data-protection-and-freedom-of-information/data-protection/">Privacy notice</a></li>
         <li><a href="https://www.gloucester.gov.uk/cookies/">Cookies</a></li>
         <li><a href="https://www.gloucester.gov.uk/sitemap/">Site map</a></li>
-        <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>
       </ul>
-    </div>
-    <div>
-      <div class="ftr-h">Follow us</div>
-      <div style="display:flex;gap:12px">
-        <a href="https://www.facebook.com/GloucesterCityCouncil/" target="_blank" rel="noopener" aria-label="Gloucester City Council on Facebook" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path fill="currentColor" d="M22 12a10 10 0 1 0-11.6 9.9v-7H7.9V12h2.5V9.8c0-2.5 1.5-3.9 3.8-3.9 1.1 0 2.2.2 2.2.2v2.4h-1.2c-1.2 0-1.6.8-1.6 1.6V12h2.8l-.4 2.9h-2.4v7A10 10 0 0 0 22 12z"/></svg></a>
-        <a href="https://x.com/GloucesterCity" target="_blank" rel="noopener" aria-label="Gloucester City Council on X" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" focusable="false"><path fill="currentColor" d="M18.9 2H22l-7.2 8.3L23.3 22h-6.7l-5.2-6.8L5.4 22H2.2l7.7-8.9L1 2h6.9l4.7 6.2L18.9 2zm-1.2 18h1.9L7.4 4H5.4l12.3 16z"/></svg></a>
-      </div>
     </div>
   </div>
   <div class="ftr-bot">

--- a/Taxi website/Webpages/gcc-vehicle-licence.html
+++ b/Taxi website/Webpages/gcc-vehicle-licence.html
@@ -744,21 +744,25 @@ a:focus-visible { color:var(--text) }
       </ul>
     </div>
     <div>
-      <div class="ftr-h">About GCC</div>
+      <div class="ftr-h">Contact us</div>
+      <ul class="ftr-ul">
+        <li><address style="font-style:normal">Gloucester City Council<br>Eastgate Management Suite<br>Eastgate Street<br>Gloucester<br>GL1 1PA</address></li>
+        <li><a href="tel:01452396396">01452 396 396</a></li>
+        <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>
+      </ul>
+      <div style="display:flex;gap:12px;margin-top:var(--sp2)">
+        <a href="https://www.facebook.com/GloucesterCityCouncil/" target="_blank" rel="noopener" aria-label="Gloucester City Council on Facebook" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path fill="currentColor" d="M22 12a10 10 0 1 0-11.6 9.9v-7H7.9V12h2.5V9.8c0-2.5 1.5-3.9 3.8-3.9 1.1 0 2.2.2 2.2.2v2.4h-1.2c-1.2 0-1.6.8-1.6 1.6V12h2.8l-.4 2.9h-2.4v7A10 10 0 0 0 22 12z"/></svg></a>
+        <a href="https://x.com/GloucesterCity" target="_blank" rel="noopener" aria-label="Gloucester City Council on X" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" focusable="false"><path fill="currentColor" d="M18.9 2H22l-7.2 8.3L23.3 22h-6.7l-5.2-6.8L5.4 22H2.2l7.7-8.9L1 2h6.9l4.7 6.2L18.9 2zm-1.2 18h1.9L7.4 4H5.4l12.3 16z"/></svg></a>
+      </div>
+    </div>
+    <div>
+      <div class="ftr-h">About us</div>
       <ul class="ftr-ul">
         <li><a href="https://www.gloucester.gov.uk/accessibility/">Accessibility statement</a></li>
         <li><a href="https://www.gloucester.gov.uk/about-the-council/data-protection-and-freedom-of-information/data-protection/">Privacy notice</a></li>
         <li><a href="https://www.gloucester.gov.uk/cookies/">Cookies</a></li>
         <li><a href="https://www.gloucester.gov.uk/sitemap/">Site map</a></li>
-        <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>
       </ul>
-    </div>
-    <div>
-      <div class="ftr-h">Follow us</div>
-      <div style="display:flex;gap:12px">
-        <a href="https://www.facebook.com/GloucesterCityCouncil/" target="_blank" rel="noopener" aria-label="Gloucester City Council on Facebook" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path fill="currentColor" d="M22 12a10 10 0 1 0-11.6 9.9v-7H7.9V12h2.5V9.8c0-2.5 1.5-3.9 3.8-3.9 1.1 0 2.2.2 2.2.2v2.4h-1.2c-1.2 0-1.6.8-1.6 1.6V12h2.8l-.4 2.9h-2.4v7A10 10 0 0 0 22 12z"/></svg></a>
-        <a href="https://x.com/GloucesterCity" target="_blank" rel="noopener" aria-label="Gloucester City Council on X" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" focusable="false"><path fill="currentColor" d="M18.9 2H22l-7.2 8.3L23.3 22h-6.7l-5.2-6.8L5.4 22H2.2l7.7-8.9L1 2h6.9l4.7 6.2L18.9 2zm-1.2 18h1.9L7.4 4H5.4l12.3 16z"/></svg></a>
-      </div>
     </div>
   </div>
   <div class="ftr-bot">


### PR DESCRIPTION
## Summary

Merged the "About GCC" and "Follow us" footer columns into two new columns:

- **Contact us**: postal address (Gloucester City Council, Eastgate Management Suite, Eastgate Street, Gloucester, GL1 1PA), phone (`tel:01452396396`), the Contact us link, and the Facebook/X icons underneath — all in one column, as requested.
- **About us**: Accessibility statement, Privacy notice, Cookies, Site map.

The "Licensing" column is unchanged.

**One thing I did not do as literally requested**: the Privacy notice URL given in this request (`https://gentle-sand-0782dd703.2.azurestaticapps.net/Taxi%20website/Webpages/gcc-hcph-landing#`) points at our own beta site's landing page with a dead `#` fragment — it looks like a copy-paste mistake rather than intentional, especially since it would undo the correct fix from #105 (which points at the real `gloucester.gov.uk` data protection page). I kept the real URL and flagged this to the user for confirmation rather than silently introducing a broken self-referential link.

Verified with Playwright across both CSS variants (main stylesheet and the WAV/register condensed stylesheet) — 3 footer columns render without overlap, correct `tel:`/`https:` hrefs, and the address renders as plain (non-italic) text via a semantic `<address>` element inheriting the footer's existing text color.

## Test plan
- [ ] Confirm the address, phone number, Contact us link and social icons all appear together in one footer column
- [ ] Click the phone number and confirm it dials `01452 396 396`
- [ ] Confirm Accessibility statement / Privacy notice / Cookies / Site map appear in a separate "About us" column

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmXBkt59tXj7B2g1x81yQX)_