### PR TITLE
Restyle refresh banner to cream background with stacked layout

### DIFF
--- a/Taxi website/Webpages/gcc-approved-garages.html
+++ b/Taxi website/Webpages/gcc-approved-garages.html
@@ -154,28 +154,20 @@ a:focus-visible { color:var(--text) }
 .bc-item a { color:var(--link); display:inline-flex; align-items:center; min-height:24px; padding:2px 0 }
 .bc-cur { color:var(--text2); font-weight:700 }
 /* ── UPDATE BANNER ──────────────────────────────────────────── */
-.update-banner { background:var(--blue); border-bottom:4px solid var(--hover) }
-.update-banner-in {
-  max-width:var(--max); margin:0 auto; padding:var(--sp4);
-  display:flex; flex-wrap:wrap; align-items:center; gap:var(--sp4);
-}
-.update-banner-copy { flex:1 1 360px }
-.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--white) }
-.update-banner-copy p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:rgba(255,255,255,.88) }
-.update-banner-copy p:last-child { margin-bottom:0 }
+.update-banner { background:#FFF9E5; border-bottom:1px solid var(--divider) }
+.update-banner-in { max-width:var(--max); margin:0 auto; padding:var(--sp4) }
+.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--deep) }
+.update-banner-in > p:not(.update-banner-title) { margin:0 0 var(--sp2); max-width:70ch; font-size:var(--t-body); color:var(--text2) }
 .update-banner-btn {
-  flex:0 0 auto; display:inline-flex; align-items:center; justify-content:center;
-  background:var(--white); color:var(--blue); text-decoration:none; font-weight:700;
+  display:inline-flex; align-items:center; justify-content:center;
+  background:var(--blue); color:var(--white); text-decoration:none; font-weight:700;
   padding:var(--btn-pad-v) var(--sp4); min-height:var(--touch); white-space:nowrap;
 }
-.update-banner-btn:hover { background:var(--grey); color:var(--hover); text-decoration:none }
-.update-banner-btn:visited { color:var(--blue) }
+.update-banner-btn:hover { background:var(--hover); color:var(--white); text-decoration:none }
+.update-banner-btn:visited { color:var(--white) }
 .update-banner-btn:focus-visible {
   outline:3px solid var(--focus); outline-offset:0;
   background:var(--focus); color:var(--text);
-}
-@media (max-width:600px) {
-  .update-banner-btn { width:100% }
 }
 
 /* ── PAGE LAYOUT ────────────────────────────────────────────── */
@@ -537,11 +529,9 @@ a:focus-visible { color:var(--text) }
 
 <div class="update-banner" role="region" aria-labelledby="update-banner-title">
   <div class="update-banner-in">
-    <div class="update-banner-copy">
-      <p class="update-banner-title" id="update-banner-title">Welcome to our refreshed Hackney Carriage and Private Hire pages</p>
-      <p>We've introduced a new and improved experience designed to make accessing information and services easier than ever.</p>
-      <p>We're keen to hear your thoughts. Your feedback will help us continue to improve and ensure these pages meet your needs.</p>
-    </div>
+    <p class="update-banner-title" id="update-banner-title">Welcome to our refreshed Hackney Carriage and Private Hire pages</p>
+    <p>We've introduced a new and improved experience designed to make accessing information and services easier than ever.</p>
+    <p>We're keen to hear your thoughts. Your feedback will help us continue to improve and ensure these pages meet your needs.</p>
     <!-- Feedback form not yet live — replace href with the real destination URL once available -->
     <a href="#" class="update-banner-btn">Give Feedback</a>
   </div>

--- a/Taxi website/Webpages/gcc-driver-licence.html
+++ b/Taxi website/Webpages/gcc-driver-licence.html
@@ -154,28 +154,20 @@ a:focus-visible { color:var(--text) }
 .bc-item a { color:var(--link); display:inline-flex; align-items:center; min-height:24px; padding:2px 0 }
 .bc-cur { color:var(--text2); font-weight:700 }
 /* ── UPDATE BANNER ──────────────────────────────────────────── */
-.update-banner { background:var(--blue); border-bottom:4px solid var(--hover) }
-.update-banner-in {
-  max-width:var(--max); margin:0 auto; padding:var(--sp4);
-  display:flex; flex-wrap:wrap; align-items:center; gap:var(--sp4);
-}
-.update-banner-copy { flex:1 1 360px }
-.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--white) }
-.update-banner-copy p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:rgba(255,255,255,.88) }
-.update-banner-copy p:last-child { margin-bottom:0 }
+.update-banner { background:#FFF9E5; border-bottom:1px solid var(--divider) }
+.update-banner-in { max-width:var(--max); margin:0 auto; padding:var(--sp4) }
+.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--deep) }
+.update-banner-in > p:not(.update-banner-title) { margin:0 0 var(--sp2); max-width:70ch; font-size:var(--t-body); color:var(--text2) }
 .update-banner-btn {
-  flex:0 0 auto; display:inline-flex; align-items:center; justify-content:center;
-  background:var(--white); color:var(--blue); text-decoration:none; font-weight:700;
+  display:inline-flex; align-items:center; justify-content:center;
+  background:var(--blue); color:var(--white); text-decoration:none; font-weight:700;
   padding:var(--btn-pad-v) var(--sp4); min-height:var(--touch); white-space:nowrap;
 }
-.update-banner-btn:hover { background:var(--grey); color:var(--hover); text-decoration:none }
-.update-banner-btn:visited { color:var(--blue) }
+.update-banner-btn:hover { background:var(--hover); color:var(--white); text-decoration:none }
+.update-banner-btn:visited { color:var(--white) }
 .update-banner-btn:focus-visible {
   outline:3px solid var(--focus); outline-offset:0;
   background:var(--focus); color:var(--text);
-}
-@media (max-width:600px) {
-  .update-banner-btn { width:100% }
 }
 
 /* ── PAGE LAYOUT ────────────────────────────────────────────── */
@@ -479,11 +471,9 @@ a:focus-visible { color:var(--text) }
 
 <div class="update-banner" role="region" aria-labelledby="update-banner-title">
   <div class="update-banner-in">
-    <div class="update-banner-copy">
-      <p class="update-banner-title" id="update-banner-title">Welcome to our refreshed Hackney Carriage and Private Hire pages</p>
-      <p>We've introduced a new and improved experience designed to make accessing information and services easier than ever.</p>
-      <p>We're keen to hear your thoughts. Your feedback will help us continue to improve and ensure these pages meet your needs.</p>
-    </div>
+    <p class="update-banner-title" id="update-banner-title">Welcome to our refreshed Hackney Carriage and Private Hire pages</p>
+    <p>We've introduced a new and improved experience designed to make accessing information and services easier than ever.</p>
+    <p>We're keen to hear your thoughts. Your feedback will help us continue to improve and ensure these pages meet your needs.</p>
     <!-- Feedback form not yet live — replace href with the real destination URL once available -->
     <a href="#" class="update-banner-btn">Give Feedback</a>
   </div>

--- a/Taxi website/Webpages/gcc-hcph-changes.html
+++ b/Taxi website/Webpages/gcc-hcph-changes.html
@@ -154,28 +154,20 @@ a:focus-visible { color:var(--text) }
 .bc-item a { color:var(--link); display:inline-flex; align-items:center; min-height:24px; padding:2px 0 }
 .bc-cur { color:var(--text2); font-weight:700 }
 /* ── UPDATE BANNER ──────────────────────────────────────────── */
-.update-banner { background:var(--blue); border-bottom:4px solid var(--hover) }
-.update-banner-in {
-  max-width:var(--max); margin:0 auto; padding:var(--sp4);
-  display:flex; flex-wrap:wrap; align-items:center; gap:var(--sp4);
-}
-.update-banner-copy { flex:1 1 360px }
-.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--white) }
-.update-banner-copy p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:rgba(255,255,255,.88) }
-.update-banner-copy p:last-child { margin-bottom:0 }
+.update-banner { background:#FFF9E5; border-bottom:1px solid var(--divider) }
+.update-banner-in { max-width:var(--max); margin:0 auto; padding:var(--sp4) }
+.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--deep) }
+.update-banner-in > p:not(.update-banner-title) { margin:0 0 var(--sp2); max-width:70ch; font-size:var(--t-body); color:var(--text2) }
 .update-banner-btn {
-  flex:0 0 auto; display:inline-flex; align-items:center; justify-content:center;
-  background:var(--white); color:var(--blue); text-decoration:none; font-weight:700;
+  display:inline-flex; align-items:center; justify-content:center;
+  background:var(--blue); color:var(--white); text-decoration:none; font-weight:700;
   padding:var(--btn-pad-v) var(--sp4); min-height:var(--touch); white-space:nowrap;
 }
-.update-banner-btn:hover { background:var(--grey); color:var(--hover); text-decoration:none }
-.update-banner-btn:visited { color:var(--blue) }
+.update-banner-btn:hover { background:var(--hover); color:var(--white); text-decoration:none }
+.update-banner-btn:visited { color:var(--white) }
 .update-banner-btn:focus-visible {
   outline:3px solid var(--focus); outline-offset:0;
   background:var(--focus); color:var(--text);
-}
-@media (max-width:600px) {
-  .update-banner-btn { width:100% }
 }
 
 /* ── PAGE LAYOUT ────────────────────────────────────────────── */
@@ -500,11 +492,9 @@ a:focus-visible { color:var(--text) }
 
 <div class="update-banner" role="region" aria-labelledby="update-banner-title">
   <div class="update-banner-in">
-    <div class="update-banner-copy">
-      <p class="update-banner-title" id="update-banner-title">Welcome to our refreshed Hackney Carriage and Private Hire pages</p>
-      <p>We've introduced a new and improved experience designed to make accessing information and services easier than ever.</p>
-      <p>We're keen to hear your thoughts. Your feedback will help us continue to improve and ensure these pages meet your needs.</p>
-    </div>
+    <p class="update-banner-title" id="update-banner-title">Welcome to our refreshed Hackney Carriage and Private Hire pages</p>
+    <p>We've introduced a new and improved experience designed to make accessing information and services easier than ever.</p>
+    <p>We're keen to hear your thoughts. Your feedback will help us continue to improve and ensure these pages meet your needs.</p>
     <!-- Feedback form not yet live — replace href with the real destination URL once available -->
     <a href="#" class="update-banner-btn">Give Feedback</a>
   </div>

--- a/Taxi website/Webpages/gcc-hcph-documents.html
+++ b/Taxi website/Webpages/gcc-hcph-documents.html
@@ -154,28 +154,20 @@ a:focus-visible { color:var(--text) }
 .bc-item a { color:var(--link); display:inline-flex; align-items:center; min-height:24px; padding:2px 0 }
 .bc-cur { color:var(--text2); font-weight:700 }
 /* ── UPDATE BANNER ──────────────────────────────────────────── */
-.update-banner { background:var(--blue); border-bottom:4px solid var(--hover) }
-.update-banner-in {
-  max-width:var(--max); margin:0 auto; padding:var(--sp4);
-  display:flex; flex-wrap:wrap; align-items:center; gap:var(--sp4);
-}
-.update-banner-copy { flex:1 1 360px }
-.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--white) }
-.update-banner-copy p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:rgba(255,255,255,.88) }
-.update-banner-copy p:last-child { margin-bottom:0 }
+.update-banner { background:#FFF9E5; border-bottom:1px solid var(--divider) }
+.update-banner-in { max-width:var(--max); margin:0 auto; padding:var(--sp4) }
+.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--deep) }
+.update-banner-in > p:not(.update-banner-title) { margin:0 0 var(--sp2); max-width:70ch; font-size:var(--t-body); color:var(--text2) }
 .update-banner-btn {
-  flex:0 0 auto; display:inline-flex; align-items:center; justify-content:center;
-  background:var(--white); color:var(--blue); text-decoration:none; font-weight:700;
+  display:inline-flex; align-items:center; justify-content:center;
+  background:var(--blue); color:var(--white); text-decoration:none; font-weight:700;
   padding:var(--btn-pad-v) var(--sp4); min-height:var(--touch); white-space:nowrap;
 }
-.update-banner-btn:hover { background:var(--grey); color:var(--hover); text-decoration:none }
-.update-banner-btn:visited { color:var(--blue) }
+.update-banner-btn:hover { background:var(--hover); color:var(--white); text-decoration:none }
+.update-banner-btn:visited { color:var(--white) }
 .update-banner-btn:focus-visible {
   outline:3px solid var(--focus); outline-offset:0;
   background:var(--focus); color:var(--text);
-}
-@media (max-width:600px) {
-  .update-banner-btn { width:100% }
 }
 
 /* ── PAGE LAYOUT ────────────────────────────────────────────── */
@@ -534,11 +526,9 @@ a:focus-visible { color:var(--text) }
 
 <div class="update-banner" role="region" aria-labelledby="update-banner-title">
   <div class="update-banner-in">
-    <div class="update-banner-copy">
-      <p class="update-banner-title" id="update-banner-title">Welcome to our refreshed Hackney Carriage and Private Hire pages</p>
-      <p>We've introduced a new and improved experience designed to make accessing information and services easier than ever.</p>
-      <p>We're keen to hear your thoughts. Your feedback will help us continue to improve and ensure these pages meet your needs.</p>
-    </div>
+    <p class="update-banner-title" id="update-banner-title">Welcome to our refreshed Hackney Carriage and Private Hire pages</p>
+    <p>We've introduced a new and improved experience designed to make accessing information and services easier than ever.</p>
+    <p>We're keen to hear your thoughts. Your feedback will help us continue to improve and ensure these pages meet your needs.</p>
     <!-- Feedback form not yet live — replace href with the real destination URL once available -->
     <a href="#" class="update-banner-btn">Give Feedback</a>
   </div>

--- a/Taxi website/Webpages/gcc-hcph-fees.html
+++ b/Taxi website/Webpages/gcc-hcph-fees.html
@@ -154,28 +154,20 @@ a:focus-visible { color:var(--text) }
 .bc-item a { color:var(--link); display:inline-flex; align-items:center; min-height:24px; padding:2px 0 }
 .bc-cur { color:var(--text2); font-weight:700 }
 /* ── UPDATE BANNER ──────────────────────────────────────────── */
-.update-banner { background:var(--blue); border-bottom:4px solid var(--hover) }
-.update-banner-in {
-  max-width:var(--max); margin:0 auto; padding:var(--sp4);
-  display:flex; flex-wrap:wrap; align-items:center; gap:var(--sp4);
-}
-.update-banner-copy { flex:1 1 360px }
-.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--white) }
-.update-banner-copy p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:rgba(255,255,255,.88) }
-.update-banner-copy p:last-child { margin-bottom:0 }
+.update-banner { background:#FFF9E5; border-bottom:1px solid var(--divider) }
+.update-banner-in { max-width:var(--max); margin:0 auto; padding:var(--sp4) }
+.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--deep) }
+.update-banner-in > p:not(.update-banner-title) { margin:0 0 var(--sp2); max-width:70ch; font-size:var(--t-body); color:var(--text2) }
 .update-banner-btn {
-  flex:0 0 auto; display:inline-flex; align-items:center; justify-content:center;
-  background:var(--white); color:var(--blue); text-decoration:none; font-weight:700;
+  display:inline-flex; align-items:center; justify-content:center;
+  background:var(--blue); color:var(--white); text-decoration:none; font-weight:700;
   padding:var(--btn-pad-v) var(--sp4); min-height:var(--touch); white-space:nowrap;
 }
-.update-banner-btn:hover { background:var(--grey); color:var(--hover); text-decoration:none }
-.update-banner-btn:visited { color:var(--blue) }
+.update-banner-btn:hover { background:var(--hover); color:var(--white); text-decoration:none }
+.update-banner-btn:visited { color:var(--white) }
 .update-banner-btn:focus-visible {
   outline:3px solid var(--focus); outline-offset:0;
   background:var(--focus); color:var(--text);
-}
-@media (max-width:600px) {
-  .update-banner-btn { width:100% }
 }
 
 /* ── PAGE LAYOUT ────────────────────────────────────────────── */
@@ -530,11 +522,9 @@ a:focus-visible { color:var(--text) }
 
 <div class="update-banner" role="region" aria-labelledby="update-banner-title">
   <div class="update-banner-in">
-    <div class="update-banner-copy">
-      <p class="update-banner-title" id="update-banner-title">Welcome to our refreshed Hackney Carriage and Private Hire pages</p>
-      <p>We've introduced a new and improved experience designed to make accessing information and services easier than ever.</p>
-      <p>We're keen to hear your thoughts. Your feedback will help us continue to improve and ensure these pages meet your needs.</p>
-    </div>
+    <p class="update-banner-title" id="update-banner-title">Welcome to our refreshed Hackney Carriage and Private Hire pages</p>
+    <p>We've introduced a new and improved experience designed to make accessing information and services easier than ever.</p>
+    <p>We're keen to hear your thoughts. Your feedback will help us continue to improve and ensure these pages meet your needs.</p>
     <!-- Feedback form not yet live — replace href with the real destination URL once available -->
     <a href="#" class="update-banner-btn">Give Feedback</a>
   </div>

--- a/Taxi website/Webpages/gcc-hcph-landing.html
+++ b/Taxi website/Webpages/gcc-hcph-landing.html
@@ -80,17 +80,14 @@ a:focus-visible{color:var(--text)}
 .bc-item a{color:var(--link);display:inline-flex;align-items:center;min-height:24px;padding:2px 0}
 .bc-cur{color:var(--text2);font-weight:700}
 /* ── UPDATE BANNER ──────────────────────────────────────────── */
-.update-banner{background:var(--blue);border-bottom:4px solid var(--hover)}
-.update-banner-in{max-width:var(--max);margin:0 auto;padding:var(--sp4);display:flex;flex-wrap:wrap;align-items:center;gap:var(--sp4)}
-.update-banner-copy{flex:1 1 360px}
-.update-banner-title{margin:0 0 var(--sp2);font-size:var(--t-md);font-weight:700;color:var(--white)}
-.update-banner-copy p:not(.update-banner-title){margin:0 0 var(--sp2);font-size:var(--t-body);color:rgba(255,255,255,.88)}
-.update-banner-copy p:last-child{margin-bottom:0}
-.update-banner-btn{flex:0 0 auto;display:inline-flex;align-items:center;justify-content:center;background:var(--white);color:var(--blue);text-decoration:none;font-weight:700;padding:10px var(--sp4);min-height:var(--touch);white-space:nowrap}
-.update-banner-btn:hover{background:var(--grey);color:var(--hover);text-decoration:none}
-.update-banner-btn:visited{color:var(--blue)}
+.update-banner{background:#FFF9E5;border-bottom:1px solid var(--divider)}
+.update-banner-in{max-width:var(--max);margin:0 auto;padding:var(--sp4)}
+.update-banner-title{margin:0 0 var(--sp2);font-size:var(--t-md);font-weight:700;color:var(--deep)}
+.update-banner-in > p:not(.update-banner-title){margin:0 0 var(--sp2);max-width:70ch;font-size:var(--t-body);color:var(--text2)}
+.update-banner-btn{display:inline-flex;align-items:center;justify-content:center;background:var(--blue);color:var(--white);text-decoration:none;font-weight:700;padding:10px var(--sp4);min-height:var(--touch);white-space:nowrap}
+.update-banner-btn:hover{background:var(--hover);color:var(--white);text-decoration:none}
+.update-banner-btn:visited{color:var(--white)}
 .update-banner-btn:focus-visible{outline:3px solid var(--focus);outline-offset:0;background:var(--focus);color:var(--text)}
-@media (max-width:600px){.update-banner-btn{width:100%}}
 
 /* PAGE */
 .page{max-width:var(--max);margin:0 auto;padding:var(--sp5) var(--sp4) var(--sp7)}
@@ -379,11 +376,9 @@ a:focus-visible{color:var(--text)}
 
 <div class="update-banner" role="region" aria-labelledby="update-banner-title">
   <div class="update-banner-in">
-    <div class="update-banner-copy">
-      <p class="update-banner-title" id="update-banner-title">Welcome to our refreshed Hackney Carriage and Private Hire pages</p>
-      <p>We've introduced a new and improved experience designed to make accessing information and services easier than ever.</p>
-      <p>We're keen to hear your thoughts. Your feedback will help us continue to improve and ensure these pages meet your needs.</p>
-    </div>
+    <p class="update-banner-title" id="update-banner-title">Welcome to our refreshed Hackney Carriage and Private Hire pages</p>
+    <p>We've introduced a new and improved experience designed to make accessing information and services easier than ever.</p>
+    <p>We're keen to hear your thoughts. Your feedback will help us continue to improve and ensure these pages meet your needs.</p>
     <!-- Feedback form not yet live — replace href with the real destination URL once available -->
     <a href="#" class="update-banner-btn">Give Feedback</a>
   </div>

--- a/Taxi website/Webpages/gcc-hcph-passengers.html
+++ b/Taxi website/Webpages/gcc-hcph-passengers.html
@@ -154,28 +154,20 @@ a:focus-visible { color:var(--text) }
 .bc-item a { color:var(--link); display:inline-flex; align-items:center; min-height:24px; padding:2px 0 }
 .bc-cur { color:var(--text2); font-weight:700 }
 /* ── UPDATE BANNER ──────────────────────────────────────────── */
-.update-banner { background:var(--blue); border-bottom:4px solid var(--hover) }
-.update-banner-in {
-  max-width:var(--max); margin:0 auto; padding:var(--sp4);
-  display:flex; flex-wrap:wrap; align-items:center; gap:var(--sp4);
-}
-.update-banner-copy { flex:1 1 360px }
-.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--white) }
-.update-banner-copy p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:rgba(255,255,255,.88) }
-.update-banner-copy p:last-child { margin-bottom:0 }
+.update-banner { background:#FFF9E5; border-bottom:1px solid var(--divider) }
+.update-banner-in { max-width:var(--max); margin:0 auto; padding:var(--sp4) }
+.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--deep) }
+.update-banner-in > p:not(.update-banner-title) { margin:0 0 var(--sp2); max-width:70ch; font-size:var(--t-body); color:var(--text2) }
 .update-banner-btn {
-  flex:0 0 auto; display:inline-flex; align-items:center; justify-content:center;
-  background:var(--white); color:var(--blue); text-decoration:none; font-weight:700;
+  display:inline-flex; align-items:center; justify-content:center;
+  background:var(--blue); color:var(--white); text-decoration:none; font-weight:700;
   padding:var(--btn-pad-v) var(--sp4); min-height:var(--touch); white-space:nowrap;
 }
-.update-banner-btn:hover { background:var(--grey); color:var(--hover); text-decoration:none }
-.update-banner-btn:visited { color:var(--blue) }
+.update-banner-btn:hover { background:var(--hover); color:var(--white); text-decoration:none }
+.update-banner-btn:visited { color:var(--white) }
 .update-banner-btn:focus-visible {
   outline:3px solid var(--focus); outline-offset:0;
   background:var(--focus); color:var(--text);
-}
-@media (max-width:600px) {
-  .update-banner-btn { width:100% }
 }
 
 /* ── PAGE LAYOUT ────────────────────────────────────────────── */
@@ -512,11 +504,9 @@ a:focus-visible { color:var(--text) }
 
 <div class="update-banner" role="region" aria-labelledby="update-banner-title">
   <div class="update-banner-in">
-    <div class="update-banner-copy">
-      <p class="update-banner-title" id="update-banner-title">Welcome to our refreshed Hackney Carriage and Private Hire pages</p>
-      <p>We've introduced a new and improved experience designed to make accessing information and services easier than ever.</p>
-      <p>We're keen to hear your thoughts. Your feedback will help us continue to improve and ensure these pages meet your needs.</p>
-    </div>
+    <p class="update-banner-title" id="update-banner-title">Welcome to our refreshed Hackney Carriage and Private Hire pages</p>
+    <p>We've introduced a new and improved experience designed to make accessing information and services easier than ever.</p>
+    <p>We're keen to hear your thoughts. Your feedback will help us continue to improve and ensure these pages meet your needs.</p>
     <!-- Feedback form not yet live — replace href with the real destination URL once available -->
     <a href="#" class="update-banner-btn">Give Feedback</a>
   </div>

--- a/Taxi website/Webpages/gcc-hcph-register.html
+++ b/Taxi website/Webpages/gcc-hcph-register.html
@@ -46,17 +46,14 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;c
 .bc-item+.bc-item::before{content:"›";color:var(--muted)}
 .bc-cur{color:var(--text);font-weight:600}
 /* ── UPDATE BANNER ──────────────────────────────────────────── */
-.update-banner{background:var(--blue);border-bottom:4px solid var(--hover)}
-.update-banner-in{max-width:var(--max);margin:0 auto;padding:var(--sp4);display:flex;flex-wrap:wrap;align-items:center;gap:var(--sp4)}
-.update-banner-copy{flex:1 1 360px}
-.update-banner-title{margin:0 0 var(--sp2);font-size:var(--t-md);font-weight:700;color:var(--white)}
-.update-banner-copy p:not(.update-banner-title){margin:0 0 var(--sp2);font-size:var(--t-body);color:rgba(255,255,255,.88)}
-.update-banner-copy p:last-child{margin-bottom:0}
-.update-banner-btn{flex:0 0 auto;display:inline-flex;align-items:center;justify-content:center;background:var(--white);color:var(--blue);text-decoration:none;font-weight:700;padding:10px var(--sp4);min-height:var(--touch);white-space:nowrap}
-.update-banner-btn:hover{background:var(--grey);color:var(--hover);text-decoration:none}
-.update-banner-btn:visited{color:var(--blue)}
+.update-banner{background:#FFF9E5;border-bottom:1px solid var(--divider)}
+.update-banner-in{max-width:var(--max);margin:0 auto;padding:var(--sp4)}
+.update-banner-title{margin:0 0 var(--sp2);font-size:var(--t-md);font-weight:700;color:var(--deep)}
+.update-banner-in > p:not(.update-banner-title){margin:0 0 var(--sp2);max-width:70ch;font-size:var(--t-body);color:var(--text2)}
+.update-banner-btn{display:inline-flex;align-items:center;justify-content:center;background:var(--blue);color:var(--white);text-decoration:none;font-weight:700;padding:10px var(--sp4);min-height:var(--touch);white-space:nowrap}
+.update-banner-btn:hover{background:var(--hover);color:var(--white);text-decoration:none}
+.update-banner-btn:visited{color:var(--white)}
 .update-banner-btn:focus-visible{outline:3px solid #FFDD00;outline-offset:0;background:#FFDD00;color:var(--text)}
-@media (max-width:600px){.update-banner-btn{width:100%}}
 .page{max-width:var(--max);margin:0 auto;padding:var(--sp5) var(--sp4) var(--sp7)}
 .back{display:inline-flex;align-items:center;gap:var(--sp1);font-size:var(--t-sm);color:var(--link);text-decoration:none;margin-bottom:var(--sp5);min-height:var(--touch);padding:var(--sp1) 0}
 .back::before{content:"‹";font-size:1.2em}
@@ -179,11 +176,9 @@ tr:last-child td{border-bottom:none}
 
 <div class="update-banner" role="region" aria-labelledby="update-banner-title">
   <div class="update-banner-in">
-    <div class="update-banner-copy">
-      <p class="update-banner-title" id="update-banner-title">Welcome to our refreshed Hackney Carriage and Private Hire pages</p>
-      <p>We've introduced a new and improved experience designed to make accessing information and services easier than ever.</p>
-      <p>We're keen to hear your thoughts. Your feedback will help us continue to improve and ensure these pages meet your needs.</p>
-    </div>
+    <p class="update-banner-title" id="update-banner-title">Welcome to our refreshed Hackney Carriage and Private Hire pages</p>
+    <p>We've introduced a new and improved experience designed to make accessing information and services easier than ever.</p>
+    <p>We're keen to hear your thoughts. Your feedback will help us continue to improve and ensure these pages meet your needs.</p>
     <!-- Feedback form not yet live — replace href with the real destination URL once available -->
     <a href="#" class="update-banner-btn">Give Feedback</a>
   </div>

--- a/Taxi website/Webpages/gcc-hcph-wav.html
+++ b/Taxi website/Webpages/gcc-hcph-wav.html
@@ -46,17 +46,14 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;c
 .bc-item+.bc-item::before{content:"›";color:var(--muted)}
 .bc-cur{color:var(--text);font-weight:600}
 /* ── UPDATE BANNER ──────────────────────────────────────────── */
-.update-banner{background:var(--blue);border-bottom:4px solid var(--hover)}
-.update-banner-in{max-width:var(--max);margin:0 auto;padding:var(--sp4);display:flex;flex-wrap:wrap;align-items:center;gap:var(--sp4)}
-.update-banner-copy{flex:1 1 360px}
-.update-banner-title{margin:0 0 var(--sp2);font-size:var(--t-md);font-weight:700;color:var(--white)}
-.update-banner-copy p:not(.update-banner-title){margin:0 0 var(--sp2);font-size:var(--t-body);color:rgba(255,255,255,.88)}
-.update-banner-copy p:last-child{margin-bottom:0}
-.update-banner-btn{flex:0 0 auto;display:inline-flex;align-items:center;justify-content:center;background:var(--white);color:var(--blue);text-decoration:none;font-weight:700;padding:10px var(--sp4);min-height:var(--touch);white-space:nowrap}
-.update-banner-btn:hover{background:var(--grey);color:var(--hover);text-decoration:none}
-.update-banner-btn:visited{color:var(--blue)}
+.update-banner{background:#FFF9E5;border-bottom:1px solid var(--divider)}
+.update-banner-in{max-width:var(--max);margin:0 auto;padding:var(--sp4)}
+.update-banner-title{margin:0 0 var(--sp2);font-size:var(--t-md);font-weight:700;color:var(--deep)}
+.update-banner-in > p:not(.update-banner-title){margin:0 0 var(--sp2);max-width:70ch;font-size:var(--t-body);color:var(--text2)}
+.update-banner-btn{display:inline-flex;align-items:center;justify-content:center;background:var(--blue);color:var(--white);text-decoration:none;font-weight:700;padding:10px var(--sp4);min-height:var(--touch);white-space:nowrap}
+.update-banner-btn:hover{background:var(--hover);color:var(--white);text-decoration:none}
+.update-banner-btn:visited{color:var(--white)}
 .update-banner-btn:focus-visible{outline:3px solid #FFDD00;outline-offset:0;background:#FFDD00;color:var(--text)}
-@media (max-width:600px){.update-banner-btn{width:100%}}
 .page{max-width:var(--max);margin:0 auto;padding:var(--sp5) var(--sp4) var(--sp7)}
 .back{display:inline-flex;align-items:center;gap:var(--sp1);font-size:var(--t-sm);color:var(--link);text-decoration:none;margin-bottom:var(--sp5);min-height:var(--touch);padding:var(--sp1) 0}
 .back::before{content:"‹";font-size:1.2em}
@@ -177,11 +174,9 @@ h1{font-size:var(--t-h1);font-weight:700;color:var(--deep);margin-bottom:var(--s
 
 <div class="update-banner" role="region" aria-labelledby="update-banner-title">
   <div class="update-banner-in">
-    <div class="update-banner-copy">
-      <p class="update-banner-title" id="update-banner-title">Welcome to our refreshed Hackney Carriage and Private Hire pages</p>
-      <p>We've introduced a new and improved experience designed to make accessing information and services easier than ever.</p>
-      <p>We're keen to hear your thoughts. Your feedback will help us continue to improve and ensure these pages meet your needs.</p>
-    </div>
+    <p class="update-banner-title" id="update-banner-title">Welcome to our refreshed Hackney Carriage and Private Hire pages</p>
+    <p>We've introduced a new and improved experience designed to make accessing information and services easier than ever.</p>
+    <p>We're keen to hear your thoughts. Your feedback will help us continue to improve and ensure these pages meet your needs.</p>
     <!-- Feedback form not yet live — replace href with the real destination URL once available -->
     <a href="#" class="update-banner-btn">Give Feedback</a>
   </div>

--- a/Taxi website/Webpages/gcc-operator-licence.html
+++ b/Taxi website/Webpages/gcc-operator-licence.html
@@ -154,28 +154,20 @@ a:focus-visible { color:var(--text) }
 .bc-item a { color:var(--link); display:inline-flex; align-items:center; min-height:24px; padding:2px 0 }
 .bc-cur { color:var(--text2); font-weight:700 }
 /* ── UPDATE BANNER ──────────────────────────────────────────── */
-.update-banner { background:var(--blue); border-bottom:4px solid var(--hover) }
-.update-banner-in {
-  max-width:var(--max); margin:0 auto; padding:var(--sp4);
-  display:flex; flex-wrap:wrap; align-items:center; gap:var(--sp4);
-}
-.update-banner-copy { flex:1 1 360px }
-.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--white) }
-.update-banner-copy p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:rgba(255,255,255,.88) }
-.update-banner-copy p:last-child { margin-bottom:0 }
+.update-banner { background:#FFF9E5; border-bottom:1px solid var(--divider) }
+.update-banner-in { max-width:var(--max); margin:0 auto; padding:var(--sp4) }
+.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--deep) }
+.update-banner-in > p:not(.update-banner-title) { margin:0 0 var(--sp2); max-width:70ch; font-size:var(--t-body); color:var(--text2) }
 .update-banner-btn {
-  flex:0 0 auto; display:inline-flex; align-items:center; justify-content:center;
-  background:var(--white); color:var(--blue); text-decoration:none; font-weight:700;
+  display:inline-flex; align-items:center; justify-content:center;
+  background:var(--blue); color:var(--white); text-decoration:none; font-weight:700;
   padding:var(--btn-pad-v) var(--sp4); min-height:var(--touch); white-space:nowrap;
 }
-.update-banner-btn:hover { background:var(--grey); color:var(--hover); text-decoration:none }
-.update-banner-btn:visited { color:var(--blue) }
+.update-banner-btn:hover { background:var(--hover); color:var(--white); text-decoration:none }
+.update-banner-btn:visited { color:var(--white) }
 .update-banner-btn:focus-visible {
   outline:3px solid var(--focus); outline-offset:0;
   background:var(--focus); color:var(--text);
-}
-@media (max-width:600px) {
-  .update-banner-btn { width:100% }
 }
 
 /* ── PAGE LAYOUT ────────────────────────────────────────────── */
@@ -414,11 +406,9 @@ a:focus-visible { color:var(--text) }
 
 <div class="update-banner" role="region" aria-labelledby="update-banner-title">
   <div class="update-banner-in">
-    <div class="update-banner-copy">
-      <p class="update-banner-title" id="update-banner-title">Welcome to our refreshed Hackney Carriage and Private Hire pages</p>
-      <p>We've introduced a new and improved experience designed to make accessing information and services easier than ever.</p>
-      <p>We're keen to hear your thoughts. Your feedback will help us continue to improve and ensure these pages meet your needs.</p>
-    </div>
+    <p class="update-banner-title" id="update-banner-title">Welcome to our refreshed Hackney Carriage and Private Hire pages</p>
+    <p>We've introduced a new and improved experience designed to make accessing information and services easier than ever.</p>
+    <p>We're keen to hear your thoughts. Your feedback will help us continue to improve and ensure these pages meet your needs.</p>
     <!-- Feedback form not yet live — replace href with the real destination URL once available -->
     <a href="#" class="update-banner-btn">Give Feedback</a>
   </div>

--- a/Taxi website/Webpages/gcc-vehicle-licence.html
+++ b/Taxi website/Webpages/gcc-vehicle-licence.html
@@ -154,28 +154,20 @@ a:focus-visible { color:var(--text) }
 .bc-item a { color:var(--link); display:inline-flex; align-items:center; min-height:24px; padding:2px 0 }
 .bc-cur { color:var(--text2); font-weight:700 }
 /* ── UPDATE BANNER ──────────────────────────────────────────── */
-.update-banner { background:var(--blue); border-bottom:4px solid var(--hover) }
-.update-banner-in {
-  max-width:var(--max); margin:0 auto; padding:var(--sp4);
-  display:flex; flex-wrap:wrap; align-items:center; gap:var(--sp4);
-}
-.update-banner-copy { flex:1 1 360px }
-.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--white) }
-.update-banner-copy p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:rgba(255,255,255,.88) }
-.update-banner-copy p:last-child { margin-bottom:0 }
+.update-banner { background:#FFF9E5; border-bottom:1px solid var(--divider) }
+.update-banner-in { max-width:var(--max); margin:0 auto; padding:var(--sp4) }
+.update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--deep) }
+.update-banner-in > p:not(.update-banner-title) { margin:0 0 var(--sp2); max-width:70ch; font-size:var(--t-body); color:var(--text2) }
 .update-banner-btn {
-  flex:0 0 auto; display:inline-flex; align-items:center; justify-content:center;
-  background:var(--white); color:var(--blue); text-decoration:none; font-weight:700;
+  display:inline-flex; align-items:center; justify-content:center;
+  background:var(--blue); color:var(--white); text-decoration:none; font-weight:700;
   padding:var(--btn-pad-v) var(--sp4); min-height:var(--touch); white-space:nowrap;
 }
-.update-banner-btn:hover { background:var(--grey); color:var(--hover); text-decoration:none }
-.update-banner-btn:visited { color:var(--blue) }
+.update-banner-btn:hover { background:var(--hover); color:var(--white); text-decoration:none }
+.update-banner-btn:visited { color:var(--white) }
 .update-banner-btn:focus-visible {
   outline:3px solid var(--focus); outline-offset:0;
   background:var(--focus); color:var(--text);
-}
-@media (max-width:600px) {
-  .update-banner-btn { width:100% }
 }
 
 /* ── PAGE LAYOUT ────────────────────────────────────────────── */
@@ -479,11 +471,9 @@ a:focus-visible { color:var(--text) }
 
 <div class="update-banner" role="region" aria-labelledby="update-banner-title">
   <div class="update-banner-in">
-    <div class="update-banner-copy">
-      <p class="update-banner-title" id="update-banner-title">Welcome to our refreshed Hackney Carriage and Private Hire pages</p>
-      <p>We've introduced a new and improved experience designed to make accessing information and services easier than ever.</p>
-      <p>We're keen to hear your thoughts. Your feedback will help us continue to improve and ensure these pages meet your needs.</p>
-    </div>
+    <p class="update-banner-title" id="update-banner-title">Welcome to our refreshed Hackney Carriage and Private Hire pages</p>
+    <p>We've introduced a new and improved experience designed to make accessing information and services easier than ever.</p>
+    <p>We're keen to hear your thoughts. Your feedback will help us continue to improve and ensure these pages meet your needs.</p>
     <!-- Feedback form not yet live — replace href with the real destination URL once available -->
     <a href="#" class="update-banner-btn">Give Feedback</a>
   </div>


### PR DESCRIPTION
## Summary
- Restyles the refresh-notification banner (from #113/#114) to match a reference design: pale cream background (`#FFF9E5`), dark navy heading, muted body text, and a solid blue "Give Feedback" button placed below the copy rather than floated to the right
- Copy text is unchanged from the previously approved wording — this is a style/layout change only

## Test plan
- [x] Computed contrast ratios: 11–13:1 for the heading, ~6.7:1 for body text, 7.5:1 for the button — all comfortably clear of the WCAG AA 4.5:1 minimum
- [x] Verified button meets the 44px minimum touch target height
- [x] Verified with Playwright (image load mocked to rule out this sandbox's blocked external-image fetch) that the banner renders consistently across all three CSS variants used on the site
- [x] Verified opening/closing tag balance is unaffected


---
_Generated by [Claude Code](https://claude.ai/code/session_01CmXBkt59tXj7B2g1x81yQX)_