### PR TITLE
Enlarge header logo and link it to gloucester.gov.uk

### DIFF
--- a/Taxi website/Webpages/gcc-approved-garages.html
+++ b/Taxi website/Webpages/gcc-approved-garages.html
@@ -131,7 +131,7 @@ a:focus-visible { color:var(--text) }
   display:flex; align-items:center; justify-content:space-between;
 }
 .logo { display:flex; align-items:center; gap:var(--sp2); text-decoration:none; color:var(--white) }
-.logo img { height:40px; width:auto }
+.logo img { height:56px; width:auto }
 .logo-txt { font-size:var(--t-md); font-weight:700 }
 .hdr-nav { display:flex; gap:var(--sp3); list-style:none }
 .hdr-nav a {
@@ -493,7 +493,7 @@ a:focus-visible { color:var(--text) }
 
 <header class="hdr" role="banner">
   <div class="hdr-in">
-    <a href="/" class="logo" aria-label="Gloucester City Council — home">
+    <a href="https://www.gloucester.gov.uk/" class="logo" aria-label="Gloucester City Council — home">
       <img src="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/templates/assets/GCC_logo.svg" alt="Gloucester City Council" style="filter:brightness(0) invert(1)">
     </a>
   </div>

--- a/Taxi website/Webpages/gcc-driver-licence.html
+++ b/Taxi website/Webpages/gcc-driver-licence.html
@@ -131,7 +131,7 @@ a:focus-visible { color:var(--text) }
   display:flex; align-items:center; justify-content:space-between;
 }
 .logo { display:flex; align-items:center; gap:var(--sp2); text-decoration:none; color:var(--white) }
-.logo img { height:40px; width:auto }
+.logo img { height:56px; width:auto }
 .logo-txt { font-size:var(--t-md); font-weight:700 }
 .hdr-nav { display:flex; gap:var(--sp3); list-style:none }
 .hdr-nav a {
@@ -436,7 +436,7 @@ a:focus-visible { color:var(--text) }
 
 <header class="hdr" role="banner">
   <div class="hdr-in">
-    <a href="/" class="logo" aria-label="Gloucester City Council — home">
+    <a href="https://www.gloucester.gov.uk/" class="logo" aria-label="Gloucester City Council — home">
       <img src="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/templates/assets/GCC_logo.svg" alt="Gloucester City Council" style="filter:brightness(0) invert(1)">
     </a>
   </div>

--- a/Taxi website/Webpages/gcc-hcph-changes.html
+++ b/Taxi website/Webpages/gcc-hcph-changes.html
@@ -131,7 +131,7 @@ a:focus-visible { color:var(--text) }
   display:flex; align-items:center; justify-content:space-between;
 }
 .logo { display:flex; align-items:center; gap:var(--sp2); text-decoration:none; color:var(--white) }
-.logo img { height:40px; width:auto }
+.logo img { height:56px; width:auto }
 .logo-txt { font-size:var(--t-md); font-weight:700 }
 .hdr-nav { display:flex; gap:var(--sp3); list-style:none }
 .hdr-nav a {
@@ -457,7 +457,7 @@ a:focus-visible { color:var(--text) }
 
 <header class="hdr" role="banner">
   <div class="hdr-in">
-    <a href="/" class="logo" aria-label="Gloucester City Council — home">
+    <a href="https://www.gloucester.gov.uk/" class="logo" aria-label="Gloucester City Council — home">
       <img src="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/templates/assets/GCC_logo.svg" alt="Gloucester City Council" style="filter:brightness(0) invert(1)">
     </a>
   </div>

--- a/Taxi website/Webpages/gcc-hcph-documents.html
+++ b/Taxi website/Webpages/gcc-hcph-documents.html
@@ -131,7 +131,7 @@ a:focus-visible { color:var(--text) }
   display:flex; align-items:center; justify-content:space-between;
 }
 .logo { display:flex; align-items:center; gap:var(--sp2); text-decoration:none; color:var(--white) }
-.logo img { height:40px; width:auto }
+.logo img { height:56px; width:auto }
 .logo-txt { font-size:var(--t-md); font-weight:700 }
 .hdr-nav { display:flex; gap:var(--sp3); list-style:none }
 .hdr-nav a {
@@ -491,7 +491,7 @@ a:focus-visible { color:var(--text) }
 
 <header class="hdr" role="banner">
   <div class="hdr-in">
-    <a href="/" class="logo" aria-label="Gloucester City Council — home">
+    <a href="https://www.gloucester.gov.uk/" class="logo" aria-label="Gloucester City Council — home">
       <img src="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/templates/assets/GCC_logo.svg" alt="Gloucester City Council" style="filter:brightness(0) invert(1)">
     </a>
   </div>

--- a/Taxi website/Webpages/gcc-hcph-fees.html
+++ b/Taxi website/Webpages/gcc-hcph-fees.html
@@ -131,7 +131,7 @@ a:focus-visible { color:var(--text) }
   display:flex; align-items:center; justify-content:space-between;
 }
 .logo { display:flex; align-items:center; gap:var(--sp2); text-decoration:none; color:var(--white) }
-.logo img { height:40px; width:auto }
+.logo img { height:56px; width:auto }
 .logo-txt { font-size:var(--t-md); font-weight:700 }
 .hdr-nav { display:flex; gap:var(--sp3); list-style:none }
 .hdr-nav a {
@@ -487,7 +487,7 @@ a:focus-visible { color:var(--text) }
 
 <header class="hdr" role="banner">
   <div class="hdr-in">
-    <a href="/" class="logo" aria-label="Gloucester City Council — home">
+    <a href="https://www.gloucester.gov.uk/" class="logo" aria-label="Gloucester City Council — home">
       <img src="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/templates/assets/GCC_logo.svg" alt="Gloucester City Council" style="filter:brightness(0) invert(1)">
     </a>
   </div>

--- a/Taxi website/Webpages/gcc-hcph-landing.html
+++ b/Taxi website/Webpages/gcc-hcph-landing.html
@@ -63,7 +63,7 @@ a:focus-visible{color:var(--text)}
 .hdr{background:var(--deep);border-bottom:4px solid var(--blue)}
 .hdr-in{max-width:var(--max);margin:0 auto;padding:var(--sp3) var(--sp4);display:flex;align-items:center;justify-content:space-between}
 .logo{display:flex;align-items:center;gap:var(--sp2);text-decoration:none;color:var(--white)}
-.logo img{height:40px;width:auto}
+.logo img{height:56px;width:auto}
 .logo-txt{font-size:var(--t-md);font-weight:700}
 .hdr-nav{display:flex;gap:var(--sp3);list-style:none}
 .hdr-nav a{color:rgba(255,255,255,.85);text-decoration:none;font-size:var(--t-sm);padding:var(--sp1) var(--sp2);min-height:var(--touch);display:flex;align-items:center}
@@ -349,7 +349,7 @@ a:focus-visible{color:var(--text)}
 
 <header class="hdr" role="banner">
   <div class="hdr-in">
-    <a href="/" class="logo" aria-label="Gloucester City Council — home">
+    <a href="https://www.gloucester.gov.uk/" class="logo" aria-label="Gloucester City Council — home">
       <img src="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/templates/assets/GCC_logo.svg" alt="Gloucester City Council" style="filter:brightness(0) invert(1)">
     </a>
   </div>

--- a/Taxi website/Webpages/gcc-hcph-passengers.html
+++ b/Taxi website/Webpages/gcc-hcph-passengers.html
@@ -131,7 +131,7 @@ a:focus-visible { color:var(--text) }
   display:flex; align-items:center; justify-content:space-between;
 }
 .logo { display:flex; align-items:center; gap:var(--sp2); text-decoration:none; color:var(--white) }
-.logo img { height:40px; width:auto }
+.logo img { height:56px; width:auto }
 .logo-txt { font-size:var(--t-md); font-weight:700 }
 .hdr-nav { display:flex; gap:var(--sp3); list-style:none }
 .hdr-nav a {
@@ -469,7 +469,7 @@ a:focus-visible { color:var(--text) }
 
 <header class="hdr" role="banner">
   <div class="hdr-in">
-    <a href="/" class="logo" aria-label="Gloucester City Council — home">
+    <a href="https://www.gloucester.gov.uk/" class="logo" aria-label="Gloucester City Council — home">
       <img src="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/templates/assets/GCC_logo.svg" alt="Gloucester City Council" style="filter:brightness(0) invert(1)">
     </a>
   </div>

--- a/Taxi website/Webpages/gcc-hcph-register.html
+++ b/Taxi website/Webpages/gcc-hcph-register.html
@@ -35,7 +35,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;c
 .skip:focus{left:4px}
 .hdr{background:var(--deep);padding:var(--sp3) 0}
 .hdr-in{max-width:var(--max);margin:0 auto;padding:0 var(--sp4)}
-.logo img{height:48px}
+.logo img{height:56px}
 .svc{background:var(--blue);padding:var(--sp2) 0}
 .svc-in{max-width:var(--max);margin:0 auto;padding:0 var(--sp4);font-size:var(--t-sm);color:var(--white);font-weight:700}
 .bc{background:var(--grey);border-bottom:1px solid var(--divider);padding:var(--sp2) 0}
@@ -147,7 +147,7 @@ tr:last-child td{border-bottom:none}
 
 <header class="hdr" role="banner">
   <div class="hdr-in">
-    <a href="/" class="logo" aria-label="Gloucester City Council — home">
+    <a href="https://www.gloucester.gov.uk/" class="logo" aria-label="Gloucester City Council — home">
       <img src="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/templates/assets/GCC_logo.svg" alt="Gloucester City Council" style="filter:brightness(0) invert(1)">
     </a>
   </div>

--- a/Taxi website/Webpages/gcc-hcph-wav.html
+++ b/Taxi website/Webpages/gcc-hcph-wav.html
@@ -35,7 +35,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;c
 .skip:focus{left:4px}
 .hdr{background:var(--deep);padding:var(--sp3) 0}
 .hdr-in{max-width:var(--max);margin:0 auto;padding:0 var(--sp4)}
-.logo img{height:48px}
+.logo img{height:56px}
 .svc{background:var(--blue);padding:var(--sp2) 0}
 .svc-in{max-width:var(--max);margin:0 auto;padding:0 var(--sp4);font-size:var(--t-sm);color:var(--white);font-weight:700}
 .bc{background:var(--grey);border-bottom:1px solid var(--divider);padding:var(--sp2) 0}
@@ -146,7 +146,7 @@ h1{font-size:var(--t-h1);font-weight:700;color:var(--deep);margin-bottom:var(--s
 
 <header class="hdr" role="banner">
   <div class="hdr-in">
-    <a href="/" class="logo" aria-label="Gloucester City Council — home">
+    <a href="https://www.gloucester.gov.uk/" class="logo" aria-label="Gloucester City Council — home">
       <img src="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/templates/assets/GCC_logo.svg" alt="Gloucester City Council" style="filter:brightness(0) invert(1)">
     </a>
   </div>

--- a/Taxi website/Webpages/gcc-operator-licence.html
+++ b/Taxi website/Webpages/gcc-operator-licence.html
@@ -131,7 +131,7 @@ a:focus-visible { color:var(--text) }
   display:flex; align-items:center; justify-content:space-between;
 }
 .logo { display:flex; align-items:center; gap:var(--sp2); text-decoration:none; color:var(--white) }
-.logo img { height:40px; width:auto }
+.logo img { height:56px; width:auto }
 .logo-txt { font-size:var(--t-md); font-weight:700 }
 .hdr-nav { display:flex; gap:var(--sp3); list-style:none }
 .hdr-nav a {
@@ -371,7 +371,7 @@ a:focus-visible { color:var(--text) }
 
 <header class="hdr" role="banner">
   <div class="hdr-in">
-    <a href="/" class="logo" aria-label="Gloucester City Council — home">
+    <a href="https://www.gloucester.gov.uk/" class="logo" aria-label="Gloucester City Council — home">
       <img src="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/templates/assets/GCC_logo.svg" alt="Gloucester City Council" style="filter:brightness(0) invert(1)">
     </a>
   </div>

--- a/Taxi website/Webpages/gcc-vehicle-licence.html
+++ b/Taxi website/Webpages/gcc-vehicle-licence.html
@@ -131,7 +131,7 @@ a:focus-visible { color:var(--text) }
   display:flex; align-items:center; justify-content:space-between;
 }
 .logo { display:flex; align-items:center; gap:var(--sp2); text-decoration:none; color:var(--white) }
-.logo img { height:40px; width:auto }
+.logo img { height:56px; width:auto }
 .logo-txt { font-size:var(--t-md); font-weight:700 }
 .hdr-nav { display:flex; gap:var(--sp3); list-style:none }
 .hdr-nav a {
@@ -436,7 +436,7 @@ a:focus-visible { color:var(--text) }
 
 <header class="hdr" role="banner">
   <div class="hdr-in">
-    <a href="/" class="logo" aria-label="Gloucester City Council — home">
+    <a href="https://www.gloucester.gov.uk/" class="logo" aria-label="Gloucester City Council — home">
       <img src="https://raw.githubusercontent.com/Gloucester-City-Council/GCC-Beta-site-v1/main/templates/assets/GCC_logo.svg" alt="Gloucester City Council" style="filter:brightness(0) invert(1)">
     </a>
   </div>


### PR DESCRIPTION
## Summary
- Increases the header logo (`.logo img`) height from 40px/48px to 56px across all 11 taxi licensing pages
- Points the logo link to `https://www.gloucester.gov.uk/` instead of the relative root path `/`, so clicking it from the beta site takes users to the live council homepage

## Test plan
- [x] Verified via grep that all 11 pages have exactly one updated href and one updated `.logo img` height rule, with no leftover old values
- [x] Verified opening/closing tag balance is unaffected across all files
- [x] Verified with Playwright (image load mocked to rule out this sandbox's blocked external-image fetch) that the logo renders at the correct 56px height on both CSS variants used across the site (main stylesheet and the wav/register stylesheet)
- [x] Confirmed the logo link points to `https://www.gloucester.gov.uk/`


---
_Generated by [Claude Code](https://claude.ai/code/session_01CmXBkt59tXj7B2g1x81yQX)_