### PR TITLE
Wire up operator application/renewal forms; remove fee grey box

### DIFF
--- a/Taxi website/Webpages/gcc-operator-licence.html
+++ b/Taxi website/Webpages/gcc-operator-licence.html
@@ -232,14 +232,6 @@ a:focus-visible { color:var(--text) }
 .inset p { font-size:var(--t-body); color:var(--text2); line-height:var(--lh-tight); margin-bottom:var(--sp1) }
 .inset p:last-child { margin-bottom:0 }
 
-/* ── FEE TAGS ───────────────────────────────────────────────── */
-.fee-tag+.fee-tag { margin-left:var(--sp2) }
-.fee-tag {
-  display:inline-block; font-size:var(--t-body); font-weight:700;
-  color:var(--deep); background:var(--grey);
-  padding:3px 10px; border:1px solid var(--border); margin-top:var(--sp2);
-}
-
 /* ── GOV.UK DETAILS/SUMMARY ─────────────────────────────────── */
 .govuk-details { margin-top:var(--sp2) }
 .govuk-details summary {
@@ -499,14 +491,12 @@ a:focus-visible { color:var(--text) }
         <li class="req-item">
           <div class="req-title">Application fee</div>
           <p class="req-desc">Paid when you submit your application online. The fee depends on the number of vehicles in your fleet — see the <a href="gcc-hcph-fees.html">full fee schedule</a>.</p>
-          <span class="fee-tag">From £352.00 (1 year, up to 3 vehicles)</span>
         </li>
 
       </ul>
 
       <div class="cta-wrap">
-        <a href="#" class="cta" role="button">Apply now <span aria-hidden="true">→</span></a>
-        <p class="cta-sub">This form is not yet linked — the Licensing Team needs to confirm the online application URL.</p>
+        <a href="https://gloucester-self.achieveservice.com/service/Taxi___Apply_for_a_new_private_hire_operator_licence" class="cta" role="button">Apply now <span aria-hidden="true">→</span></a>
       </div>
     </section>
 
@@ -541,14 +531,12 @@ a:focus-visible { color:var(--text) }
         <li class="req-item">
           <div class="req-title">Renewal fee</div>
           <p class="req-desc">Paid when you submit your renewal online. The fee depends on the number of vehicles in your fleet — see the <a href="gcc-hcph-fees.html">full fee schedule</a>.</p>
-          <span class="fee-tag">From £352.00 (1 year, up to 3 vehicles)</span>
         </li>
 
       </ul>
 
       <div class="cta-wrap">
-        <a href="#" class="cta" role="button">Renew now <span aria-hidden="true">→</span></a>
-        <p class="cta-sub">This form is not yet linked — the Licensing Team needs to confirm the online renewal URL.</p>
+        <a href="https://gloucester-self.achieveservice.com/service/Taxi___Renew_Private_Hire_Operator_licence" class="cta" role="button">Renew now <span aria-hidden="true">→</span></a>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- Linked the "Apply now" and "Renew now" CTAs to the real online forms and removed the "not yet linked" placeholder notes:
  - `https://gloucester-self.achieveservice.com/service/Taxi___Apply_for_a_new_private_hire_operator_licence`
  - `https://gloucester-self.achieveservice.com/service/Taxi___Renew_Private_Hire_Operator_licence`
- Removed the grey fee-tag box under the Application/Renewal fee items, keeping just the "see the full fee schedule" link, since a single flat figure doesn't represent a fee that varies by fleet size and term.
- Removed the now-unused `.fee-tag` CSS rules from this page.

Verified with Playwright: both CTA hrefs resolve to the correct URLs, `fee-tag` count is 0, no console errors, all tags balanced.

## Test plan
- [ ] Click "Apply now" and "Renew now" on the operator page and confirm they open the correct forms
- [ ] Confirm no grey fee box appears under the fee text, just the "full fee schedule" link

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmXBkt59tXj7B2g1x81yQX)_