### PR TITLE
Add site-refresh notification banner across taxi licensing pages

### DIFF
--- a/Taxi website/Webpages/gcc-approved-garages.html
+++ b/Taxi website/Webpages/gcc-approved-garages.html
@@ -153,6 +153,30 @@ a:focus-visible { color:var(--text) }
 .bc-item+.bc-item::before { content:"›"; color:var(--muted) }
 .bc-item a { color:var(--link); display:inline-flex; align-items:center; min-height:24px; padding:2px 0 }
 .bc-cur { color:var(--text2); font-weight:700 }
+/* ── UPDATE BANNER ──────────────────────────────────────────── */
+.update-banner { background:#EFF6FC; border-top:4px solid var(--blue); border-bottom:1px solid var(--divider) }
+.update-banner-in {
+  max-width:var(--max); margin:0 auto; padding:var(--sp4);
+  display:flex; flex-wrap:wrap; align-items:center; gap:var(--sp4);
+}
+.update-banner-copy { flex:1 1 360px }
+.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--text) }
+.update-banner-copy p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:var(--text2) }
+.update-banner-copy p:last-child { margin-bottom:0 }
+.update-banner-btn {
+  flex:0 0 auto; display:inline-flex; align-items:center; justify-content:center;
+  background:var(--blue); color:var(--white); text-decoration:none; font-weight:700;
+  padding:var(--btn-pad-v) var(--sp4); min-height:var(--touch); white-space:nowrap;
+}
+.update-banner-btn:hover { background:var(--hover); color:var(--white); text-decoration:none }
+.update-banner-btn:visited { color:var(--white) }
+.update-banner-btn:focus-visible {
+  outline:3px solid var(--focus); outline-offset:0;
+  background:var(--focus); color:var(--text);
+}
+@media (max-width:600px) {
+  .update-banner-btn { width:100% }
+}
 
 /* ── PAGE LAYOUT ────────────────────────────────────────────── */
 .page { max-width:var(--max); margin:0 auto; padding:var(--sp5) var(--sp4) var(--sp7) }
@@ -510,6 +534,18 @@ a:focus-visible { color:var(--text) }
     <li class="bc-item"><span class="bc-cur" aria-current="page">Approved testing garages</span></li>
   </ol></div>
 </nav>
+
+<div class="update-banner" role="region" aria-labelledby="update-banner-title">
+  <div class="update-banner-in">
+    <div class="update-banner-copy">
+      <p class="update-banner-title" id="update-banner-title">Welcome to our refreshed Hackney Carriage and Private Hire pages</p>
+      <p>We've introduced a new and improved experience designed to make accessing information and services easier than ever.</p>
+      <p>We're keen to hear your thoughts. Your feedback will help us continue to improve and ensure these pages meet your needs.</p>
+    </div>
+    <!-- Feedback form not yet live — replace href with the real destination URL once available -->
+    <a href="#" class="update-banner-btn">Give Feedback</a>
+  </div>
+</div>
 
 <main id="main-content">
 <div class="page">

--- a/Taxi website/Webpages/gcc-driver-licence.html
+++ b/Taxi website/Webpages/gcc-driver-licence.html
@@ -153,6 +153,30 @@ a:focus-visible { color:var(--text) }
 .bc-item+.bc-item::before { content:"›"; color:var(--muted) }
 .bc-item a { color:var(--link); display:inline-flex; align-items:center; min-height:24px; padding:2px 0 }
 .bc-cur { color:var(--text2); font-weight:700 }
+/* ── UPDATE BANNER ──────────────────────────────────────────── */
+.update-banner { background:#EFF6FC; border-top:4px solid var(--blue); border-bottom:1px solid var(--divider) }
+.update-banner-in {
+  max-width:var(--max); margin:0 auto; padding:var(--sp4);
+  display:flex; flex-wrap:wrap; align-items:center; gap:var(--sp4);
+}
+.update-banner-copy { flex:1 1 360px }
+.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--text) }
+.update-banner-copy p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:var(--text2) }
+.update-banner-copy p:last-child { margin-bottom:0 }
+.update-banner-btn {
+  flex:0 0 auto; display:inline-flex; align-items:center; justify-content:center;
+  background:var(--blue); color:var(--white); text-decoration:none; font-weight:700;
+  padding:var(--btn-pad-v) var(--sp4); min-height:var(--touch); white-space:nowrap;
+}
+.update-banner-btn:hover { background:var(--hover); color:var(--white); text-decoration:none }
+.update-banner-btn:visited { color:var(--white) }
+.update-banner-btn:focus-visible {
+  outline:3px solid var(--focus); outline-offset:0;
+  background:var(--focus); color:var(--text);
+}
+@media (max-width:600px) {
+  .update-banner-btn { width:100% }
+}
 
 /* ── PAGE LAYOUT ────────────────────────────────────────────── */
 .page { max-width:var(--max); margin:0 auto; padding:var(--sp5) var(--sp4) var(--sp7) }
@@ -452,6 +476,18 @@ a:focus-visible { color:var(--text) }
     <li class="bc-item"><span class="bc-cur" aria-current="page">Driver licence</span></li>
   </ol></div>
 </nav>
+
+<div class="update-banner" role="region" aria-labelledby="update-banner-title">
+  <div class="update-banner-in">
+    <div class="update-banner-copy">
+      <p class="update-banner-title" id="update-banner-title">Welcome to our refreshed Hackney Carriage and Private Hire pages</p>
+      <p>We've introduced a new and improved experience designed to make accessing information and services easier than ever.</p>
+      <p>We're keen to hear your thoughts. Your feedback will help us continue to improve and ensure these pages meet your needs.</p>
+    </div>
+    <!-- Feedback form not yet live — replace href with the real destination URL once available -->
+    <a href="#" class="update-banner-btn">Give Feedback</a>
+  </div>
+</div>
 
 <main id="main-content">
 <div class="page">

--- a/Taxi website/Webpages/gcc-hcph-changes.html
+++ b/Taxi website/Webpages/gcc-hcph-changes.html
@@ -153,6 +153,30 @@ a:focus-visible { color:var(--text) }
 .bc-item+.bc-item::before { content:"›"; color:var(--muted) }
 .bc-item a { color:var(--link); display:inline-flex; align-items:center; min-height:24px; padding:2px 0 }
 .bc-cur { color:var(--text2); font-weight:700 }
+/* ── UPDATE BANNER ──────────────────────────────────────────── */
+.update-banner { background:#EFF6FC; border-top:4px solid var(--blue); border-bottom:1px solid var(--divider) }
+.update-banner-in {
+  max-width:var(--max); margin:0 auto; padding:var(--sp4);
+  display:flex; flex-wrap:wrap; align-items:center; gap:var(--sp4);
+}
+.update-banner-copy { flex:1 1 360px }
+.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--text) }
+.update-banner-copy p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:var(--text2) }
+.update-banner-copy p:last-child { margin-bottom:0 }
+.update-banner-btn {
+  flex:0 0 auto; display:inline-flex; align-items:center; justify-content:center;
+  background:var(--blue); color:var(--white); text-decoration:none; font-weight:700;
+  padding:var(--btn-pad-v) var(--sp4); min-height:var(--touch); white-space:nowrap;
+}
+.update-banner-btn:hover { background:var(--hover); color:var(--white); text-decoration:none }
+.update-banner-btn:visited { color:var(--white) }
+.update-banner-btn:focus-visible {
+  outline:3px solid var(--focus); outline-offset:0;
+  background:var(--focus); color:var(--text);
+}
+@media (max-width:600px) {
+  .update-banner-btn { width:100% }
+}
 
 /* ── PAGE LAYOUT ────────────────────────────────────────────── */
 .page { max-width:var(--max); margin:0 auto; padding:var(--sp5) var(--sp4) var(--sp7) }
@@ -473,6 +497,18 @@ a:focus-visible { color:var(--text) }
     <li class="bc-item"><span class="bc-cur" aria-current="page">Something has changed</span></li>
   </ol></div>
 </nav>
+
+<div class="update-banner" role="region" aria-labelledby="update-banner-title">
+  <div class="update-banner-in">
+    <div class="update-banner-copy">
+      <p class="update-banner-title" id="update-banner-title">Welcome to our refreshed Hackney Carriage and Private Hire pages</p>
+      <p>We've introduced a new and improved experience designed to make accessing information and services easier than ever.</p>
+      <p>We're keen to hear your thoughts. Your feedback will help us continue to improve and ensure these pages meet your needs.</p>
+    </div>
+    <!-- Feedback form not yet live — replace href with the real destination URL once available -->
+    <a href="#" class="update-banner-btn">Give Feedback</a>
+  </div>
+</div>
 
 <main id="main-content">
 <div class="page">

--- a/Taxi website/Webpages/gcc-hcph-documents.html
+++ b/Taxi website/Webpages/gcc-hcph-documents.html
@@ -153,6 +153,30 @@ a:focus-visible { color:var(--text) }
 .bc-item+.bc-item::before { content:"›"; color:var(--muted) }
 .bc-item a { color:var(--link); display:inline-flex; align-items:center; min-height:24px; padding:2px 0 }
 .bc-cur { color:var(--text2); font-weight:700 }
+/* ── UPDATE BANNER ──────────────────────────────────────────── */
+.update-banner { background:#EFF6FC; border-top:4px solid var(--blue); border-bottom:1px solid var(--divider) }
+.update-banner-in {
+  max-width:var(--max); margin:0 auto; padding:var(--sp4);
+  display:flex; flex-wrap:wrap; align-items:center; gap:var(--sp4);
+}
+.update-banner-copy { flex:1 1 360px }
+.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--text) }
+.update-banner-copy p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:var(--text2) }
+.update-banner-copy p:last-child { margin-bottom:0 }
+.update-banner-btn {
+  flex:0 0 auto; display:inline-flex; align-items:center; justify-content:center;
+  background:var(--blue); color:var(--white); text-decoration:none; font-weight:700;
+  padding:var(--btn-pad-v) var(--sp4); min-height:var(--touch); white-space:nowrap;
+}
+.update-banner-btn:hover { background:var(--hover); color:var(--white); text-decoration:none }
+.update-banner-btn:visited { color:var(--white) }
+.update-banner-btn:focus-visible {
+  outline:3px solid var(--focus); outline-offset:0;
+  background:var(--focus); color:var(--text);
+}
+@media (max-width:600px) {
+  .update-banner-btn { width:100% }
+}
 
 /* ── PAGE LAYOUT ────────────────────────────────────────────── */
 .page { max-width:var(--max); margin:0 auto; padding:var(--sp5) var(--sp4) var(--sp7) }
@@ -507,6 +531,18 @@ a:focus-visible { color:var(--text) }
     <li class="bc-item"><span class="bc-cur" aria-current="page">Policies and documents</span></li>
   </ol></div>
 </nav>
+
+<div class="update-banner" role="region" aria-labelledby="update-banner-title">
+  <div class="update-banner-in">
+    <div class="update-banner-copy">
+      <p class="update-banner-title" id="update-banner-title">Welcome to our refreshed Hackney Carriage and Private Hire pages</p>
+      <p>We've introduced a new and improved experience designed to make accessing information and services easier than ever.</p>
+      <p>We're keen to hear your thoughts. Your feedback will help us continue to improve and ensure these pages meet your needs.</p>
+    </div>
+    <!-- Feedback form not yet live — replace href with the real destination URL once available -->
+    <a href="#" class="update-banner-btn">Give Feedback</a>
+  </div>
+</div>
 
 <main id="main-content">
 <div class="page">

--- a/Taxi website/Webpages/gcc-hcph-fees.html
+++ b/Taxi website/Webpages/gcc-hcph-fees.html
@@ -153,6 +153,30 @@ a:focus-visible { color:var(--text) }
 .bc-item+.bc-item::before { content:"›"; color:var(--muted) }
 .bc-item a { color:var(--link); display:inline-flex; align-items:center; min-height:24px; padding:2px 0 }
 .bc-cur { color:var(--text2); font-weight:700 }
+/* ── UPDATE BANNER ──────────────────────────────────────────── */
+.update-banner { background:#EFF6FC; border-top:4px solid var(--blue); border-bottom:1px solid var(--divider) }
+.update-banner-in {
+  max-width:var(--max); margin:0 auto; padding:var(--sp4);
+  display:flex; flex-wrap:wrap; align-items:center; gap:var(--sp4);
+}
+.update-banner-copy { flex:1 1 360px }
+.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--text) }
+.update-banner-copy p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:var(--text2) }
+.update-banner-copy p:last-child { margin-bottom:0 }
+.update-banner-btn {
+  flex:0 0 auto; display:inline-flex; align-items:center; justify-content:center;
+  background:var(--blue); color:var(--white); text-decoration:none; font-weight:700;
+  padding:var(--btn-pad-v) var(--sp4); min-height:var(--touch); white-space:nowrap;
+}
+.update-banner-btn:hover { background:var(--hover); color:var(--white); text-decoration:none }
+.update-banner-btn:visited { color:var(--white) }
+.update-banner-btn:focus-visible {
+  outline:3px solid var(--focus); outline-offset:0;
+  background:var(--focus); color:var(--text);
+}
+@media (max-width:600px) {
+  .update-banner-btn { width:100% }
+}
 
 /* ── PAGE LAYOUT ────────────────────────────────────────────── */
 .page { max-width:var(--max); margin:0 auto; padding:var(--sp5) var(--sp4) var(--sp7) }
@@ -503,6 +527,18 @@ a:focus-visible { color:var(--text) }
     <li class="bc-item"><span class="bc-cur" aria-current="page">Fees and charges</span></li>
   </ol></div>
 </nav>
+
+<div class="update-banner" role="region" aria-labelledby="update-banner-title">
+  <div class="update-banner-in">
+    <div class="update-banner-copy">
+      <p class="update-banner-title" id="update-banner-title">Welcome to our refreshed Hackney Carriage and Private Hire pages</p>
+      <p>We've introduced a new and improved experience designed to make accessing information and services easier than ever.</p>
+      <p>We're keen to hear your thoughts. Your feedback will help us continue to improve and ensure these pages meet your needs.</p>
+    </div>
+    <!-- Feedback form not yet live — replace href with the real destination URL once available -->
+    <a href="#" class="update-banner-btn">Give Feedback</a>
+  </div>
+</div>
 
 <main id="main-content">
 <div class="page">

--- a/Taxi website/Webpages/gcc-hcph-landing.html
+++ b/Taxi website/Webpages/gcc-hcph-landing.html
@@ -79,6 +79,18 @@ a:focus-visible{color:var(--text)}
 .bc-item+.bc-item::before{content:"›";color:var(--muted)}
 .bc-item a{color:var(--link);display:inline-flex;align-items:center;min-height:24px;padding:2px 0}
 .bc-cur{color:var(--text2);font-weight:700}
+/* ── UPDATE BANNER ──────────────────────────────────────────── */
+.update-banner{background:#EFF6FC;border-top:4px solid var(--blue);border-bottom:1px solid var(--divider)}
+.update-banner-in{max-width:var(--max);margin:0 auto;padding:var(--sp4);display:flex;flex-wrap:wrap;align-items:center;gap:var(--sp4)}
+.update-banner-copy{flex:1 1 360px}
+.update-banner-title{margin:0 0 var(--sp2);font-size:var(--t-md);font-weight:700;color:var(--text)}
+.update-banner-copy p:not(.update-banner-title){margin:0 0 var(--sp2);font-size:var(--t-body);color:var(--text2)}
+.update-banner-copy p:last-child{margin-bottom:0}
+.update-banner-btn{flex:0 0 auto;display:inline-flex;align-items:center;justify-content:center;background:var(--blue);color:var(--white);text-decoration:none;font-weight:700;padding:10px var(--sp4);min-height:var(--touch);white-space:nowrap}
+.update-banner-btn:hover{background:var(--hover);color:var(--white);text-decoration:none}
+.update-banner-btn:visited{color:var(--white)}
+.update-banner-btn:focus-visible{outline:3px solid var(--focus);outline-offset:0;background:var(--focus);color:var(--text)}
+@media (max-width:600px){.update-banner-btn{width:100%}}
 
 /* PAGE */
 .page{max-width:var(--max);margin:0 auto;padding:var(--sp5) var(--sp4) var(--sp7)}
@@ -364,6 +376,18 @@ a:focus-visible{color:var(--text)}
     <li class="bc-item"><span class="bc-cur" aria-current="page">Hackney carriage and private hire</span></li>
   </ol></div>
 </nav>
+
+<div class="update-banner" role="region" aria-labelledby="update-banner-title">
+  <div class="update-banner-in">
+    <div class="update-banner-copy">
+      <p class="update-banner-title" id="update-banner-title">Welcome to our refreshed Hackney Carriage and Private Hire pages</p>
+      <p>We've introduced a new and improved experience designed to make accessing information and services easier than ever.</p>
+      <p>We're keen to hear your thoughts. Your feedback will help us continue to improve and ensure these pages meet your needs.</p>
+    </div>
+    <!-- Feedback form not yet live — replace href with the real destination URL once available -->
+    <a href="#" class="update-banner-btn">Give Feedback</a>
+  </div>
+</div>
 
 <main id="main-content">
 <div class="page">

--- a/Taxi website/Webpages/gcc-hcph-passengers.html
+++ b/Taxi website/Webpages/gcc-hcph-passengers.html
@@ -153,6 +153,30 @@ a:focus-visible { color:var(--text) }
 .bc-item+.bc-item::before { content:"›"; color:var(--muted) }
 .bc-item a { color:var(--link); display:inline-flex; align-items:center; min-height:24px; padding:2px 0 }
 .bc-cur { color:var(--text2); font-weight:700 }
+/* ── UPDATE BANNER ──────────────────────────────────────────── */
+.update-banner { background:#EFF6FC; border-top:4px solid var(--blue); border-bottom:1px solid var(--divider) }
+.update-banner-in {
+  max-width:var(--max); margin:0 auto; padding:var(--sp4);
+  display:flex; flex-wrap:wrap; align-items:center; gap:var(--sp4);
+}
+.update-banner-copy { flex:1 1 360px }
+.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--text) }
+.update-banner-copy p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:var(--text2) }
+.update-banner-copy p:last-child { margin-bottom:0 }
+.update-banner-btn {
+  flex:0 0 auto; display:inline-flex; align-items:center; justify-content:center;
+  background:var(--blue); color:var(--white); text-decoration:none; font-weight:700;
+  padding:var(--btn-pad-v) var(--sp4); min-height:var(--touch); white-space:nowrap;
+}
+.update-banner-btn:hover { background:var(--hover); color:var(--white); text-decoration:none }
+.update-banner-btn:visited { color:var(--white) }
+.update-banner-btn:focus-visible {
+  outline:3px solid var(--focus); outline-offset:0;
+  background:var(--focus); color:var(--text);
+}
+@media (max-width:600px) {
+  .update-banner-btn { width:100% }
+}
 
 /* ── PAGE LAYOUT ────────────────────────────────────────────── */
 .page { max-width:var(--max); margin:0 auto; padding:var(--sp5) var(--sp4) var(--sp7) }
@@ -485,6 +509,18 @@ a:focus-visible { color:var(--text) }
     <li class="bc-item"><span class="bc-cur" aria-current="page">Passengers</span></li>
   </ol></div>
 </nav>
+
+<div class="update-banner" role="region" aria-labelledby="update-banner-title">
+  <div class="update-banner-in">
+    <div class="update-banner-copy">
+      <p class="update-banner-title" id="update-banner-title">Welcome to our refreshed Hackney Carriage and Private Hire pages</p>
+      <p>We've introduced a new and improved experience designed to make accessing information and services easier than ever.</p>
+      <p>We're keen to hear your thoughts. Your feedback will help us continue to improve and ensure these pages meet your needs.</p>
+    </div>
+    <!-- Feedback form not yet live — replace href with the real destination URL once available -->
+    <a href="#" class="update-banner-btn">Give Feedback</a>
+  </div>
+</div>
 
 <main id="main-content">
 <div class="page">

--- a/Taxi website/Webpages/gcc-hcph-register.html
+++ b/Taxi website/Webpages/gcc-hcph-register.html
@@ -45,6 +45,18 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;c
 .bc-item a{color:var(--link);display:inline-flex;align-items:center;min-height:24px;padding:2px 0}
 .bc-item+.bc-item::before{content:"›";color:var(--muted)}
 .bc-cur{color:var(--text);font-weight:600}
+/* ── UPDATE BANNER ──────────────────────────────────────────── */
+.update-banner{background:#EFF6FC;border-top:4px solid var(--blue);border-bottom:1px solid var(--divider)}
+.update-banner-in{max-width:var(--max);margin:0 auto;padding:var(--sp4);display:flex;flex-wrap:wrap;align-items:center;gap:var(--sp4)}
+.update-banner-copy{flex:1 1 360px}
+.update-banner-title{margin:0 0 var(--sp2);font-size:var(--t-md);font-weight:700;color:var(--text)}
+.update-banner-copy p:not(.update-banner-title){margin:0 0 var(--sp2);font-size:var(--t-body);color:var(--text2)}
+.update-banner-copy p:last-child{margin-bottom:0}
+.update-banner-btn{flex:0 0 auto;display:inline-flex;align-items:center;justify-content:center;background:var(--blue);color:var(--white);text-decoration:none;font-weight:700;padding:10px var(--sp4);min-height:var(--touch);white-space:nowrap}
+.update-banner-btn:hover{background:var(--hover);color:var(--white);text-decoration:none}
+.update-banner-btn:visited{color:var(--white)}
+.update-banner-btn:focus-visible{outline:3px solid #FFDD00;outline-offset:0;background:#FFDD00;color:var(--text)}
+@media (max-width:600px){.update-banner-btn{width:100%}}
 .page{max-width:var(--max);margin:0 auto;padding:var(--sp5) var(--sp4) var(--sp7)}
 .back{display:inline-flex;align-items:center;gap:var(--sp1);font-size:var(--t-sm);color:var(--link);text-decoration:none;margin-bottom:var(--sp5);min-height:var(--touch);padding:var(--sp1) 0}
 .back::before{content:"‹";font-size:1.2em}
@@ -164,6 +176,18 @@ tr:last-child td{border-bottom:none}
     <li class="bc-item"><span class="bc-cur" aria-current="page">Public register</span></li>
   </ol></div>
 </nav>
+
+<div class="update-banner" role="region" aria-labelledby="update-banner-title">
+  <div class="update-banner-in">
+    <div class="update-banner-copy">
+      <p class="update-banner-title" id="update-banner-title">Welcome to our refreshed Hackney Carriage and Private Hire pages</p>
+      <p>We've introduced a new and improved experience designed to make accessing information and services easier than ever.</p>
+      <p>We're keen to hear your thoughts. Your feedback will help us continue to improve and ensure these pages meet your needs.</p>
+    </div>
+    <!-- Feedback form not yet live — replace href with the real destination URL once available -->
+    <a href="#" class="update-banner-btn">Give Feedback</a>
+  </div>
+</div>
 
 <main id="main-content">
 <div class="page">

--- a/Taxi website/Webpages/gcc-hcph-wav.html
+++ b/Taxi website/Webpages/gcc-hcph-wav.html
@@ -45,6 +45,18 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;c
 .bc-item a{color:var(--link);display:inline-flex;align-items:center;min-height:24px;padding:2px 0}
 .bc-item+.bc-item::before{content:"›";color:var(--muted)}
 .bc-cur{color:var(--text);font-weight:600}
+/* ── UPDATE BANNER ──────────────────────────────────────────── */
+.update-banner{background:#EFF6FC;border-top:4px solid var(--blue);border-bottom:1px solid var(--divider)}
+.update-banner-in{max-width:var(--max);margin:0 auto;padding:var(--sp4);display:flex;flex-wrap:wrap;align-items:center;gap:var(--sp4)}
+.update-banner-copy{flex:1 1 360px}
+.update-banner-title{margin:0 0 var(--sp2);font-size:var(--t-md);font-weight:700;color:var(--text)}
+.update-banner-copy p:not(.update-banner-title){margin:0 0 var(--sp2);font-size:var(--t-body);color:var(--text2)}
+.update-banner-copy p:last-child{margin-bottom:0}
+.update-banner-btn{flex:0 0 auto;display:inline-flex;align-items:center;justify-content:center;background:var(--blue);color:var(--white);text-decoration:none;font-weight:700;padding:10px var(--sp4);min-height:var(--touch);white-space:nowrap}
+.update-banner-btn:hover{background:var(--hover);color:var(--white);text-decoration:none}
+.update-banner-btn:visited{color:var(--white)}
+.update-banner-btn:focus-visible{outline:3px solid #FFDD00;outline-offset:0;background:#FFDD00;color:var(--text)}
+@media (max-width:600px){.update-banner-btn{width:100%}}
 .page{max-width:var(--max);margin:0 auto;padding:var(--sp5) var(--sp4) var(--sp7)}
 .back{display:inline-flex;align-items:center;gap:var(--sp1);font-size:var(--t-sm);color:var(--link);text-decoration:none;margin-bottom:var(--sp5);min-height:var(--touch);padding:var(--sp1) 0}
 .back::before{content:"‹";font-size:1.2em}
@@ -162,6 +174,18 @@ h1{font-size:var(--t-h1);font-weight:700;color:var(--deep);margin-bottom:var(--s
     <li class="bc-item"><span class="bc-cur" aria-current="page">Wheelchair accessible vehicles</span></li>
   </ol></div>
 </nav>
+
+<div class="update-banner" role="region" aria-labelledby="update-banner-title">
+  <div class="update-banner-in">
+    <div class="update-banner-copy">
+      <p class="update-banner-title" id="update-banner-title">Welcome to our refreshed Hackney Carriage and Private Hire pages</p>
+      <p>We've introduced a new and improved experience designed to make accessing information and services easier than ever.</p>
+      <p>We're keen to hear your thoughts. Your feedback will help us continue to improve and ensure these pages meet your needs.</p>
+    </div>
+    <!-- Feedback form not yet live — replace href with the real destination URL once available -->
+    <a href="#" class="update-banner-btn">Give Feedback</a>
+  </div>
+</div>
 
 <main id="main-content">
 <div class="page">

--- a/Taxi website/Webpages/gcc-operator-licence.html
+++ b/Taxi website/Webpages/gcc-operator-licence.html
@@ -153,6 +153,30 @@ a:focus-visible { color:var(--text) }
 .bc-item+.bc-item::before { content:"›"; color:var(--muted) }
 .bc-item a { color:var(--link); display:inline-flex; align-items:center; min-height:24px; padding:2px 0 }
 .bc-cur { color:var(--text2); font-weight:700 }
+/* ── UPDATE BANNER ──────────────────────────────────────────── */
+.update-banner { background:#EFF6FC; border-top:4px solid var(--blue); border-bottom:1px solid var(--divider) }
+.update-banner-in {
+  max-width:var(--max); margin:0 auto; padding:var(--sp4);
+  display:flex; flex-wrap:wrap; align-items:center; gap:var(--sp4);
+}
+.update-banner-copy { flex:1 1 360px }
+.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--text) }
+.update-banner-copy p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:var(--text2) }
+.update-banner-copy p:last-child { margin-bottom:0 }
+.update-banner-btn {
+  flex:0 0 auto; display:inline-flex; align-items:center; justify-content:center;
+  background:var(--blue); color:var(--white); text-decoration:none; font-weight:700;
+  padding:var(--btn-pad-v) var(--sp4); min-height:var(--touch); white-space:nowrap;
+}
+.update-banner-btn:hover { background:var(--hover); color:var(--white); text-decoration:none }
+.update-banner-btn:visited { color:var(--white) }
+.update-banner-btn:focus-visible {
+  outline:3px solid var(--focus); outline-offset:0;
+  background:var(--focus); color:var(--text);
+}
+@media (max-width:600px) {
+  .update-banner-btn { width:100% }
+}
 
 /* ── PAGE LAYOUT ────────────────────────────────────────────── */
 .page { max-width:var(--max); margin:0 auto; padding:var(--sp5) var(--sp4) var(--sp7) }
@@ -387,6 +411,18 @@ a:focus-visible { color:var(--text) }
     <li class="bc-item"><span class="bc-cur" aria-current="page">Private hire operator licence</span></li>
   </ol></div>
 </nav>
+
+<div class="update-banner" role="region" aria-labelledby="update-banner-title">
+  <div class="update-banner-in">
+    <div class="update-banner-copy">
+      <p class="update-banner-title" id="update-banner-title">Welcome to our refreshed Hackney Carriage and Private Hire pages</p>
+      <p>We've introduced a new and improved experience designed to make accessing information and services easier than ever.</p>
+      <p>We're keen to hear your thoughts. Your feedback will help us continue to improve and ensure these pages meet your needs.</p>
+    </div>
+    <!-- Feedback form not yet live — replace href with the real destination URL once available -->
+    <a href="#" class="update-banner-btn">Give Feedback</a>
+  </div>
+</div>
 
 <main id="main-content">
 <div class="page">

--- a/Taxi website/Webpages/gcc-vehicle-licence.html
+++ b/Taxi website/Webpages/gcc-vehicle-licence.html
@@ -153,6 +153,30 @@ a:focus-visible { color:var(--text) }
 .bc-item+.bc-item::before { content:"›"; color:var(--muted) }
 .bc-item a { color:var(--link); display:inline-flex; align-items:center; min-height:24px; padding:2px 0 }
 .bc-cur { color:var(--text2); font-weight:700 }
+/* ── UPDATE BANNER ──────────────────────────────────────────── */
+.update-banner { background:#EFF6FC; border-top:4px solid var(--blue); border-bottom:1px solid var(--divider) }
+.update-banner-in {
+  max-width:var(--max); margin:0 auto; padding:var(--sp4);
+  display:flex; flex-wrap:wrap; align-items:center; gap:var(--sp4);
+}
+.update-banner-copy { flex:1 1 360px }
+.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--text) }
+.update-banner-copy p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:var(--text2) }
+.update-banner-copy p:last-child { margin-bottom:0 }
+.update-banner-btn {
+  flex:0 0 auto; display:inline-flex; align-items:center; justify-content:center;
+  background:var(--blue); color:var(--white); text-decoration:none; font-weight:700;
+  padding:var(--btn-pad-v) var(--sp4); min-height:var(--touch); white-space:nowrap;
+}
+.update-banner-btn:hover { background:var(--hover); color:var(--white); text-decoration:none }
+.update-banner-btn:visited { color:var(--white) }
+.update-banner-btn:focus-visible {
+  outline:3px solid var(--focus); outline-offset:0;
+  background:var(--focus); color:var(--text);
+}
+@media (max-width:600px) {
+  .update-banner-btn { width:100% }
+}
 
 /* ── PAGE LAYOUT ────────────────────────────────────────────── */
 .page { max-width:var(--max); margin:0 auto; padding:var(--sp5) var(--sp4) var(--sp7) }
@@ -452,6 +476,18 @@ a:focus-visible { color:var(--text) }
     <li class="bc-item"><span class="bc-cur" aria-current="page">Vehicle licence</span></li>
   </ol></div>
 </nav>
+
+<div class="update-banner" role="region" aria-labelledby="update-banner-title">
+  <div class="update-banner-in">
+    <div class="update-banner-copy">
+      <p class="update-banner-title" id="update-banner-title">Welcome to our refreshed Hackney Carriage and Private Hire pages</p>
+      <p>We've introduced a new and improved experience designed to make accessing information and services easier than ever.</p>
+      <p>We're keen to hear your thoughts. Your feedback will help us continue to improve and ensure these pages meet your needs.</p>
+    </div>
+    <!-- Feedback form not yet live — replace href with the real destination URL once available -->
+    <a href="#" class="update-banner-btn">Give Feedback</a>
+  </div>
+</div>
 
 <main id="main-content">
 <div class="page">


### PR DESCRIPTION
## Summary
- Adds a notification banner to all 11 taxi licensing pages, sitting between the breadcrumb and the main content — before the H1 — so it's seen once on arrival without interrupting the task flow (back link/H1 follow immediately beneath it)
- Copy: "Welcome to our refreshed Hackney Carriage and Private Hire pages", intro text, feedback ask, and a "Give Feedback" button
- Follows the same pattern GOV.UK uses for beta banners/service notifications: a distinct region, not part of navigation or page content
- The banner title is a styled paragraph (not a heading element) so it doesn't disrupt the page's H1-first heading hierarchy (WCAG 1.3.1)
- Verified consistent rendering, 44px+ button target size, and GDS-style focus-visible styling across all three stylesheet variants used on the site (main 8-page stylesheet, landing's variant, wav/register's variant)

## Note
- The "Give Feedback" button currently links to `#` as a placeholder — no feedback form exists yet. This needs a real destination URL before launch; flagging for follow-up once one is available.

## Test plan
- [x] Verified via grep that the banner markup/CSS was inserted exactly once per file, in the right location, across all 11 pages
- [x] Verified opening/closing tag balance is unaffected
- [x] Verified with Playwright (image load mocked to rule out this sandbox's blocked external-image fetch) that the banner renders correctly and consistently on all three CSS variants
- [x] Verified the feedback button meets the 44px minimum touch target size and shows the standard yellow GDS focus indicator on keyboard focus


---
_Generated by [Claude Code](https://claude.ai/code/session_01CmXBkt59tXj7B2g1x81yQX)_