### PR TITLE
Match operator eligibility wording and order to the driver page

### DIFF
--- a/Taxi website/Webpages/gcc-operator-licence.html
+++ b/Taxi website/Webpages/gcc-operator-licence.html
@@ -427,23 +427,6 @@ a:focus-visible { color:var(--text) }
 
         <li class="elig-item">
           <span class="elig-mark" aria-hidden="true">✓</span>
-          <div>
-            <span>Be a fit and proper person</span>
-            <p class="elig-note">A licence will not be granted unless the Licensing Authority is satisfied that you are a fit and proper person. Where the applicant is a company or partnership, every director or partner must meet this standard.</p>
-            <p class="elig-note">You must declare any convictions, cautions, fixed penalties or pending court cases that arise between submitting your application and your licence being issued.</p>
-          </div>
-        </li>
-
-        <li class="elig-item">
-          <span class="elig-mark" aria-hidden="true">✓</span>
-          <div>
-            <span>Be eligible to work in the UK</span>
-            <p class="elig-note">A right to work check will be carried out on the applicant (or, for a company or partnership, the nominated responsible person) before your licence is issued.</p>
-          </div>
-        </li>
-
-        <li class="elig-item">
-          <span class="elig-mark" aria-hidden="true">✓</span>
           <span>Have appropriate public liability insurance for your private hire operating business</span>
         </li>
 
@@ -458,6 +441,25 @@ a:focus-visible { color:var(--text) }
         <li class="elig-item">
           <span class="elig-mark" aria-hidden="true">✓</span>
           <span>Only accept bookings for vehicles and drivers licensed by a UK licensing authority</span>
+        </li>
+
+        <li class="elig-item">
+          <span class="elig-mark" aria-hidden="true">✓</span>
+          <div>
+            <span>Be a fit and proper person</span>
+            <p class="elig-note">A licence will not be granted unless the Licensing Authority is satisfied that you are a fit and proper person.</p>
+            <p class="elig-note">You must declare any convictions, cautions, fixed penalties or pending court cases that arise between submitting your application and your licence being issued.</p>
+            <p class="elig-note">Where the applicant is a company or partnership, every director or partner must meet this standard.</p>
+          </div>
+        </li>
+
+        <li class="elig-item">
+          <span class="elig-mark" aria-hidden="true">✓</span>
+          <div>
+            <span>Be eligible to work in the UK</span>
+            <p class="elig-note">A right to work check will be carried out automatically before your licence is issued.</p>
+            <p class="elig-note">Where the applicant is a company or partnership, this check is carried out on the nominated responsible person.</p>
+          </div>
         </li>
 
       </ul>


### PR DESCRIPTION
## Summary
- Made the shared "fit and proper person" and "eligible to work in the UK" notes byte-identical to the driver page's wording, instead of a paraphrased version. The company/partnership nuance now sits in its own separate note rather than being folded into the shared sentence, so the reused text is untouched.
- Reordered the eligibility list to match the driver page's pattern: type/domain-specific criteria first (insurance, booking records, only using licensed vehicles/drivers), then the two universal criteria (fit and proper person, eligible to work in the UK) last, in that order — so the journey reads consistently across driver, vehicle and operator pages.

Verified the three shared sentences are byte-identical between the driver and operator pages, and confirmed the new item order renders correctly with Playwright.

## Test plan
- [ ] Compare the "Be a fit and proper person" and "Be eligible to work in the UK" wording side-by-side between the driver and operator pages
- [ ] Confirm the eligibility item order on the operator page reads: insurance → booking records → licensed vehicles/drivers → fit and proper person → eligible to work in the UK

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmXBkt59tXj7B2g1x81yQX)_