### PR TITLE
Remove 70ch max-width so banner text stretches full width

### DIFF
--- a/Taxi website/Webpages/gcc-approved-garages.html
+++ b/Taxi website/Webpages/gcc-approved-garages.html
@@ -157,7 +157,7 @@ a:focus-visible { color:var(--text) }
 .update-banner { background:#FFF9E5; border-bottom:1px solid var(--divider) }
 .update-banner-in { max-width:var(--max); margin:0 auto; padding:var(--sp4) }
 .update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--deep) }
-.update-banner-in > p:not(.update-banner-title) { margin:0 0 var(--sp2); max-width:70ch; font-size:var(--t-body); color:var(--text2) }
+.update-banner-in > p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:var(--text2) }
 .update-banner-btn {
   display:inline-flex; align-items:center; justify-content:center;
   background:var(--blue); color:var(--white); text-decoration:none; font-weight:700;

--- a/Taxi website/Webpages/gcc-driver-licence.html
+++ b/Taxi website/Webpages/gcc-driver-licence.html
@@ -157,7 +157,7 @@ a:focus-visible { color:var(--text) }
 .update-banner { background:#FFF9E5; border-bottom:1px solid var(--divider) }
 .update-banner-in { max-width:var(--max); margin:0 auto; padding:var(--sp4) }
 .update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--deep) }
-.update-banner-in > p:not(.update-banner-title) { margin:0 0 var(--sp2); max-width:70ch; font-size:var(--t-body); color:var(--text2) }
+.update-banner-in > p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:var(--text2) }
 .update-banner-btn {
   display:inline-flex; align-items:center; justify-content:center;
   background:var(--blue); color:var(--white); text-decoration:none; font-weight:700;

--- a/Taxi website/Webpages/gcc-hcph-changes.html
+++ b/Taxi website/Webpages/gcc-hcph-changes.html
@@ -157,7 +157,7 @@ a:focus-visible { color:var(--text) }
 .update-banner { background:#FFF9E5; border-bottom:1px solid var(--divider) }
 .update-banner-in { max-width:var(--max); margin:0 auto; padding:var(--sp4) }
 .update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--deep) }
-.update-banner-in > p:not(.update-banner-title) { margin:0 0 var(--sp2); max-width:70ch; font-size:var(--t-body); color:var(--text2) }
+.update-banner-in > p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:var(--text2) }
 .update-banner-btn {
   display:inline-flex; align-items:center; justify-content:center;
   background:var(--blue); color:var(--white); text-decoration:none; font-weight:700;

--- a/Taxi website/Webpages/gcc-hcph-documents.html
+++ b/Taxi website/Webpages/gcc-hcph-documents.html
@@ -157,7 +157,7 @@ a:focus-visible { color:var(--text) }
 .update-banner { background:#FFF9E5; border-bottom:1px solid var(--divider) }
 .update-banner-in { max-width:var(--max); margin:0 auto; padding:var(--sp4) }
 .update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--deep) }
-.update-banner-in > p:not(.update-banner-title) { margin:0 0 var(--sp2); max-width:70ch; font-size:var(--t-body); color:var(--text2) }
+.update-banner-in > p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:var(--text2) }
 .update-banner-btn {
   display:inline-flex; align-items:center; justify-content:center;
   background:var(--blue); color:var(--white); text-decoration:none; font-weight:700;

--- a/Taxi website/Webpages/gcc-hcph-fees.html
+++ b/Taxi website/Webpages/gcc-hcph-fees.html
@@ -157,7 +157,7 @@ a:focus-visible { color:var(--text) }
 .update-banner { background:#FFF9E5; border-bottom:1px solid var(--divider) }
 .update-banner-in { max-width:var(--max); margin:0 auto; padding:var(--sp4) }
 .update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--deep) }
-.update-banner-in > p:not(.update-banner-title) { margin:0 0 var(--sp2); max-width:70ch; font-size:var(--t-body); color:var(--text2) }
+.update-banner-in > p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:var(--text2) }
 .update-banner-btn {
   display:inline-flex; align-items:center; justify-content:center;
   background:var(--blue); color:var(--white); text-decoration:none; font-weight:700;

--- a/Taxi website/Webpages/gcc-hcph-landing.html
+++ b/Taxi website/Webpages/gcc-hcph-landing.html
@@ -83,7 +83,7 @@ a:focus-visible{color:var(--text)}
 .update-banner{background:#FFF9E5;border-bottom:1px solid var(--divider)}
 .update-banner-in{max-width:var(--max);margin:0 auto;padding:var(--sp4)}
 .update-banner-title{margin:0 0 var(--sp2);font-size:var(--t-md);font-weight:700;color:var(--deep)}
-.update-banner-in > p:not(.update-banner-title){margin:0 0 var(--sp2);max-width:70ch;font-size:var(--t-body);color:var(--text2)}
+.update-banner-in > p:not(.update-banner-title){margin:0 0 var(--sp2);font-size:var(--t-body);color:var(--text2)}
 .update-banner-btn{display:inline-flex;align-items:center;justify-content:center;background:var(--blue);color:var(--white);text-decoration:none;font-weight:700;padding:10px var(--sp4);min-height:var(--touch);white-space:nowrap}
 .update-banner-btn:hover{background:var(--hover);color:var(--white);text-decoration:none}
 .update-banner-btn:visited{color:var(--white)}

--- a/Taxi website/Webpages/gcc-hcph-passengers.html
+++ b/Taxi website/Webpages/gcc-hcph-passengers.html
@@ -157,7 +157,7 @@ a:focus-visible { color:var(--text) }
 .update-banner { background:#FFF9E5; border-bottom:1px solid var(--divider) }
 .update-banner-in { max-width:var(--max); margin:0 auto; padding:var(--sp4) }
 .update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--deep) }
-.update-banner-in > p:not(.update-banner-title) { margin:0 0 var(--sp2); max-width:70ch; font-size:var(--t-body); color:var(--text2) }
+.update-banner-in > p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:var(--text2) }
 .update-banner-btn {
   display:inline-flex; align-items:center; justify-content:center;
   background:var(--blue); color:var(--white); text-decoration:none; font-weight:700;

--- a/Taxi website/Webpages/gcc-hcph-register.html
+++ b/Taxi website/Webpages/gcc-hcph-register.html
@@ -49,7 +49,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;c
 .update-banner{background:#FFF9E5;border-bottom:1px solid var(--divider)}
 .update-banner-in{max-width:var(--max);margin:0 auto;padding:var(--sp4)}
 .update-banner-title{margin:0 0 var(--sp2);font-size:var(--t-md);font-weight:700;color:var(--deep)}
-.update-banner-in > p:not(.update-banner-title){margin:0 0 var(--sp2);max-width:70ch;font-size:var(--t-body);color:var(--text2)}
+.update-banner-in > p:not(.update-banner-title){margin:0 0 var(--sp2);font-size:var(--t-body);color:var(--text2)}
 .update-banner-btn{display:inline-flex;align-items:center;justify-content:center;background:var(--blue);color:var(--white);text-decoration:none;font-weight:700;padding:10px var(--sp4);min-height:var(--touch);white-space:nowrap}
 .update-banner-btn:hover{background:var(--hover);color:var(--white);text-decoration:none}
 .update-banner-btn:visited{color:var(--white)}

--- a/Taxi website/Webpages/gcc-hcph-wav.html
+++ b/Taxi website/Webpages/gcc-hcph-wav.html
@@ -49,7 +49,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;c
 .update-banner{background:#FFF9E5;border-bottom:1px solid var(--divider)}
 .update-banner-in{max-width:var(--max);margin:0 auto;padding:var(--sp4)}
 .update-banner-title{margin:0 0 var(--sp2);font-size:var(--t-md);font-weight:700;color:var(--deep)}
-.update-banner-in > p:not(.update-banner-title){margin:0 0 var(--sp2);max-width:70ch;font-size:var(--t-body);color:var(--text2)}
+.update-banner-in > p:not(.update-banner-title){margin:0 0 var(--sp2);font-size:var(--t-body);color:var(--text2)}
 .update-banner-btn{display:inline-flex;align-items:center;justify-content:center;background:var(--blue);color:var(--white);text-decoration:none;font-weight:700;padding:10px var(--sp4);min-height:var(--touch);white-space:nowrap}
 .update-banner-btn:hover{background:var(--hover);color:var(--white);text-decoration:none}
 .update-banner-btn:visited{color:var(--white)}

--- a/Taxi website/Webpages/gcc-operator-licence.html
+++ b/Taxi website/Webpages/gcc-operator-licence.html
@@ -157,7 +157,7 @@ a:focus-visible { color:var(--text) }
 .update-banner { background:#FFF9E5; border-bottom:1px solid var(--divider) }
 .update-banner-in { max-width:var(--max); margin:0 auto; padding:var(--sp4) }
 .update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--deep) }
-.update-banner-in > p:not(.update-banner-title) { margin:0 0 var(--sp2); max-width:70ch; font-size:var(--t-body); color:var(--text2) }
+.update-banner-in > p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:var(--text2) }
 .update-banner-btn {
   display:inline-flex; align-items:center; justify-content:center;
   background:var(--blue); color:var(--white); text-decoration:none; font-weight:700;

--- a/Taxi website/Webpages/gcc-vehicle-licence.html
+++ b/Taxi website/Webpages/gcc-vehicle-licence.html
@@ -157,7 +157,7 @@ a:focus-visible { color:var(--text) }
 .update-banner { background:#FFF9E5; border-bottom:1px solid var(--divider) }
 .update-banner-in { max-width:var(--max); margin:0 auto; padding:var(--sp4) }
 .update-banner-title { margin:0 0 var(--sp2); font-size:var(--t-md); font-weight:700; color:var(--deep) }
-.update-banner-in > p:not(.update-banner-title) { margin:0 0 var(--sp2); max-width:70ch; font-size:var(--t-body); color:var(--text2) }
+.update-banner-in > p:not(.update-banner-title) { margin:0 0 var(--sp2); font-size:var(--t-body); color:var(--text2) }
 .update-banner-btn {
   display:inline-flex; align-items:center; justify-content:center;
   background:var(--blue); color:var(--white); text-decoration:none; font-weight:700;


### PR DESCRIPTION
## Summary
- The cream-styled banner (#115) added a `max-width:70ch` on the body paragraphs, which wrapped the text sooner than the original full-width version
- Removes that constraint so each paragraph stretches to the full banner width, matching the wrapping from before the restyle

## Test plan
- [x] Verified with Playwright (image load mocked to rule out this sandbox's blocked external-image fetch) that paragraphs now wrap onto a single line at desktop width, matching the pre-restyle behaviour
- [x] Verified opening/closing tag balance is unaffected


---
_Generated by [Claude Code](https://claude.ai/code/session_01CmXBkt59tXj7B2g1x81yQX)_