### PR TITLE
Remove Licensing footer column; point Contact us at the online form

### DIFF
--- a/Taxi website/Webpages/gcc-approved-garages.html
+++ b/Taxi website/Webpages/gcc-approved-garages.html
@@ -612,19 +612,11 @@ a:focus-visible { color:var(--text) }
 <footer class="ftr" role="contentinfo">
   <div class="ftr-in">
     <div>
-      <div class="ftr-h">Licensing</div>
-      <ul class="ftr-ul">
-        <li><a href="gcc-hcph-landing.html">Hackney carriage and private hire</a></li>
-        <li><a href="#">Premises licences</a></li>
-        <li><a href="#">Personal licences</a></li>
-      </ul>
-    </div>
-    <div>
       <div class="ftr-h">Contact us</div>
       <ul class="ftr-ul">
         <li><address style="font-style:normal">Gloucester City Council<br>Eastgate Management Suite<br>Eastgate Street<br>Gloucester<br>GL1 1PA</address></li>
         <li><a href="tel:01452396396">01452 396 396</a></li>
-        <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>
+        <li><a href="https://gloucester-self.achieveservice.com/service/Contact_us">Contact us</a></li>
       </ul>
       <div style="display:flex;gap:12px;margin-top:var(--sp2)">
         <a href="https://www.facebook.com/GloucesterCityCouncil/" target="_blank" rel="noopener" aria-label="Gloucester City Council on Facebook" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path fill="currentColor" d="M22 12a10 10 0 1 0-11.6 9.9v-7H7.9V12h2.5V9.8c0-2.5 1.5-3.9 3.8-3.9 1.1 0 2.2.2 2.2.2v2.4h-1.2c-1.2 0-1.6.8-1.6 1.6V12h2.8l-.4 2.9h-2.4v7A10 10 0 0 0 22 12z"/></svg></a>

--- a/Taxi website/Webpages/gcc-driver-licence.html
+++ b/Taxi website/Webpages/gcc-driver-licence.html
@@ -710,19 +710,11 @@ a:focus-visible { color:var(--text) }
 <footer class="ftr" role="contentinfo">
   <div class="ftr-in">
     <div>
-      <div class="ftr-h">Licensing</div>
-      <ul class="ftr-ul">
-        <li><a href="gcc-hcph-landing.html">Hackney carriage and private hire</a></li>
-        <li><a href="#">Premises licences</a></li>
-        <li><a href="#">Personal licences</a></li>
-      </ul>
-    </div>
-    <div>
       <div class="ftr-h">Contact us</div>
       <ul class="ftr-ul">
         <li><address style="font-style:normal">Gloucester City Council<br>Eastgate Management Suite<br>Eastgate Street<br>Gloucester<br>GL1 1PA</address></li>
         <li><a href="tel:01452396396">01452 396 396</a></li>
-        <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>
+        <li><a href="https://gloucester-self.achieveservice.com/service/Contact_us">Contact us</a></li>
       </ul>
       <div style="display:flex;gap:12px;margin-top:var(--sp2)">
         <a href="https://www.facebook.com/GloucesterCityCouncil/" target="_blank" rel="noopener" aria-label="Gloucester City Council on Facebook" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path fill="currentColor" d="M22 12a10 10 0 1 0-11.6 9.9v-7H7.9V12h2.5V9.8c0-2.5 1.5-3.9 3.8-3.9 1.1 0 2.2.2 2.2.2v2.4h-1.2c-1.2 0-1.6.8-1.6 1.6V12h2.8l-.4 2.9h-2.4v7A10 10 0 0 0 22 12z"/></svg></a>

--- a/Taxi website/Webpages/gcc-hcph-changes.html
+++ b/Taxi website/Webpages/gcc-hcph-changes.html
@@ -599,19 +599,11 @@ a:focus-visible { color:var(--text) }
 <footer class="ftr" role="contentinfo">
   <div class="ftr-in">
     <div>
-      <div class="ftr-h">Licensing</div>
-      <ul class="ftr-ul">
-        <li><a href="gcc-hcph-landing.html">Hackney carriage and private hire</a></li>
-        <li><a href="#">Premises licences</a></li>
-        <li><a href="#">Personal licences</a></li>
-      </ul>
-    </div>
-    <div>
       <div class="ftr-h">Contact us</div>
       <ul class="ftr-ul">
         <li><address style="font-style:normal">Gloucester City Council<br>Eastgate Management Suite<br>Eastgate Street<br>Gloucester<br>GL1 1PA</address></li>
         <li><a href="tel:01452396396">01452 396 396</a></li>
-        <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>
+        <li><a href="https://gloucester-self.achieveservice.com/service/Contact_us">Contact us</a></li>
       </ul>
       <div style="display:flex;gap:12px;margin-top:var(--sp2)">
         <a href="https://www.facebook.com/GloucesterCityCouncil/" target="_blank" rel="noopener" aria-label="Gloucester City Council on Facebook" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path fill="currentColor" d="M22 12a10 10 0 1 0-11.6 9.9v-7H7.9V12h2.5V9.8c0-2.5 1.5-3.9 3.8-3.9 1.1 0 2.2.2 2.2.2v2.4h-1.2c-1.2 0-1.6.8-1.6 1.6V12h2.8l-.4 2.9h-2.4v7A10 10 0 0 0 22 12z"/></svg></a>

--- a/Taxi website/Webpages/gcc-hcph-documents.html
+++ b/Taxi website/Webpages/gcc-hcph-documents.html
@@ -606,19 +606,11 @@ a:focus-visible { color:var(--text) }
 <footer class="ftr" role="contentinfo">
   <div class="ftr-in">
     <div>
-      <div class="ftr-h">Licensing</div>
-      <ul class="ftr-ul">
-        <li><a href="gcc-hcph-landing.html">Hackney carriage and private hire</a></li>
-        <li><a href="#">Premises licences</a></li>
-        <li><a href="#">Personal licences</a></li>
-      </ul>
-    </div>
-    <div>
       <div class="ftr-h">Contact us</div>
       <ul class="ftr-ul">
         <li><address style="font-style:normal">Gloucester City Council<br>Eastgate Management Suite<br>Eastgate Street<br>Gloucester<br>GL1 1PA</address></li>
         <li><a href="tel:01452396396">01452 396 396</a></li>
-        <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>
+        <li><a href="https://gloucester-self.achieveservice.com/service/Contact_us">Contact us</a></li>
       </ul>
       <div style="display:flex;gap:12px;margin-top:var(--sp2)">
         <a href="https://www.facebook.com/GloucesterCityCouncil/" target="_blank" rel="noopener" aria-label="Gloucester City Council on Facebook" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path fill="currentColor" d="M22 12a10 10 0 1 0-11.6 9.9v-7H7.9V12h2.5V9.8c0-2.5 1.5-3.9 3.8-3.9 1.1 0 2.2.2 2.2.2v2.4h-1.2c-1.2 0-1.6.8-1.6 1.6V12h2.8l-.4 2.9h-2.4v7A10 10 0 0 0 22 12z"/></svg></a>

--- a/Taxi website/Webpages/gcc-hcph-fees.html
+++ b/Taxi website/Webpages/gcc-hcph-fees.html
@@ -603,19 +603,11 @@ a:focus-visible { color:var(--text) }
 <footer class="ftr" role="contentinfo">
   <div class="ftr-in">
     <div>
-      <div class="ftr-h">Licensing</div>
-      <ul class="ftr-ul">
-        <li><a href="gcc-hcph-landing.html">Hackney carriage and private hire</a></li>
-        <li><a href="#">Premises licences</a></li>
-        <li><a href="#">Personal licences</a></li>
-      </ul>
-    </div>
-    <div>
       <div class="ftr-h">Contact us</div>
       <ul class="ftr-ul">
         <li><address style="font-style:normal">Gloucester City Council<br>Eastgate Management Suite<br>Eastgate Street<br>Gloucester<br>GL1 1PA</address></li>
         <li><a href="tel:01452396396">01452 396 396</a></li>
-        <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>
+        <li><a href="https://gloucester-self.achieveservice.com/service/Contact_us">Contact us</a></li>
       </ul>
       <div style="display:flex;gap:12px;margin-top:var(--sp2)">
         <a href="https://www.facebook.com/GloucesterCityCouncil/" target="_blank" rel="noopener" aria-label="Gloucester City Council on Facebook" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path fill="currentColor" d="M22 12a10 10 0 1 0-11.6 9.9v-7H7.9V12h2.5V9.8c0-2.5 1.5-3.9 3.8-3.9 1.1 0 2.2.2 2.2.2v2.4h-1.2c-1.2 0-1.6.8-1.6 1.6V12h2.8l-.4 2.9h-2.4v7A10 10 0 0 0 22 12z"/></svg></a>

--- a/Taxi website/Webpages/gcc-hcph-landing.html
+++ b/Taxi website/Webpages/gcc-hcph-landing.html
@@ -419,20 +419,11 @@ a:focus-visible{color:var(--text)}
 <footer class="ftr" role="contentinfo">
   <div class="ftr-in">
     <div>
-      <div class="ftr-h">Licensing</div>
-      <ul class="ftr-ul">
-        <li><a href="#">Hackney carriage and private hire</a></li>
-        <li><a href="#">Premises licences</a></li>
-        <li><a href="#">Personal licences</a></li>
-        <li><a href="#">Street trading</a></li>
-      </ul>
-    </div>
-    <div>
       <div class="ftr-h">Contact us</div>
       <ul class="ftr-ul">
         <li><address style="font-style:normal">Gloucester City Council<br>Eastgate Management Suite<br>Eastgate Street<br>Gloucester<br>GL1 1PA</address></li>
         <li><a href="tel:01452396396">01452 396 396</a></li>
-        <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>
+        <li><a href="https://gloucester-self.achieveservice.com/service/Contact_us">Contact us</a></li>
       </ul>
       <div style="display:flex;gap:12px;margin-top:var(--sp2)">
         <a href="https://www.facebook.com/GloucesterCityCouncil/" target="_blank" rel="noopener" aria-label="Gloucester City Council on Facebook" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path fill="currentColor" d="M22 12a10 10 0 1 0-11.6 9.9v-7H7.9V12h2.5V9.8c0-2.5 1.5-3.9 3.8-3.9 1.1 0 2.2.2 2.2.2v2.4h-1.2c-1.2 0-1.6.8-1.6 1.6V12h2.8l-.4 2.9h-2.4v7A10 10 0 0 0 22 12z"/></svg></a>

--- a/Taxi website/Webpages/gcc-hcph-passengers.html
+++ b/Taxi website/Webpages/gcc-hcph-passengers.html
@@ -625,19 +625,11 @@ a:focus-visible { color:var(--text) }
 <footer class="ftr" role="contentinfo">
   <div class="ftr-in">
     <div>
-      <div class="ftr-h">Licensing</div>
-      <ul class="ftr-ul">
-        <li><a href="gcc-hcph-landing.html">Hackney carriage and private hire</a></li>
-        <li><a href="#">Premises licences</a></li>
-        <li><a href="#">Personal licences</a></li>
-      </ul>
-    </div>
-    <div>
       <div class="ftr-h">Contact us</div>
       <ul class="ftr-ul">
         <li><address style="font-style:normal">Gloucester City Council<br>Eastgate Management Suite<br>Eastgate Street<br>Gloucester<br>GL1 1PA</address></li>
         <li><a href="tel:01452396396">01452 396 396</a></li>
-        <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>
+        <li><a href="https://gloucester-self.achieveservice.com/service/Contact_us">Contact us</a></li>
       </ul>
       <div style="display:flex;gap:12px;margin-top:var(--sp2)">
         <a href="https://www.facebook.com/GloucesterCityCouncil/" target="_blank" rel="noopener" aria-label="Gloucester City Council on Facebook" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path fill="currentColor" d="M22 12a10 10 0 1 0-11.6 9.9v-7H7.9V12h2.5V9.8c0-2.5 1.5-3.9 3.8-3.9 1.1 0 2.2.2 2.2.2v2.4h-1.2c-1.2 0-1.6.8-1.6 1.6V12h2.8l-.4 2.9h-2.4v7A10 10 0 0 0 22 12z"/></svg></a>

--- a/Taxi website/Webpages/gcc-hcph-register.html
+++ b/Taxi website/Webpages/gcc-hcph-register.html
@@ -198,19 +198,11 @@ tr:last-child td{border-bottom:none}
 <footer class="ftr" role="contentinfo">
   <div class="ftr-in">
     <div>
-      <div class="ftr-h">Licensing</div>
-      <ul class="ftr-ul">
-        <li><a href="gcc-hcph-landing.html">Hackney carriage and private hire</a></li>
-        <li><a href="#">Premises licences</a></li>
-        <li><a href="#">Personal licences</a></li>
-      </ul>
-    </div>
-    <div>
       <div class="ftr-h">Contact us</div>
       <ul class="ftr-ul">
         <li><address style="font-style:normal">Gloucester City Council<br>Eastgate Management Suite<br>Eastgate Street<br>Gloucester<br>GL1 1PA</address></li>
         <li><a href="tel:01452396396">01452 396 396</a></li>
-        <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>
+        <li><a href="https://gloucester-self.achieveservice.com/service/Contact_us">Contact us</a></li>
       </ul>
       <div style="display:flex;gap:12px;margin-top:var(--sp2)">
         <a href="https://www.facebook.com/GloucesterCityCouncil/" target="_blank" rel="noopener" aria-label="Gloucester City Council on Facebook" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path fill="currentColor" d="M22 12a10 10 0 1 0-11.6 9.9v-7H7.9V12h2.5V9.8c0-2.5 1.5-3.9 3.8-3.9 1.1 0 2.2.2 2.2.2v2.4h-1.2c-1.2 0-1.6.8-1.6 1.6V12h2.8l-.4 2.9h-2.4v7A10 10 0 0 0 22 12z"/></svg></a>

--- a/Taxi website/Webpages/gcc-hcph-wav.html
+++ b/Taxi website/Webpages/gcc-hcph-wav.html
@@ -299,19 +299,11 @@ h1{font-size:var(--t-h1);font-weight:700;color:var(--deep);margin-bottom:var(--s
 <footer class="ftr" role="contentinfo">
   <div class="ftr-in">
     <div>
-      <div class="ftr-h">Licensing</div>
-      <ul class="ftr-ul">
-        <li><a href="gcc-hcph-landing.html">Hackney carriage and private hire</a></li>
-        <li><a href="#">Premises licences</a></li>
-        <li><a href="#">Personal licences</a></li>
-      </ul>
-    </div>
-    <div>
       <div class="ftr-h">Contact us</div>
       <ul class="ftr-ul">
         <li><address style="font-style:normal">Gloucester City Council<br>Eastgate Management Suite<br>Eastgate Street<br>Gloucester<br>GL1 1PA</address></li>
         <li><a href="tel:01452396396">01452 396 396</a></li>
-        <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>
+        <li><a href="https://gloucester-self.achieveservice.com/service/Contact_us">Contact us</a></li>
       </ul>
       <div style="display:flex;gap:12px;margin-top:var(--sp2)">
         <a href="https://www.facebook.com/GloucesterCityCouncil/" target="_blank" rel="noopener" aria-label="Gloucester City Council on Facebook" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path fill="currentColor" d="M22 12a10 10 0 1 0-11.6 9.9v-7H7.9V12h2.5V9.8c0-2.5 1.5-3.9 3.8-3.9 1.1 0 2.2.2 2.2.2v2.4h-1.2c-1.2 0-1.6.8-1.6 1.6V12h2.8l-.4 2.9h-2.4v7A10 10 0 0 0 22 12z"/></svg></a>

--- a/Taxi website/Webpages/gcc-vehicle-licence.html
+++ b/Taxi website/Webpages/gcc-vehicle-licence.html
@@ -736,19 +736,11 @@ a:focus-visible { color:var(--text) }
 <footer class="ftr" role="contentinfo">
   <div class="ftr-in">
     <div>
-      <div class="ftr-h">Licensing</div>
-      <ul class="ftr-ul">
-        <li><a href="gcc-hcph-landing.html">Hackney carriage and private hire</a></li>
-        <li><a href="#">Premises licences</a></li>
-        <li><a href="#">Personal licences</a></li>
-      </ul>
-    </div>
-    <div>
       <div class="ftr-h">Contact us</div>
       <ul class="ftr-ul">
         <li><address style="font-style:normal">Gloucester City Council<br>Eastgate Management Suite<br>Eastgate Street<br>Gloucester<br>GL1 1PA</address></li>
         <li><a href="tel:01452396396">01452 396 396</a></li>
-        <li><a href="https://www.gloucester.gov.uk/about-the-council/contact-us/">Contact us</a></li>
+        <li><a href="https://gloucester-self.achieveservice.com/service/Contact_us">Contact us</a></li>
       </ul>
       <div style="display:flex;gap:12px;margin-top:var(--sp2)">
         <a href="https://www.facebook.com/GloucesterCityCouncil/" target="_blank" rel="noopener" aria-label="Gloucester City Council on Facebook" style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;color:rgba(255,255,255,.85)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path fill="currentColor" d="M22 12a10 10 0 1 0-11.6 9.9v-7H7.9V12h2.5V9.8c0-2.5 1.5-3.9 3.8-3.9 1.1 0 2.2.2 2.2.2v2.4h-1.2c-1.2 0-1.6.8-1.6 1.6V12h2.8l-.4 2.9h-2.4v7A10 10 0 0 0 22 12z"/></svg></a>


### PR DESCRIPTION
## Summary
- Removed the "Licensing" footer column (Hackney carriage and private hire, Premises licences, Personal licences, and Street trading on the landing page) from all 10 pages, leaving Contact us and About us as the two footer columns.
- Changed the "Contact us" link to the online contact form: `https://gloucester-self.achieveservice.com/service/Contact_us`.

Verified with Playwright: footer now renders as a clean 2-column layout, Contact us href confirmed, no leftover Licensing markup, all tags balanced.

## Test plan
- [ ] Confirm the footer no longer shows a "Licensing" column on any page
- [ ] Click "Contact us" in the footer and confirm it opens the online contact form

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmXBkt59tXj7B2g1x81yQX)_