### PR TITLE
Make the refresh banner stand out with a solid blue background

### DIFF
--- a/Taxi website/Webpages/gcc-approved-garages.html
+++ b/Taxi website/Webpages/gcc-approved-garages.html
@@ -154,22 +154,22 @@ a:focus-visible { color:var(--text) }
 .bc-item a { color:var(--link); display:inline-flex; align-items:center; min-height:24px; padding:2px 0 }
 .bc-cur { color:var(--text2); font-weight:700 }
 /* ── UPDATE BANNER ──────────────────────────────────────────── */
-.update-banner { background:#EFF6FC; border-top:4px solid var(--blue); border-bottom:1px solid var(--divider) }
+.update-banner { background:var(--blue); border-bottom:4px solid var(--hover) }
 .update-banner-in {
   max-width:var(--max); margin:0 auto; padding:var(--sp4);
   display:flex; flex-wrap:wrap; align-items:center; gap:var(--sp4);
 }
 .update-banner-copy { flex:1 1 360px }
-.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--text) }
-.update-banner-copy p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:var(--text2) }
+.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--white) }
+.update-banner-copy p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:rgba(255,255,255,.88) }
 .update-banner-copy p:last-child { margin-bottom:0 }
 .update-banner-btn {
   flex:0 0 auto; display:inline-flex; align-items:center; justify-content:center;
-  background:var(--blue); color:var(--white); text-decoration:none; font-weight:700;
+  background:var(--white); color:var(--blue); text-decoration:none; font-weight:700;
   padding:var(--btn-pad-v) var(--sp4); min-height:var(--touch); white-space:nowrap;
 }
-.update-banner-btn:hover { background:var(--hover); color:var(--white); text-decoration:none }
-.update-banner-btn:visited { color:var(--white) }
+.update-banner-btn:hover { background:var(--grey); color:var(--hover); text-decoration:none }
+.update-banner-btn:visited { color:var(--blue) }
 .update-banner-btn:focus-visible {
   outline:3px solid var(--focus); outline-offset:0;
   background:var(--focus); color:var(--text);

--- a/Taxi website/Webpages/gcc-driver-licence.html
+++ b/Taxi website/Webpages/gcc-driver-licence.html
@@ -154,22 +154,22 @@ a:focus-visible { color:var(--text) }
 .bc-item a { color:var(--link); display:inline-flex; align-items:center; min-height:24px; padding:2px 0 }
 .bc-cur { color:var(--text2); font-weight:700 }
 /* ── UPDATE BANNER ──────────────────────────────────────────── */
-.update-banner { background:#EFF6FC; border-top:4px solid var(--blue); border-bottom:1px solid var(--divider) }
+.update-banner { background:var(--blue); border-bottom:4px solid var(--hover) }
 .update-banner-in {
   max-width:var(--max); margin:0 auto; padding:var(--sp4);
   display:flex; flex-wrap:wrap; align-items:center; gap:var(--sp4);
 }
 .update-banner-copy { flex:1 1 360px }
-.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--text) }
-.update-banner-copy p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:var(--text2) }
+.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--white) }
+.update-banner-copy p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:rgba(255,255,255,.88) }
 .update-banner-copy p:last-child { margin-bottom:0 }
 .update-banner-btn {
   flex:0 0 auto; display:inline-flex; align-items:center; justify-content:center;
-  background:var(--blue); color:var(--white); text-decoration:none; font-weight:700;
+  background:var(--white); color:var(--blue); text-decoration:none; font-weight:700;
   padding:var(--btn-pad-v) var(--sp4); min-height:var(--touch); white-space:nowrap;
 }
-.update-banner-btn:hover { background:var(--hover); color:var(--white); text-decoration:none }
-.update-banner-btn:visited { color:var(--white) }
+.update-banner-btn:hover { background:var(--grey); color:var(--hover); text-decoration:none }
+.update-banner-btn:visited { color:var(--blue) }
 .update-banner-btn:focus-visible {
   outline:3px solid var(--focus); outline-offset:0;
   background:var(--focus); color:var(--text);

--- a/Taxi website/Webpages/gcc-hcph-changes.html
+++ b/Taxi website/Webpages/gcc-hcph-changes.html
@@ -154,22 +154,22 @@ a:focus-visible { color:var(--text) }
 .bc-item a { color:var(--link); display:inline-flex; align-items:center; min-height:24px; padding:2px 0 }
 .bc-cur { color:var(--text2); font-weight:700 }
 /* ── UPDATE BANNER ──────────────────────────────────────────── */
-.update-banner { background:#EFF6FC; border-top:4px solid var(--blue); border-bottom:1px solid var(--divider) }
+.update-banner { background:var(--blue); border-bottom:4px solid var(--hover) }
 .update-banner-in {
   max-width:var(--max); margin:0 auto; padding:var(--sp4);
   display:flex; flex-wrap:wrap; align-items:center; gap:var(--sp4);
 }
 .update-banner-copy { flex:1 1 360px }
-.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--text) }
-.update-banner-copy p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:var(--text2) }
+.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--white) }
+.update-banner-copy p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:rgba(255,255,255,.88) }
 .update-banner-copy p:last-child { margin-bottom:0 }
 .update-banner-btn {
   flex:0 0 auto; display:inline-flex; align-items:center; justify-content:center;
-  background:var(--blue); color:var(--white); text-decoration:none; font-weight:700;
+  background:var(--white); color:var(--blue); text-decoration:none; font-weight:700;
   padding:var(--btn-pad-v) var(--sp4); min-height:var(--touch); white-space:nowrap;
 }
-.update-banner-btn:hover { background:var(--hover); color:var(--white); text-decoration:none }
-.update-banner-btn:visited { color:var(--white) }
+.update-banner-btn:hover { background:var(--grey); color:var(--hover); text-decoration:none }
+.update-banner-btn:visited { color:var(--blue) }
 .update-banner-btn:focus-visible {
   outline:3px solid var(--focus); outline-offset:0;
   background:var(--focus); color:var(--text);

--- a/Taxi website/Webpages/gcc-hcph-documents.html
+++ b/Taxi website/Webpages/gcc-hcph-documents.html
@@ -154,22 +154,22 @@ a:focus-visible { color:var(--text) }
 .bc-item a { color:var(--link); display:inline-flex; align-items:center; min-height:24px; padding:2px 0 }
 .bc-cur { color:var(--text2); font-weight:700 }
 /* ── UPDATE BANNER ──────────────────────────────────────────── */
-.update-banner { background:#EFF6FC; border-top:4px solid var(--blue); border-bottom:1px solid var(--divider) }
+.update-banner { background:var(--blue); border-bottom:4px solid var(--hover) }
 .update-banner-in {
   max-width:var(--max); margin:0 auto; padding:var(--sp4);
   display:flex; flex-wrap:wrap; align-items:center; gap:var(--sp4);
 }
 .update-banner-copy { flex:1 1 360px }
-.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--text) }
-.update-banner-copy p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:var(--text2) }
+.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--white) }
+.update-banner-copy p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:rgba(255,255,255,.88) }
 .update-banner-copy p:last-child { margin-bottom:0 }
 .update-banner-btn {
   flex:0 0 auto; display:inline-flex; align-items:center; justify-content:center;
-  background:var(--blue); color:var(--white); text-decoration:none; font-weight:700;
+  background:var(--white); color:var(--blue); text-decoration:none; font-weight:700;
   padding:var(--btn-pad-v) var(--sp4); min-height:var(--touch); white-space:nowrap;
 }
-.update-banner-btn:hover { background:var(--hover); color:var(--white); text-decoration:none }
-.update-banner-btn:visited { color:var(--white) }
+.update-banner-btn:hover { background:var(--grey); color:var(--hover); text-decoration:none }
+.update-banner-btn:visited { color:var(--blue) }
 .update-banner-btn:focus-visible {
   outline:3px solid var(--focus); outline-offset:0;
   background:var(--focus); color:var(--text);

--- a/Taxi website/Webpages/gcc-hcph-fees.html
+++ b/Taxi website/Webpages/gcc-hcph-fees.html
@@ -154,22 +154,22 @@ a:focus-visible { color:var(--text) }
 .bc-item a { color:var(--link); display:inline-flex; align-items:center; min-height:24px; padding:2px 0 }
 .bc-cur { color:var(--text2); font-weight:700 }
 /* ── UPDATE BANNER ──────────────────────────────────────────── */
-.update-banner { background:#EFF6FC; border-top:4px solid var(--blue); border-bottom:1px solid var(--divider) }
+.update-banner { background:var(--blue); border-bottom:4px solid var(--hover) }
 .update-banner-in {
   max-width:var(--max); margin:0 auto; padding:var(--sp4);
   display:flex; flex-wrap:wrap; align-items:center; gap:var(--sp4);
 }
 .update-banner-copy { flex:1 1 360px }
-.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--text) }
-.update-banner-copy p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:var(--text2) }
+.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--white) }
+.update-banner-copy p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:rgba(255,255,255,.88) }
 .update-banner-copy p:last-child { margin-bottom:0 }
 .update-banner-btn {
   flex:0 0 auto; display:inline-flex; align-items:center; justify-content:center;
-  background:var(--blue); color:var(--white); text-decoration:none; font-weight:700;
+  background:var(--white); color:var(--blue); text-decoration:none; font-weight:700;
   padding:var(--btn-pad-v) var(--sp4); min-height:var(--touch); white-space:nowrap;
 }
-.update-banner-btn:hover { background:var(--hover); color:var(--white); text-decoration:none }
-.update-banner-btn:visited { color:var(--white) }
+.update-banner-btn:hover { background:var(--grey); color:var(--hover); text-decoration:none }
+.update-banner-btn:visited { color:var(--blue) }
 .update-banner-btn:focus-visible {
   outline:3px solid var(--focus); outline-offset:0;
   background:var(--focus); color:var(--text);

--- a/Taxi website/Webpages/gcc-hcph-landing.html
+++ b/Taxi website/Webpages/gcc-hcph-landing.html
@@ -80,15 +80,15 @@ a:focus-visible{color:var(--text)}
 .bc-item a{color:var(--link);display:inline-flex;align-items:center;min-height:24px;padding:2px 0}
 .bc-cur{color:var(--text2);font-weight:700}
 /* ── UPDATE BANNER ──────────────────────────────────────────── */
-.update-banner{background:#EFF6FC;border-top:4px solid var(--blue);border-bottom:1px solid var(--divider)}
+.update-banner{background:var(--blue);border-bottom:4px solid var(--hover)}
 .update-banner-in{max-width:var(--max);margin:0 auto;padding:var(--sp4);display:flex;flex-wrap:wrap;align-items:center;gap:var(--sp4)}
 .update-banner-copy{flex:1 1 360px}
-.update-banner-title{margin:0 0 var(--sp2);font-size:var(--t-md);font-weight:700;color:var(--text)}
-.update-banner-copy p:not(.update-banner-title){margin:0 0 var(--sp2);font-size:var(--t-body);color:var(--text2)}
+.update-banner-title{margin:0 0 var(--sp2);font-size:var(--t-md);font-weight:700;color:var(--white)}
+.update-banner-copy p:not(.update-banner-title){margin:0 0 var(--sp2);font-size:var(--t-body);color:rgba(255,255,255,.88)}
 .update-banner-copy p:last-child{margin-bottom:0}
-.update-banner-btn{flex:0 0 auto;display:inline-flex;align-items:center;justify-content:center;background:var(--blue);color:var(--white);text-decoration:none;font-weight:700;padding:10px var(--sp4);min-height:var(--touch);white-space:nowrap}
-.update-banner-btn:hover{background:var(--hover);color:var(--white);text-decoration:none}
-.update-banner-btn:visited{color:var(--white)}
+.update-banner-btn{flex:0 0 auto;display:inline-flex;align-items:center;justify-content:center;background:var(--white);color:var(--blue);text-decoration:none;font-weight:700;padding:10px var(--sp4);min-height:var(--touch);white-space:nowrap}
+.update-banner-btn:hover{background:var(--grey);color:var(--hover);text-decoration:none}
+.update-banner-btn:visited{color:var(--blue)}
 .update-banner-btn:focus-visible{outline:3px solid var(--focus);outline-offset:0;background:var(--focus);color:var(--text)}
 @media (max-width:600px){.update-banner-btn{width:100%}}
 

--- a/Taxi website/Webpages/gcc-hcph-passengers.html
+++ b/Taxi website/Webpages/gcc-hcph-passengers.html
@@ -154,22 +154,22 @@ a:focus-visible { color:var(--text) }
 .bc-item a { color:var(--link); display:inline-flex; align-items:center; min-height:24px; padding:2px 0 }
 .bc-cur { color:var(--text2); font-weight:700 }
 /* ── UPDATE BANNER ──────────────────────────────────────────── */
-.update-banner { background:#EFF6FC; border-top:4px solid var(--blue); border-bottom:1px solid var(--divider) }
+.update-banner { background:var(--blue); border-bottom:4px solid var(--hover) }
 .update-banner-in {
   max-width:var(--max); margin:0 auto; padding:var(--sp4);
   display:flex; flex-wrap:wrap; align-items:center; gap:var(--sp4);
 }
 .update-banner-copy { flex:1 1 360px }
-.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--text) }
-.update-banner-copy p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:var(--text2) }
+.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--white) }
+.update-banner-copy p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:rgba(255,255,255,.88) }
 .update-banner-copy p:last-child { margin-bottom:0 }
 .update-banner-btn {
   flex:0 0 auto; display:inline-flex; align-items:center; justify-content:center;
-  background:var(--blue); color:var(--white); text-decoration:none; font-weight:700;
+  background:var(--white); color:var(--blue); text-decoration:none; font-weight:700;
   padding:var(--btn-pad-v) var(--sp4); min-height:var(--touch); white-space:nowrap;
 }
-.update-banner-btn:hover { background:var(--hover); color:var(--white); text-decoration:none }
-.update-banner-btn:visited { color:var(--white) }
+.update-banner-btn:hover { background:var(--grey); color:var(--hover); text-decoration:none }
+.update-banner-btn:visited { color:var(--blue) }
 .update-banner-btn:focus-visible {
   outline:3px solid var(--focus); outline-offset:0;
   background:var(--focus); color:var(--text);

--- a/Taxi website/Webpages/gcc-hcph-register.html
+++ b/Taxi website/Webpages/gcc-hcph-register.html
@@ -46,15 +46,15 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;c
 .bc-item+.bc-item::before{content:"›";color:var(--muted)}
 .bc-cur{color:var(--text);font-weight:600}
 /* ── UPDATE BANNER ──────────────────────────────────────────── */
-.update-banner{background:#EFF6FC;border-top:4px solid var(--blue);border-bottom:1px solid var(--divider)}
+.update-banner{background:var(--blue);border-bottom:4px solid var(--hover)}
 .update-banner-in{max-width:var(--max);margin:0 auto;padding:var(--sp4);display:flex;flex-wrap:wrap;align-items:center;gap:var(--sp4)}
 .update-banner-copy{flex:1 1 360px}
-.update-banner-title{margin:0 0 var(--sp2);font-size:var(--t-md);font-weight:700;color:var(--text)}
-.update-banner-copy p:not(.update-banner-title){margin:0 0 var(--sp2);font-size:var(--t-body);color:var(--text2)}
+.update-banner-title{margin:0 0 var(--sp2);font-size:var(--t-md);font-weight:700;color:var(--white)}
+.update-banner-copy p:not(.update-banner-title){margin:0 0 var(--sp2);font-size:var(--t-body);color:rgba(255,255,255,.88)}
 .update-banner-copy p:last-child{margin-bottom:0}
-.update-banner-btn{flex:0 0 auto;display:inline-flex;align-items:center;justify-content:center;background:var(--blue);color:var(--white);text-decoration:none;font-weight:700;padding:10px var(--sp4);min-height:var(--touch);white-space:nowrap}
-.update-banner-btn:hover{background:var(--hover);color:var(--white);text-decoration:none}
-.update-banner-btn:visited{color:var(--white)}
+.update-banner-btn{flex:0 0 auto;display:inline-flex;align-items:center;justify-content:center;background:var(--white);color:var(--blue);text-decoration:none;font-weight:700;padding:10px var(--sp4);min-height:var(--touch);white-space:nowrap}
+.update-banner-btn:hover{background:var(--grey);color:var(--hover);text-decoration:none}
+.update-banner-btn:visited{color:var(--blue)}
 .update-banner-btn:focus-visible{outline:3px solid #FFDD00;outline-offset:0;background:#FFDD00;color:var(--text)}
 @media (max-width:600px){.update-banner-btn{width:100%}}
 .page{max-width:var(--max);margin:0 auto;padding:var(--sp5) var(--sp4) var(--sp7)}

--- a/Taxi website/Webpages/gcc-hcph-wav.html
+++ b/Taxi website/Webpages/gcc-hcph-wav.html
@@ -46,15 +46,15 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;c
 .bc-item+.bc-item::before{content:"›";color:var(--muted)}
 .bc-cur{color:var(--text);font-weight:600}
 /* ── UPDATE BANNER ──────────────────────────────────────────── */
-.update-banner{background:#EFF6FC;border-top:4px solid var(--blue);border-bottom:1px solid var(--divider)}
+.update-banner{background:var(--blue);border-bottom:4px solid var(--hover)}
 .update-banner-in{max-width:var(--max);margin:0 auto;padding:var(--sp4);display:flex;flex-wrap:wrap;align-items:center;gap:var(--sp4)}
 .update-banner-copy{flex:1 1 360px}
-.update-banner-title{margin:0 0 var(--sp2);font-size:var(--t-md);font-weight:700;color:var(--text)}
-.update-banner-copy p:not(.update-banner-title){margin:0 0 var(--sp2);font-size:var(--t-body);color:var(--text2)}
+.update-banner-title{margin:0 0 var(--sp2);font-size:var(--t-md);font-weight:700;color:var(--white)}
+.update-banner-copy p:not(.update-banner-title){margin:0 0 var(--sp2);font-size:var(--t-body);color:rgba(255,255,255,.88)}
 .update-banner-copy p:last-child{margin-bottom:0}
-.update-banner-btn{flex:0 0 auto;display:inline-flex;align-items:center;justify-content:center;background:var(--blue);color:var(--white);text-decoration:none;font-weight:700;padding:10px var(--sp4);min-height:var(--touch);white-space:nowrap}
-.update-banner-btn:hover{background:var(--hover);color:var(--white);text-decoration:none}
-.update-banner-btn:visited{color:var(--white)}
+.update-banner-btn{flex:0 0 auto;display:inline-flex;align-items:center;justify-content:center;background:var(--white);color:var(--blue);text-decoration:none;font-weight:700;padding:10px var(--sp4);min-height:var(--touch);white-space:nowrap}
+.update-banner-btn:hover{background:var(--grey);color:var(--hover);text-decoration:none}
+.update-banner-btn:visited{color:var(--blue)}
 .update-banner-btn:focus-visible{outline:3px solid #FFDD00;outline-offset:0;background:#FFDD00;color:var(--text)}
 @media (max-width:600px){.update-banner-btn{width:100%}}
 .page{max-width:var(--max);margin:0 auto;padding:var(--sp5) var(--sp4) var(--sp7)}

--- a/Taxi website/Webpages/gcc-operator-licence.html
+++ b/Taxi website/Webpages/gcc-operator-licence.html
@@ -154,22 +154,22 @@ a:focus-visible { color:var(--text) }
 .bc-item a { color:var(--link); display:inline-flex; align-items:center; min-height:24px; padding:2px 0 }
 .bc-cur { color:var(--text2); font-weight:700 }
 /* ── UPDATE BANNER ──────────────────────────────────────────── */
-.update-banner { background:#EFF6FC; border-top:4px solid var(--blue); border-bottom:1px solid var(--divider) }
+.update-banner { background:var(--blue); border-bottom:4px solid var(--hover) }
 .update-banner-in {
   max-width:var(--max); margin:0 auto; padding:var(--sp4);
   display:flex; flex-wrap:wrap; align-items:center; gap:var(--sp4);
 }
 .update-banner-copy { flex:1 1 360px }
-.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--text) }
-.update-banner-copy p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:var(--text2) }
+.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--white) }
+.update-banner-copy p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:rgba(255,255,255,.88) }
 .update-banner-copy p:last-child { margin-bottom:0 }
 .update-banner-btn {
   flex:0 0 auto; display:inline-flex; align-items:center; justify-content:center;
-  background:var(--blue); color:var(--white); text-decoration:none; font-weight:700;
+  background:var(--white); color:var(--blue); text-decoration:none; font-weight:700;
   padding:var(--btn-pad-v) var(--sp4); min-height:var(--touch); white-space:nowrap;
 }
-.update-banner-btn:hover { background:var(--hover); color:var(--white); text-decoration:none }
-.update-banner-btn:visited { color:var(--white) }
+.update-banner-btn:hover { background:var(--grey); color:var(--hover); text-decoration:none }
+.update-banner-btn:visited { color:var(--blue) }
 .update-banner-btn:focus-visible {
   outline:3px solid var(--focus); outline-offset:0;
   background:var(--focus); color:var(--text);

--- a/Taxi website/Webpages/gcc-vehicle-licence.html
+++ b/Taxi website/Webpages/gcc-vehicle-licence.html
@@ -154,22 +154,22 @@ a:focus-visible { color:var(--text) }
 .bc-item a { color:var(--link); display:inline-flex; align-items:center; min-height:24px; padding:2px 0 }
 .bc-cur { color:var(--text2); font-weight:700 }
 /* ── UPDATE BANNER ──────────────────────────────────────────── */
-.update-banner { background:#EFF6FC; border-top:4px solid var(--blue); border-bottom:1px solid var(--divider) }
+.update-banner { background:var(--blue); border-bottom:4px solid var(--hover) }
 .update-banner-in {
   max-width:var(--max); margin:0 auto; padding:var(--sp4);
   display:flex; flex-wrap:wrap; align-items:center; gap:var(--sp4);
 }
 .update-banner-copy { flex:1 1 360px }
-.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--text) }
-.update-banner-copy p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:var(--text2) }
+.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--white) }
+.update-banner-copy p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:rgba(255,255,255,.88) }
 .update-banner-copy p:last-child { margin-bottom:0 }
 .update-banner-btn {
   flex:0 0 auto; display:inline-flex; align-items:center; justify-content:center;
-  background:var(--blue); color:var(--white); text-decoration:none; font-weight:700;
+  background:var(--white); color:var(--blue); text-decoration:none; font-weight:700;
   padding:var(--btn-pad-v) var(--sp4); min-height:var(--touch); white-space:nowrap;
 }
-.update-banner-btn:hover { background:var(--hover); color:var(--white); text-decoration:none }
-.update-banner-btn:visited { color:var(--white) }
+.update-banner-btn:hover { background:var(--grey); color:var(--hover); text-decoration:none }
+.update-banner-btn:visited { color:var(--blue) }
 .update-banner-btn:focus-visible {
   outline:3px solid var(--focus); outline-offset:0;
   background:var(--focus); color:var(--text);


### PR DESCRIPTION
## Summary
- The new refresh-notification banner (added in #113) used a very pale blue tint that blended into the white page background
- Switches it to the site's solid primary brand blue (`--blue`) with white heading/body text and a white "Give Feedback" button with blue text — the same colour pairing already used for the header and CTA buttons elsewhere on the site, so it stays fully on-brand while reading as a clearly distinct section

## Test plan
- [x] Computed contrast ratios: ~7.5:1 for the heading and button text, ~6:1 for the body copy — both comfortably clear of the WCAG AA 4.5:1 minimum for normal text
- [x] Verified with Playwright (image load mocked to rule out this sandbox's blocked external-image fetch) that the banner renders consistently across all three CSS variants used on the site
- [x] Verified the "Give Feedback" button still shows the standard yellow GDS focus indicator, clearly visible against the blue background
- [x] Verified opening/closing tag balance is unaffected


---
_Generated by [Claude Code](https://claude.ai/code/session_01CmXBkt59tXj7B2g1x81yQX)_